### PR TITLE
Fix FPD user.ext.data passing to bidders

### DIFF
--- a/src/main/java/org/prebid/server/auction/FpdResolver.java
+++ b/src/main/java/org/prebid/server/auction/FpdResolver.java
@@ -248,7 +248,7 @@ public class FpdResolver {
 
     private ObjectNode mergeExtData(JsonNode fpdData, JsonNode originData) {
         if (fpdData.isMissingNode() || !fpdData.isObject()) {
-            return originData != null && originData.isObject() ? (ObjectNode) originData : null;
+            return originData != null && originData.isObject() ? ((ObjectNode) originData).deepCopy() : null;
         }
 
         if (originData != null && originData.isObject()) {

--- a/src/test/java/org/prebid/server/auction/FpdResolverTest.java
+++ b/src/test/java/org/prebid/server/auction/FpdResolverTest.java
@@ -176,6 +176,27 @@ public class FpdResolverTest extends VertxTest {
     }
 
     @Test
+    public void resolveUserShouldReturnCopyOfUserExtDataIfFPDUserExtDataIsMissing() {
+        // given
+        final ObjectNode originExtUserData = mapper.createObjectNode().put("originAttr", "originValue");
+
+        final User originUser = User.builder()
+                .ext(ExtUser.builder().data(originExtUserData).build())
+                .build();
+
+        final User fpdUser = User.builder()
+                .ext(ExtUser.builder().data(null).build())
+                .build();
+
+        // when
+        final User resultUser = fpdResolver.resolveUser(originUser, mapper.valueToTree(fpdUser));
+
+        // then
+        assertThat(resultUser.getExt().getData() != originExtUserData).isTrue(); // different by reference
+        assertThat(resultUser.getExt().getData().equals(originExtUserData)).isTrue(); // but the same by value
+    }
+
+    @Test
     public void resolveAppShouldOverrideFpdFieldsFromFpdApp() {
         // given
         final App originApp = App.builder()


### PR DESCRIPTION
This PR fixes passing of `user.ext.data`, `site.ext.data` and `app.ext.data` when creating individual bidder's requests.

Before we modified shared `ext.data` if there is no FPD `ext.data` object.
Now we return new copy of `ext.data` for each bidder.

Thanks @schernysh for solution.