### PR TITLE
Fix NPE in FPD when targeting.bidders is not defined

### DIFF
--- a/src/main/java/org/prebid/server/auction/FpdResolver.java
+++ b/src/main/java/org/prebid/server/auction/FpdResolver.java
@@ -277,7 +277,7 @@ public class FpdResolver {
     }
 
     private ExtRequestPrebidData resolveExtRequestPrebidData(ExtRequestPrebidData data, List<String> fpdBidders) {
-        if (CollectionUtils.isEmpty(fpdBidders) && data == null) {
+        if (CollectionUtils.isEmpty(fpdBidders)) {
             return null;
         }
         final List<String> originBidders = data != null ? data.getBidders() : Collections.emptyList();

--- a/src/test/java/org/prebid/server/auction/FpdResolverTest.java
+++ b/src/test/java/org/prebid/server/auction/FpdResolverTest.java
@@ -725,6 +725,20 @@ public class FpdResolverTest extends VertxTest {
     }
 
     @Test
+    public void resolveBidRequestExtShouldTolerateMissingBidders() {
+        // given
+        final ExtRequest givenExtRequest = ExtRequest.of(ExtRequestPrebid.builder()
+                .data(ExtRequestPrebidData.of(Arrays.asList("rubicon", "appnexus"))).build());
+
+        // when
+        final ExtRequest result = fpdResolver.resolveBidRequestExt(givenExtRequest,
+                Targeting.of(null, null, null)); // no bidders
+
+        // then
+        assertThat(result.getPrebid().getData().getBidders()).contains("rubicon", "appnexus");
+    }
+
+    @Test
     public void resolveBidRequestExtShouldMergeBidders() {
         // given
         final ExtRequest givenExtRequest = ExtRequest.of(ExtRequestPrebid.builder()


### PR DESCRIPTION
This PR fixes NPE:
```
2021-02-15 05:35:44.236 ERROR 7753 --- [vert.x-eventloop-thread-2] o.p.server.handler.openrtb2.AmpHandler   : Critical error while running the auction                                                       
java.lang.NullPointerException: null                                                                                                                                                                         
        at java.util.AbstractCollection.addAll(Unknown Source)                                                                                                                                               
        at org.prebid.server.auction.FpdResolver.mergeBidders(FpdResolver.java:303)                                                                                                                          
        at org.prebid.server.auction.FpdResolver.resolveExtRequestPrebidData(FpdResolver.java:286)                                                                                                           
        at org.prebid.server.auction.FpdResolver.resolveBidRequestExt(FpdResolver.java:261)                                                                                                                  
        at org.prebid.server.auction.AmpRequestFactory.overrideExtBidRequest(AmpRequestFactory.java:531)                                                                                                     
        at org.prebid.server.auction.AmpRequestFactory.overrideParameters(AmpRequestFactory.java:281)                                                                                                        
        at org.prebid.server.auction.AmpRequestFactory.lambda$createBidRequest$3(AmpRequestFactory.java:127)                                                                                                 
```