### PR TITLE
Add Dockerfile and automate publishing after release

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish to Github Package
+        uses: matootie/github-docker@v1.0.1
+        with:
+          username: rubicon-project
+          personalAccessToken: ${{secrets.GITHUB_TOKEN}}
+          repositoryName: rubicon-project/prebid-server-java
+          imageName: prebid-server

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,9 +7,6 @@ on:
       - '.github/**'
     branches:
       - master
-  release:
-    types:
-      - created
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine/git as clone
+WORKDIR /app
+RUN git clone https://github.com/rubicon-project/prebid-server-java.git
+
+FROM maven:3.6.0-jdk-8-slim AS build
+WORKDIR /app
+COPY --from=clone /app/prebid-server-java /app
+RUN mvn -Dmaven.test.skip=true clean package
+
+FROM openjdk:8-jre-alpine
+WORKDIR /app
+COPY --from=clone /app/prebid-server-java/sample /app/sample
+COPY --from=build /app/target/prebid-server.jar /app
+EXPOSE 8080
+EXPOSE 8000
+CMD ["java", "-jar", "prebid-server.jar", "--spring.config.additional-location=sample/prebid-config.yaml"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/rubicon-project/prebid-server-java.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rubicon-project/prebid-server-java/alerts/)
 [![GitHub contributors](https://img.shields.io/github/contributors/rubicon-project/prebid-server-java.svg)](https://GitHub.com/rubicon-project/prebid-server-java/contributors/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/rubicon-project/prebid-server-java/blob/master/docs/contributing.md) 
-[![GitHub pull-requests closed](https://img.shields.io/github/issues-pr-closed/rubicon-project/prebid-server-java.svg)](https://GitHub.com/rubicon-project/prebid-server-java/pull/)
+[![GitHub pull-requests closed](https://img.shields.io/github/issues-pr-closed/rubicon-project/prebid-server-java.svg)](https://GitHub.com/rubicon-project/prebid-server-java/pulls/)
 
 Prebid Server is an open source implementation of Server-Side Header Bidding.
 It is managed by [Prebid.org](http://prebid.org/overview/what-is-prebid-org.html),


### PR DESCRIPTION
Action will be triggered after release created.
It automatically build image with jar and push it to GitHub Package registry.
To pull image from registry you need to have Token with `read:packages` permission.
(Or we can change registry)
```
docker login docker.pkg.github.com -u <GITHUB_USERNAME> -p <TOKEN_WITH_READ_PACKAGES_RIGHTS>

docker pull docker.pkg.github.com/rubicon-project/prebid-server-java/prebid-server:master
```

To run docker image you can use:
`docker run -p 8080:8080 docker.pkg.github.com/dgarbar/prebid-server-java/prebid-server:master`