### PR TITLE
Fix Duplicate key exception for yieldlab targeting

### DIFF
--- a/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
@@ -90,7 +90,7 @@ public class YieldlabBidder implements Bidder<Void> {
                 .filter(Objects::nonNull)
                 .flatMap(map -> map.entrySet().stream())
                 .filter(entry -> entry.getKey() != null)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (channel1, channel2) -> channel1)));
 
         final String adSlotIdsParams = adSlotIds.stream().sorted().collect(Collectors.joining(AD_SLOT_ID_SEPARATOR));
         return ExtImpYieldlab.builder().adslotId(adSlotIdsParams).targeting(targeting).build();

--- a/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
@@ -90,7 +90,7 @@ public class YieldlabBidder implements Bidder<Void> {
                 .filter(Objects::nonNull)
                 .flatMap(map -> map.entrySet().stream())
                 .filter(entry -> entry.getKey() != null)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (channel1, channel2) -> channel1)));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (channel1, channel2) -> channel1));
 
         final String adSlotIdsParams = adSlotIds.stream().sorted().collect(Collectors.joining(AD_SLOT_ID_SEPARATOR));
         return ExtImpYieldlab.builder().adslotId(adSlotIdsParams).targeting(targeting).build();


### PR DESCRIPTION
If the same targeting parameter is set for multiple ad units the prebid server will crash with 500 as the merging fails.

Fix inspired by [this SO answer](https://stackoverflow.com/questions/32312876/ignore-duplicates-when-producing-map-using-streams)