### PR TITLE
Fix github actions release publishing with set env in new way

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Extract tag from commit message
         run: |
           target_tag=${COMMIT_MSG#"Prebid Server prepare release "}
-          echo "::set-env name=TARGET_TAG::$target_tag"
+          echo "TARGET_TAG=$target_tag" >> $GITHUB_ENV
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
       - name: Create and publish release


### PR DESCRIPTION
This PR fixes `update_release_draft` GitHub actions job failed with error:
```
---
Run target_tag=${COMMIT_MSG#"Prebid Server prepare release "}
  target_tag=${COMMIT_MSG#"Prebid Server prepare release "}
  echo "::set-env name=TARGET_TAG::$target_tag"
  shell: /bin/bash -e {0}
  env:
    COMMIT_MSG: Prebid Server prepare release 1.50.0
---

Error: Unable to process command '::set-env name=TARGET_TAG::1.50.0' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command
execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. 
```
For more information see: 
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
