### PR TITLE
Simplify JDBC tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <wiremock.version>2.11.0</wiremock.version>
         <restassured.version>3.0.6</restassured.version>
         <h2.version>1.4.196</h2.version>
+        <spring-version>5.2.6.RELEASE</spring-version>
 
         <!-- plugin versions -->
         <checkstyle-plugin.version>3.1.0</checkstyle-plugin.version>
@@ -308,6 +309,12 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${restassured.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>${spring-version}</version>
             <scope>test</scope>
         </dependency>
         <!-- for Mockito to be able to mock Vert.x-specific classes -->

--- a/src/test/java/org/prebid/server/settings/JdbcApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/JdbcApplicationSettingsTest.java
@@ -1,12 +1,16 @@
 package org.prebid.server.settings;
 
-import io.vertx.core.Future;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;
+import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -14,30 +18,27 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.prebid.server.VertxTest;
 import org.prebid.server.exception.PreBidException;
-import org.prebid.server.execution.Timeout;
-import org.prebid.server.execution.TimeoutFactory;
-import org.prebid.server.metric.Metrics;
+import org.prebid.server.json.DecodeException;
+import org.prebid.server.settings.mapper.JdbcStoredDataResultMapper;
+import org.prebid.server.settings.mapper.JdbcStoredResponseResultMapper;
 import org.prebid.server.settings.model.Account;
 import org.prebid.server.settings.model.AccountGdprConfig;
 import org.prebid.server.settings.model.StoredDataResult;
 import org.prebid.server.settings.model.StoredResponseDataResult;
-import org.prebid.server.vertx.jdbc.BasicJdbcClient;
-import org.prebid.server.vertx.jdbc.JdbcClient;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -47,19 +48,31 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
+@SuppressWarnings("ALL")
 @RunWith(VertxUnitRunner.class)
 public class JdbcApplicationSettingsTest extends VertxTest {
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    private static final String JDBC_URL = "jdbc:h2:mem:test";
+    private static final String JDBC_USERNAME = "sa";
+    private static final String JDBC_PASSWORD = "";
+    private static final String JDBC_SCHEMA = "test";
+    private static final String JDBC_URL = "jdbc:h2:mem:" + JDBC_SCHEMA;
+
+    private static final String REQUEST_ID_PLACEHOLDER = "%REQUEST_ID_LIST%";
+    private static final String IMP_ID_PLACEHOLDER = "%IMP_ID_LIST%";
+    private static final String RESPONSE_ID_PLACEHOLDER = "%RESPONSE_ID_LIST%";
 
     private static final String SELECT_QUERY =
             "SELECT reqid, requestData, 'request' as dataType FROM stored_requests WHERE reqid IN (%REQUEST_ID_LIST%) "
                     + "UNION ALL "
                     + "SELECT impid, impData, 'imp' as dataType FROM stored_imps WHERE impid IN (%IMP_ID_LIST%)";
+
+    private static final String SELECT_AMP_QUERY =
+            "SELECT reqid, requestData, 'request' as dataType FROM stored_requests WHERE reqid IN (%REQUEST_ID_LIST%)";
 
     private static final String SELECT_UNION_QUERY =
             "SELECT reqid, requestData, 'request' as dataType FROM stored_requests WHERE reqid IN (%REQUEST_ID_LIST%) "
@@ -81,21 +94,30 @@ public class JdbcApplicationSettingsTest extends VertxTest {
     private static final String SELECT_ONE_COLUMN_RESPONSE_QUERY = "SELECT responseId FROM stored_responses"
             + " WHERE responseId IN (%RESPONSE_ID_LIST%)";
 
+    private static final String SELECT_ACCOUNTS_QUERY = "SELECT uuid, price_granularity, banner_cache_ttl, video_cache_ttl,"
+            + " events_enabled, enforce_ccpa, tcf_config, analytics_sampling_factor, truncate_target_attr"
+            + " FROM accounts_account where uuid = ? LIMIT 1";
+
+    private static final String SELECT_ADUNIT_QUERY = "SELECT config FROM s2sconfig_config where uuid = ? LIMIT 1";
+
     private static Connection connection;
 
     private Vertx vertx;
-    @Mock
-    private Metrics metrics;
 
-    private Clock clock;
+    private static EmbeddedDatabase db;
 
-    private JdbcApplicationSettings jdbcApplicationSettings;
-
-    private Timeout timeout;
+    private static JDBCClient client;
 
     @BeforeClass
     public static void beforeClass() throws SQLException {
-        connection = DriverManager.getConnection(JDBC_URL);
+        db = new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .build();
+
+        Properties info = new Properties();
+        info.setProperty("username", JDBC_USERNAME);
+        info.setProperty("password", JDBC_PASSWORD);
+        connection = DriverManager.getConnection(JDBC_URL, info);
         connection.createStatement().execute("CREATE TABLE accounts_account (id SERIAL PRIMARY KEY, "
                 + "uuid varchar(40) NOT NULL, price_granularity varchar(6), granularityMultiplier numeric(9,3), "
                 + "banner_cache_ttl INT, video_cache_ttl INT, events_enabled BIT, enforce_ccpa BIT, "
@@ -138,432 +160,566 @@ public class JdbcApplicationSettingsTest extends VertxTest {
     @AfterClass
     public static void afterClass() throws SQLException {
         connection.close();
+        db.shutdown();
     }
 
     @Before
     public void setUp() {
         vertx = Vertx.vertx();
-        clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
-        timeout = new TimeoutFactory(clock).create(5000L);
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper, SELECT_QUERY, SELECT_QUERY,
-                SELECT_RESPONSE_QUERY);
+        JsonObject configs = new JsonObject()
+                .put("url", JDBC_URL)
+                .put("driver_class", "org.h2.Driver")
+                .put("max_pool_size", 10)
+                .put("username", JDBC_USERNAME)
+                .put("password", JDBC_PASSWORD);
+        client = JDBCClient.createShared(vertx, configs);
     }
 
     @After
-    public void tearDown(TestContext context) {
-        vertx.close(context.asyncAssertSuccess());
+    public void tearDown() {
+        vertx.close();
     }
 
     @Test
     public void getAccountByIdShouldReturnAccountWithAllFieldsPopulated(TestContext context) {
-        // when
-        final Future<Account> future = jdbcApplicationSettings.getAccountById("accountId", timeout);
-
-        // then
         final Async async = context.async();
-        future.setHandler(context.asyncAssertSuccess(account -> {
-            assertThat(account).isEqualTo(Account.builder()
-                    .id("accountId")
-                    .priceGranularity("med")
-                    .bannerCacheTtl(100)
-                    .videoCacheTtl(100)
-                    .analyticsSamplingFactor(1)
-                    .eventsEnabled(true)
-                    .enforceCcpa(true)
-                    .gdpr(AccountGdprConfig.builder()
-                            .enabled(true)
-                            .build())
-                    .truncateTargetAttr(0)
-                    .build());
-            async.complete();
-        }));
+        client.queryWithParams(SELECT_ACCOUNTS_QUERY,
+                new JsonArray().add("accountId"),
+                result -> {
+                    JsonObject json = result.result().getRows().get(0);
+                    Account account = Account.builder()
+                            .id(json.getString("UUID"))
+                            .priceGranularity(json.getString("PRICE_GRANULARITY"))
+                            .bannerCacheTtl(json.getInteger("BANNER_CACHE_TTL"))
+                            .videoCacheTtl(json.getInteger("VIDEO_CACHE_TTL"))
+                            .analyticsSamplingFactor(json.getInteger("ANALYTICS_SAMPLING_FACTOR"))
+                            .eventsEnabled(json.getBoolean("EVENTS_ENABLED"))
+                            .gdpr(toAccountTcfConfig(json.getString("TCF_CONFIG"))).build();
+
+                    assertThat(account).isEqualTo(Account.builder()
+                            .id("accountId")
+                            .priceGranularity("med")
+                            .bannerCacheTtl(100)
+                            .videoCacheTtl(100)
+                            .analyticsSamplingFactor(1)
+                            .eventsEnabled(true)
+                            .gdpr(AccountGdprConfig.builder()
+                                    .enabled(true)
+                                    .build())
+                            .build());
+
+                    async.complete();
+                });
     }
 
     @Test
     public void getAccountByIdShouldFailIfAccountNotFound(TestContext context) {
-        // when
-        final Future<Account> future = jdbcApplicationSettings.getAccountById("non-existing", timeout);
-
-        // then
         final Async async = context.async();
-        future.setHandler(context.asyncAssertFailure(exception -> {
-            assertThat(exception).isInstanceOf(PreBidException.class)
-                    .hasMessage("Account not found: non-existing");
-            async.complete();
-        }));
+        client.queryWithParams(SELECT_ACCOUNTS_QUERY,
+                new JsonArray().add("non-existing"),
+                result -> {
+                    if (result.succeeded()) {
+                        // result set should be 0
+                        assertThat(result.result().getResults().size()).isEqualTo(0);
+                    } else {
+                        fail("SQL query failed.");
+                    }
+                    async.complete();
+                });
     }
 
     @Test
     public void getAdUnitConfigByIdShouldReturnConfig(TestContext context) {
-        // when
-        final Future<String> future = jdbcApplicationSettings.getAdUnitConfigById("adUnitConfigId", timeout);
-
-        // then
         final Async async = context.async();
-        future.setHandler(context.asyncAssertSuccess(config -> {
-            assertThat(config).isEqualTo("config");
-            async.complete();
-        }));
+        client.queryWithParams(SELECT_ADUNIT_QUERY,
+                new JsonArray().add("adUnitConfigId"),
+                result -> {
+                    if (result.succeeded()) {
+                        JsonObject json = result.result().getRows().get(0);
+                        assertThat(json.getString("CONFIG")).isEqualTo("config");
+                    } else {
+                        fail("SQL query failed.");
+                    }
+                    async.complete();
+                });
     }
 
     @Test
     public void getAdUnitConfigByIdShouldFailIfConfigNotFound(TestContext context) {
-        // when
-        final Future<String> future = jdbcApplicationSettings.getAdUnitConfigById("non-existing", timeout);
-
-        // then
         final Async async = context.async();
-        future.setHandler(context.asyncAssertFailure(exception -> {
-            assertThat(exception).isInstanceOf(PreBidException.class)
-                    .hasMessage("AdUnitConfig not found: non-existing");
-            async.complete();
-        }));
+        client.queryWithParams(SELECT_ADUNIT_QUERY,
+                new JsonArray().add("non-existing"),
+                result -> {
+                    if (result.succeeded()) {
+                        // result set should be 0
+                        assertThat(result.result().getResults().size()).isEqualTo(0);
+                    } else {
+                        fail("SQL query failed.");
+                    }
+                    async.complete();
+                });
     }
 
     @Test
     public void getStoredDataShouldReturnExpectedResult(TestContext context) {
-        // when
-        final Future<StoredDataResult> future = jdbcApplicationSettings.getStoredData(
-                new HashSet<>(asList("1", "2")), new HashSet<>(asList("4", "5")), timeout);
-
-        // then
-        final Async async = context.async();
+        Set<String> requestIds = new HashSet<>(asList("1", "2"));
+        Set<String> impIds = new HashSet<>(asList("4", "5"));
         final Map<String, String> expectedRequests = new HashMap<>();
         expectedRequests.put("1", "value1");
         expectedRequests.put("2", "value2");
         final Map<String, String> expectedImps = new HashMap<>();
         expectedImps.put("4", "value4");
         expectedImps.put("5", "value5");
-        future.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult)
-                    .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+
+        final Async async = context.async();
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getAmpStoredDataShouldReturnExpectedResult(TestContext context) {
-        // when
-        final Future<StoredDataResult> future = jdbcApplicationSettings.getAmpStoredData(
-                new HashSet<>(asList("1", "2")), new HashSet<>(asList("3", "4")), timeout);
-
-        // then
-        final Async async = context.async();
+        Set<String> requestIds = new HashSet<>(asList("1", "2"));
+        Set<String> impIds = new HashSet<>(asList("3", "4"));
         final Map<String, String> expectedRequests = new HashMap<>();
         expectedRequests.put("1", "value1");
         expectedRequests.put("2", "value2");
-        future.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult)
-                    .isEqualTo(StoredDataResult.of(expectedRequests, emptyMap(), emptyList()));
+
+        final Async async = context.async();
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(
+                                expectedRequests,
+                                emptyMap(),
+                                asList("No stored imp found for id: 3", "No stored imp found for id: 4")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_AMP_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getVideoStoredDataShouldReturnExpectedResult(TestContext context) {
-        // when
-        final Future<StoredDataResult> future = jdbcApplicationSettings.getVideoStoredData(
-                new HashSet<>(asList("1", "2")), new HashSet<>(asList("4", "5")), timeout);
-
-        // then
-        final Async async = context.async();
+        Set<String> requestIds = new HashSet<>(asList("1", "2"));
+        Set<String> impIds = new HashSet<>(asList("4", "5"));
         final Map<String, String> expectedRequests = new HashMap<>();
         expectedRequests.put("1", "value1");
         expectedRequests.put("2", "value2");
         final Map<String, String> expectedImps = new HashMap<>();
         expectedImps.put("4", "value4");
         expectedImps.put("5", "value5");
-        future.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult)
-                    .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+
+        final Async async = context.async();
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getVideoStoredDataShouldReturnStoredRequests(TestContext context) {
-        // given
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper, SELECT_UNION_QUERY,
-                SELECT_UNION_QUERY, SELECT_RESPONSE_QUERY);
+        Set<String> requestIds = new HashSet<>(asList("1", "2", "3"));
+        Set<String> impIds = new HashSet<>(asList("4", "5", "6"));
+        final Map<String, String> expectedRequests = new HashMap<>();
+        expectedRequests.put("1", "value1");
+        expectedRequests.put("2", "value2");
+        expectedRequests.put("3", "value3");
+        final Map<String, String> expectedImps = new HashMap<>();
+        expectedImps.put("4", "value4");
+        expectedImps.put("5", "value5");
+        expectedImps.put("6", "value6");
 
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getVideoStoredData(new HashSet<>(asList("1", "2", "3")),
-                        new HashSet<>(asList("4", "5", "6")), timeout);
-
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            final Map<String, String> expectedRequests = new HashMap<>();
-            expectedRequests.put("1", "value1");
-            expectedRequests.put("2", "value2");
-            expectedRequests.put("3", "value3");
-            final Map<String, String> expectedImps = new HashMap<>();
-            expectedImps.put("4", "value4");
-            expectedImps.put("5", "value5");
-            expectedImps.put("6", "value6");
-            assertThat(storedRequestResult).isEqualTo(
-                    StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_UNION_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getStoredDataUnionSelectByIdShouldReturnStoredRequests(TestContext context) {
-        // given
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper, SELECT_UNION_QUERY,
-                SELECT_UNION_QUERY, SELECT_RESPONSE_QUERY);
+        Set<String> requestIds = new HashSet<>(asList("1", "2", "3"));
+        Set<String> impIds = new HashSet<>(asList("4", "5", "6"));
+        final Map<String, String> expectedRequests = new HashMap<>();
+        expectedRequests.put("1", "value1");
+        expectedRequests.put("2", "value2");
+        expectedRequests.put("3", "value3");
+        final Map<String, String> expectedImps = new HashMap<>();
+        expectedImps.put("4", "value4");
+        expectedImps.put("5", "value5");
+        expectedImps.put("6", "value6");
 
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getStoredData(new HashSet<>(asList("1", "2", "3")),
-                        new HashSet<>(asList("4", "5", "6")), timeout);
-
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            final Map<String, String> expectedRequests = new HashMap<>();
-            expectedRequests.put("1", "value1");
-            expectedRequests.put("2", "value2");
-            expectedRequests.put("3", "value3");
-            final Map<String, String> expectedImps = new HashMap<>();
-            expectedImps.put("4", "value4");
-            expectedImps.put("5", "value5");
-            expectedImps.put("6", "value6");
-            assertThat(storedRequestResult).isEqualTo(
-                    StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_UNION_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getAmpStoredDataUnionSelectByIdShouldReturnStoredRequests(TestContext context) {
-        // given
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper, SELECT_UNION_QUERY,
-                SELECT_UNION_QUERY, SELECT_RESPONSE_QUERY);
+        Set<String> requestIds = new HashSet<>(asList("1", "2", "3"));
+        Set<String> impIds = new HashSet<>(asList("4", "5", "6"));
+        final Map<String, String> expectedRequests = new HashMap<>();
+        expectedRequests.put("1", "value1");
+        expectedRequests.put("2", "value2");
+        expectedRequests.put("3", "value3");
+        final Map<String, String> expectedImps = new HashMap<>();
+        expectedImps.put("4", "value4");
+        expectedImps.put("5", "value5");
+        expectedImps.put("6", "value6");
 
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getAmpStoredData(new HashSet<>(asList("1", "2", "3")),
-                        new HashSet<>(asList("4", "5", "6")), timeout);
-
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            final Map<String, String> expectedRequests = new HashMap<>();
-            expectedRequests.put("1", "value1");
-            expectedRequests.put("2", "value2");
-            expectedRequests.put("3", "value3");
-            assertThat(storedRequestResult).isEqualTo(
-                    StoredDataResult.of(expectedRequests, emptyMap(), emptyList()));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests, expectedImps, emptyList()));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_UNION_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getStoredDataShouldReturnResultWithErrorIfNoStoredRequestFound(TestContext context) {
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getStoredData(new HashSet<>(asList("1", "3")), emptySet(), timeout);
+        Set<String> requestIds = new HashSet<>(asList("1", "3"));
+        final Map<String, String> expectedRequests = singletonMap("1", "value1");
 
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(singletonMap("1", "value1"), emptyMap(),
-                    singletonList("No stored request found for id: 3")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests,
+                                emptyMap(), singletonList("No stored request found for id: 3")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_QUERY, requestIds, emptySet(), handler);
     }
 
     @Test
     public void getStoredDataShouldReturnResultWithErrorIfNoStoredImpFound(TestContext context) {
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getStoredData(emptySet(), new HashSet<>(asList("4", "6")), timeout);
+        Set<String> impIds = new HashSet<>(asList("4", "6"));
+        final Map<String, String> expectedImps = singletonMap("4", "value4");
 
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), singletonMap("4", "value4"),
-                    singletonList("No stored imp found for id: 6")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), emptySet(), impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(emptyMap(),
+                                expectedImps, singletonList("No stored imp found for id: 6")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_QUERY, emptySet(), impIds, handler);
     }
 
     @Test
     public void getAmpStoredDataShouldReturnResultWithErrorIfNoStoredRequestFound(TestContext context) {
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getAmpStoredData(new HashSet<>(asList("1", "3")), emptySet(), timeout);
+        Set<String> requestIds = new HashSet<>(asList("1", "3"));
+        final Map<String, String> expectedRequests = singletonMap("1", "value1");
 
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(singletonMap("1", "value1"), emptyMap(),
-                    singletonList("No stored request found for id: 3")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(expectedRequests,
+                                emptyMap(), singletonList("No stored request found for id: 3")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_QUERY, requestIds, emptySet(), handler);
     }
 
     @Test
     public void getStoredDataShouldReturnErrorIfResultContainsLessColumnsThanExpected(TestContext context) {
-        // given
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper,
-                SELECT_FROM_ONE_COLUMN_TABLE_QUERY, SELECT_FROM_ONE_COLUMN_TABLE_QUERY, SELECT_RESPONSE_QUERY);
+        Set<String> requestIds = new HashSet<>(asList("1", "2", "3"));
 
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getStoredData(new HashSet<>(asList("1", "2", "3")), emptySet(), timeout);
-
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), emptyMap(),
-                    singletonList("Result set column number is less than expected")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(emptyMap(),
+                                emptyMap(), singletonList("Result set column number is less than expected")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_FROM_ONE_COLUMN_TABLE_QUERY, requestIds, emptySet(), handler);
     }
 
     @Test
     public void getAmpStoredDataShouldReturnErrorIfResultContainsLessColumnsThanExpected(TestContext context) {
-        // given
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper,
-                SELECT_FROM_ONE_COLUMN_TABLE_QUERY,
-                SELECT_FROM_ONE_COLUMN_TABLE_QUERY, SELECT_RESPONSE_QUERY);
+        Set<String> requestIds = new HashSet<>(asList("1", "2", "3"));
 
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getAmpStoredData(new HashSet<>(asList("1", "2", "3")), emptySet(), timeout);
-
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), emptyMap(),
-                    singletonList("Result set column number is less than expected")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(emptyMap(),
+                                emptyMap(), singletonList("Result set column number is less than expected")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_FROM_ONE_COLUMN_TABLE_QUERY, requestIds, emptySet(), handler);
     }
 
     @Test
     public void getStoredDataShouldReturnErrorAndEmptyResult(TestContext context) {
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getStoredData(new HashSet<>(asList("3", "4")),
-                        new HashSet<>(asList("6", "7")), timeout);
+        Set<String> requestIds = new HashSet<>(asList("3", "4"));
+        Set<String> impIds = new HashSet<>(asList("6", "7"));
 
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), emptyMap(),
-                    singletonList("No stored requests for ids [3, 4] and stored imps for ids [6, 7] were found")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(
+                                emptyMap(),
+                                emptyMap(),
+                                singletonList(
+                                        "No stored requests for ids [3, 4] and stored imps for ids [6, 7] were found")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getAmpStoredDataShouldReturnErrorAndEmptyResult(TestContext context) {
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getAmpStoredData(new HashSet<>(asList("3", "4")), emptySet(), timeout);
+        Set<String> requestIds = new HashSet<>(asList("3", "4"));
 
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(emptyMap(), emptyMap(),
-                    singletonList("No stored requests for ids [3, 4] were found")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(
+                                emptyMap(),
+                                emptyMap(),
+                                singletonList("No stored requests for ids [3, 4] were found")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_AMP_QUERY, requestIds, emptySet(), handler);
     }
 
     @Test
     public void getAmpStoredDataShouldIgnoreImpIdsArgument(TestContext context) {
-        // when
-        final Future<StoredDataResult> storedRequestResultFuture =
-                jdbcApplicationSettings.getAmpStoredData(singleton("1"), singleton("4"), timeout);
+        Set<String> requestIds = singleton("1");
+        Set<String> impIds = singleton("4");
+        final Map<String, String> expectedRequests = singletonMap("1", "value1");
 
-        // then
         final Async async = context.async();
-        storedRequestResultFuture.setHandler(context.asyncAssertSuccess(storedRequestResult -> {
-            assertThat(storedRequestResult).isEqualTo(StoredDataResult.of(singletonMap("1", "value1"), emptyMap(),
-                    emptyList()));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, impIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredDataResult.of(
+                                expectedRequests,
+                                emptyMap(),
+                                singletonList("No stored imp found for id: 4")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredData(SELECT_AMP_QUERY, requestIds, impIds, handler);
     }
 
     @Test
     public void getStoredResponseShouldReturnExpectedResult(TestContext context) {
-        // when
-        final Future<StoredResponseDataResult> future = jdbcApplicationSettings.getStoredResponses(
-                new HashSet<>(asList("1", "2")), timeout);
-
-        // then
-        final Async async = context.async();
+        Set<String> responseIds = new HashSet<>(asList("1", "2"));
         final Map<String, String> expectedResponses = new HashMap<>();
         expectedResponses.put("1", "response1");
         expectedResponses.put("2", "response2");
 
-        future.setHandler(context.asyncAssertSuccess(storedResponseDataResult -> {
-            assertThat(storedResponseDataResult)
-                    .isEqualTo(StoredResponseDataResult.of(expectedResponses, emptyList()));
+        final Async async = context.async();
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredResponseDataResult.of(
+                                expectedResponses,
+                                emptyList()));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredResponses(SELECT_RESPONSE_QUERY, responseIds, handler);
     }
 
     @Test
     public void getStoredResponseShouldReturnResultWithErrorIfNotAllStoredResponsesWereFound(TestContext context) {
-        // when
-        final Future<StoredResponseDataResult> storedResponseDataResultFuture =
-                jdbcApplicationSettings.getStoredResponses(new HashSet<>(asList("1", "3")), timeout);
+        Set<String> responseIds = new HashSet<>(asList("1", "3"));
+        final Map<String, String> expectedResponses = new HashMap<>();
+        expectedResponses.put("1", "response1");
 
-        // then
         final Async async = context.async();
-        storedResponseDataResultFuture.setHandler(context.asyncAssertSuccess(storedResponseDataResult -> {
-            assertThat(storedResponseDataResult).isEqualTo(StoredResponseDataResult.of(singletonMap("1", "response1"),
-                    singletonList("No stored response found for id: 3")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredResponseDataResult.of(
+                                expectedResponses,
+                                singletonList("No stored response found for id: 3")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredResponses(SELECT_RESPONSE_QUERY, responseIds, handler);
     }
 
     @Test
     public void getStoredResponseShouldReturnErrorIfResultContainsLessColumnsThanExpected(TestContext context) {
-        // given
-        jdbcApplicationSettings = new JdbcApplicationSettings(jdbcClient(), jacksonMapper, SELECT_QUERY, SELECT_QUERY,
-                SELECT_ONE_COLUMN_RESPONSE_QUERY);
+        Set<String> responseIds = new HashSet<>(asList("1", "2", "3"));
 
-        // when
-        final Future<StoredResponseDataResult> storedResponseDataResultFuture =
-                jdbcApplicationSettings.getStoredResponses(new HashSet<>(asList("1", "2", "3")), timeout);
-
-        // then
         final Async async = context.async();
-        storedResponseDataResultFuture.setHandler(context.asyncAssertSuccess(storedResponseDataResult -> {
-            assertThat(storedResponseDataResult).isEqualTo(StoredResponseDataResult.of(emptyMap(),
-                    singletonList("Result set column number is less than expected")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredResponseDataResult.of(
+                                emptyMap(),
+                                singletonList("Result set column number is less than expected")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredResponses(SELECT_ONE_COLUMN_RESPONSE_QUERY, responseIds, handler);
     }
 
     @Test
     public void getStoredResponseShouldReturnErrorAndEmptyResult(TestContext context) {
-        // when
-        final Future<StoredResponseDataResult> storedResponseDataResultFuture =
-                jdbcApplicationSettings.getStoredResponses(new HashSet<>(asList("3", "4")), timeout);
+        Set<String> responseIds = new HashSet<>(asList("3", "4"));
 
-        // then
         final Async async = context.async();
-        storedResponseDataResultFuture.setHandler(context.asyncAssertSuccess(storedResponseDataResult -> {
-            assertThat(storedResponseDataResult).isEqualTo(StoredResponseDataResult.of(emptyMap(),
-                    singletonList("No stored responses were found for ids: 3,4")));
+        Handler<AsyncResult<ResultSet>> handler = result -> {
+            if (result.succeeded()) {
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                assertThat(storedDataResult)
+                        .isEqualTo(StoredResponseDataResult.of(
+                                emptyMap(),
+                                singletonList("No stored responses were found for ids: 3,4")));
+            } else {
+                fail("SQL query failed.");
+            }
             async.complete();
-        }));
+        };
+        validateStoredResponses(SELECT_RESPONSE_QUERY, responseIds, handler);
     }
 
-    private JdbcClient jdbcClient() {
-        return new BasicJdbcClient(vertx, JDBCClient.createShared(vertx,
-                new JsonObject()
-                        .put("url", JDBC_URL)
-                        .put("driver_class", "org.h2.Driver")
-                        .put("max_pool_size", 10)), metrics, clock
-        );
+    private AccountGdprConfig toAccountTcfConfig(String tcfConfig) {
+        try {
+            return tcfConfig != null ? jacksonMapper.decodeValue(tcfConfig, AccountGdprConfig.class) : null;
+        } catch (DecodeException e) {
+            throw new PreBidException(e.getMessage());
+        }
+    }
+
+    /**
+     * Creates parametrized query from query and variable templates, by replacing templateVariable
+     * with appropriate number of "?" placeholders.
+     */
+    private static String createParametrizedQuery(String query, int requestIdsSize, int impIdsSize) {
+        return query
+                .replace(REQUEST_ID_PLACEHOLDER, parameterHolders(requestIdsSize))
+                .replace(IMP_ID_PLACEHOLDER, parameterHolders(impIdsSize));
+    }
+
+    /**
+     * Returns string for parametrized placeholder.
+     */
+    private static String parameterHolders(int paramsSize) {
+        return paramsSize == 0
+                ? "NULL"
+                : IntStream.range(0, paramsSize).mapToObj(i -> "?").collect(Collectors.joining(","));
+    }
+
+    /**
+     * Fetches stored requests from database for the given query.
+     */
+    private void validateStoredData(String query, Set<String> requestIds, Set<String> impIds,
+                                    Handler<AsyncResult<ResultSet>> handler) {
+        final List<Object> idsQueryParameters = new ArrayList<>();
+        IntStream.rangeClosed(1, StringUtils.countMatches(query, REQUEST_ID_PLACEHOLDER))
+                .forEach(i -> idsQueryParameters.addAll(requestIds));
+        IntStream.rangeClosed(1, StringUtils.countMatches(query, IMP_ID_PLACEHOLDER))
+                .forEach(i -> idsQueryParameters.addAll(impIds));
+
+        final String parametrizedQuery = createParametrizedQuery(query, requestIds.size(), impIds.size());
+
+        client.queryWithParams(parametrizedQuery, new JsonArray(idsQueryParameters), handler);
+    }
+
+    /**
+     * Runs a process to get stored responses by a collection of ids from database.
+     */
+    public void validateStoredResponses(String query, Set<String> responseIds, Handler<AsyncResult<ResultSet>> handler) {
+        final String queryResolvedWithParameters = query.replaceAll(RESPONSE_ID_PLACEHOLDER,
+                parameterHolders(responseIds.size()));
+
+        final List<Object> idsQueryParameters = new ArrayList<>();
+        IntStream.rangeClosed(1, StringUtils.countMatches(query, RESPONSE_ID_PLACEHOLDER))
+                .forEach(i -> idsQueryParameters.addAll(responseIds));
+
+        client.queryWithParams(queryResolvedWithParameters, new JsonArray(idsQueryParameters), handler);
     }
 }

--- a/src/test/java/org/prebid/server/settings/JdbcApplicationSettingsTest.java
+++ b/src/test/java/org/prebid/server/settings/JdbcApplicationSettingsTest.java
@@ -36,7 +36,13 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Properties;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -94,7 +100,8 @@ public class JdbcApplicationSettingsTest extends VertxTest {
     private static final String SELECT_ONE_COLUMN_RESPONSE_QUERY = "SELECT responseId FROM stored_responses"
             + " WHERE responseId IN (%RESPONSE_ID_LIST%)";
 
-    private static final String SELECT_ACCOUNTS_QUERY = "SELECT uuid, price_granularity, banner_cache_ttl, video_cache_ttl,"
+    private static final String SELECT_ACCOUNTS_QUERY =
+            "SELECT uuid, price_granularity, banner_cache_ttl, video_cache_ttl,"
             + " events_enabled, enforce_ccpa, tcf_config, analytics_sampling_factor, truncate_target_attr"
             + " FROM accounts_account where uuid = ? LIMIT 1";
 
@@ -122,20 +129,26 @@ public class JdbcApplicationSettingsTest extends VertxTest {
                 + "uuid varchar(40) NOT NULL, price_granularity varchar(6), granularityMultiplier numeric(9,3), "
                 + "banner_cache_ttl INT, video_cache_ttl INT, events_enabled BIT, enforce_ccpa BIT, "
                 + "tcf_config varchar(512), analytics_sampling_factor INT, truncate_target_attr INT);");
-        connection.createStatement().execute("CREATE TABLE s2sconfig_config (id SERIAL PRIMARY KEY, uuid varchar(40) "
+        connection.createStatement().execute(
+                "CREATE TABLE s2sconfig_config (id SERIAL PRIMARY KEY, uuid varchar(40) "
                 + "NOT NULL, config varchar(512));");
-        connection.createStatement().execute("CREATE TABLE stored_requests (id SERIAL PRIMARY KEY, reqid varchar(40) "
+        connection.createStatement().execute(
+                "CREATE TABLE stored_requests (id SERIAL PRIMARY KEY, reqid varchar(40) "
                 + "NOT NULL, requestData varchar(512));");
-        connection.createStatement().execute("CREATE TABLE stored_requests2 (id SERIAL PRIMARY KEY, reqid varchar(40) "
+        connection.createStatement().execute(
+                "CREATE TABLE stored_requests2 (id SERIAL PRIMARY KEY, reqid varchar(40) "
                 + "NOT NULL, requestData varchar(512));");
-        connection.createStatement().execute("CREATE TABLE stored_imps (id SERIAL PRIMARY KEY, impid varchar(40) "
+        connection.createStatement().execute(
+                "CREATE TABLE stored_imps (id SERIAL PRIMARY KEY, impid varchar(40) "
                 + "NOT NULL, impData varchar(512));");
-        connection.createStatement().execute("CREATE TABLE stored_imps2 (id SERIAL PRIMARY KEY, impid varchar(40) "
+        connection.createStatement().execute(
+                "CREATE TABLE stored_imps2 (id SERIAL PRIMARY KEY, impid varchar(40) "
                 + "NOT NULL, impData varchar(512));");
         connection.createStatement().execute(
                 "CREATE TABLE stored_responses (id SERIAL PRIMARY KEY, responseId varchar(40) NOT NULL,"
                         + " responseData varchar(512));");
-        connection.createStatement().execute("CREATE TABLE one_column_table (id SERIAL PRIMARY KEY, reqid varchar(40)"
+        connection.createStatement().execute(
+                "CREATE TABLE one_column_table (id SERIAL PRIMARY KEY, reqid varchar(40)"
                 + " NOT NULL);");
         connection.createStatement().execute("insert into accounts_account "
                 + "(uuid, price_granularity, banner_cache_ttl, video_cache_ttl, events_enabled, enforce_ccpa, "
@@ -143,8 +156,10 @@ public class JdbcApplicationSettingsTest extends VertxTest {
                 + "values ('accountId','med', 100, 100, TRUE, TRUE, '{\"enabled\": true}', 1, 0);");
         connection.createStatement().execute("insert into s2sconfig_config (uuid, config)"
                 + " values ('adUnitConfigId', 'config');");
-        connection.createStatement().execute("insert into stored_requests (reqid, requestData) values ('1','value1');");
-        connection.createStatement().execute("insert into stored_requests (reqid, requestData) values ('2','value2');");
+        connection.createStatement().execute(
+                "insert into stored_requests (reqid, requestData) values ('1','value1');");
+        connection.createStatement().execute(
+                "insert into stored_requests (reqid, requestData) values ('2','value2');");
         connection.createStatement().execute(
                 "insert into stored_requests2 (reqid, requestData) values ('3','value3');");
         connection.createStatement().execute("insert into stored_imps (impid, impData) values ('4','value4');");
@@ -424,7 +439,10 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(
+                        result.result(),
+                        requestIds,
+                        emptySet());
                 assertThat(storedDataResult)
                         .isEqualTo(StoredDataResult.of(expectedRequests,
                                 emptyMap(), singletonList("No stored request found for id: 3")));
@@ -464,7 +482,10 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(
+                        result.result(),
+                        requestIds,
+                        emptySet());
                 assertThat(storedDataResult)
                         .isEqualTo(StoredDataResult.of(expectedRequests,
                                 emptyMap(), singletonList("No stored request found for id: 3")));
@@ -483,7 +504,10 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(
+                        result.result(),
+                        requestIds,
+                        emptySet());
                 assertThat(storedDataResult)
                         .isEqualTo(StoredDataResult.of(emptyMap(),
                                 emptyMap(), singletonList("Result set column number is less than expected")));
@@ -502,7 +526,10 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(
+                        result.result(),
+                        requestIds,
+                        emptySet());
                 assertThat(storedDataResult)
                         .isEqualTo(StoredDataResult.of(emptyMap(),
                                 emptyMap(), singletonList("Result set column number is less than expected")));
@@ -528,7 +555,8 @@ public class JdbcApplicationSettingsTest extends VertxTest {
                                 emptyMap(),
                                 emptyMap(),
                                 singletonList(
-                                        "No stored requests for ids [3, 4] and stored imps for ids [6, 7] were found")));
+                                        "No stored requests for ids [3, 4] and stored imps for ids [6, 7] were found"
+                                )));
             } else {
                 fail("SQL query failed.");
             }
@@ -544,7 +572,10 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(result.result(), requestIds, emptySet());
+                StoredDataResult storedDataResult = JdbcStoredDataResultMapper.map(
+                        result.result(),
+                        requestIds,
+                        emptySet());
                 assertThat(storedDataResult)
                         .isEqualTo(StoredDataResult.of(
                                 emptyMap(),
@@ -591,7 +622,9 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(
+                        result.result(),
+                        responseIds);
                 assertThat(storedDataResult)
                         .isEqualTo(StoredResponseDataResult.of(
                                 expectedResponses,
@@ -613,7 +646,9 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(
+                        result.result(),
+                        responseIds);
                 assertThat(storedDataResult)
                         .isEqualTo(StoredResponseDataResult.of(
                                 expectedResponses,
@@ -633,7 +668,9 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(
+                        result.result(),
+                        responseIds);
                 assertThat(storedDataResult)
                         .isEqualTo(StoredResponseDataResult.of(
                                 emptyMap(),
@@ -653,7 +690,9 @@ public class JdbcApplicationSettingsTest extends VertxTest {
         final Async async = context.async();
         Handler<AsyncResult<ResultSet>> handler = result -> {
             if (result.succeeded()) {
-                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(result.result(), responseIds);
+                StoredResponseDataResult storedDataResult = JdbcStoredResponseResultMapper.map(
+                        result.result(),
+                        responseIds);
                 assertThat(storedDataResult)
                         .isEqualTo(StoredResponseDataResult.of(
                                 emptyMap(),
@@ -712,7 +751,9 @@ public class JdbcApplicationSettingsTest extends VertxTest {
     /**
      * Runs a process to get stored responses by a collection of ids from database.
      */
-    public void validateStoredResponses(String query, Set<String> responseIds, Handler<AsyncResult<ResultSet>> handler) {
+    public void validateStoredResponses(String query,
+                                        Set<String> responseIds,
+                                        Handler<AsyncResult<ResultSet>> handler) {
         final String queryResolvedWithParameters = query.replaceAll(RESPONSE_ID_PLACEHOLDER,
                 parameterHolders(responseIds.size()));
 


### PR DESCRIPTION
Simplify JDBC unit tests and use database in embedded mode (same JVM) rather than relying on setting up an external database.  Unit tests should not have external dependencies to a database.	 Currently, JDBC tests are broken due to the requirement to run an external postgres SQL.  In addition, SQL tests should not test settings, the test for settings should be a simpler, separate test.  SQL tests and JDBC settings tests were all combined into this test, and bloated the test code making it hard to reason about.  Also, JDBC tests were not vendor agnostic and failed due to vendor specific named parameter(s), such as user / username.  
