### PR TITLE
Pass bid.ext.skadn to PBS response instead of bid.ext.bidder.skadn

### DIFF
--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -807,20 +807,7 @@ public class BidResponseCreator {
                 .video(extBidPrebidVideo)
                 .build();
 
-        // will be updated in https://github.com/prebid/prebid-server-java/pull/1126
-        final ObjectNode existingBidExt = bid.getExt();
-        JsonNode skadnObject = mapper.mapper().createObjectNode();
-        if (bid.getExt() != null && !existingBidExt.isEmpty()) {
-            skadnObject = existingBidExt.get(SKADN_PROPERTY);
-            existingBidExt.remove(SKADN_PROPERTY);
-        }
-        final ExtPrebid<ExtBidPrebid, ObjectNode> bidExt = ExtPrebid.of(extBidPrebid, existingBidExt);
-        final ObjectNode updatedBidExt = mapper.mapper().valueToTree(bidExt);
-        if (skadnObject != null && !skadnObject.isEmpty()) {
-            updatedBidExt.set(SKADN_PROPERTY, skadnObject);
-        }
-
-        bid.setExt(updatedBidExt);
+        bid.setExt(createBidExt(bid.getExt(), extBidPrebid));
 
         final Integer ttl = cacheInfo != null ? ObjectUtils.max(cacheInfo.getTtl(), cacheInfo.getVideoTtl()) : null;
         bid.setExp(ttl);
@@ -1070,5 +1057,21 @@ public class BidResponseCreator {
                 .convertValue(bidExt, EXT_PREBID_TYPE_REFERENCE);
         final ExtBidPrebid extBidPrebid = extPrebid != null ? extPrebid.getPrebid() : null;
         return extBidPrebid != null ? extBidPrebid.getVideo() : null;
+    }
+
+    // will be updated in https://github.com/prebid/prebid-server-java/pull/1126
+    private ObjectNode createBidExt(ObjectNode existingBidExt, ExtBidPrebid extBidPrebid) {
+        JsonNode skadnObject = mapper.mapper().createObjectNode();
+        if (existingBidExt != null && !existingBidExt.isEmpty()) {
+            skadnObject = existingBidExt.get(SKADN_PROPERTY);
+            existingBidExt.remove(SKADN_PROPERTY);
+        }
+        final ExtPrebid<ExtBidPrebid, ObjectNode> bidExt = ExtPrebid.of(extBidPrebid, existingBidExt);
+        final ObjectNode updatedBidExt = mapper.mapper().valueToTree(bidExt);
+        if (skadnObject != null && !skadnObject.isEmpty()) {
+            updatedBidExt.set(SKADN_PROPERTY, skadnObject);
+        }
+
+        return updatedBidExt;
     }
 }

--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -97,6 +97,7 @@ public class BidResponseCreator {
 
     private static final String CACHE = "cache";
     private static final String PREBID_EXT = "prebid";
+    private static final String SKADN_PROPERTY = "skadn";
 
     private final CacheService cacheService;
     private final BidderCatalog bidderCatalog;
@@ -810,13 +811,13 @@ public class BidResponseCreator {
         final ObjectNode existingBidExt = bid.getExt();
         JsonNode skadnObject = mapper.mapper().createObjectNode();
         if (bid.getExt() != null && !existingBidExt.isEmpty()) {
-            skadnObject = existingBidExt.get("skadn");
-            existingBidExt.remove("skadn");
+            skadnObject = existingBidExt.get(SKADN_PROPERTY);
+            existingBidExt.remove(SKADN_PROPERTY);
         }
         final ExtPrebid<ExtBidPrebid, ObjectNode> bidExt = ExtPrebid.of(extBidPrebid, existingBidExt);
         final ObjectNode updatedBidExt = mapper.mapper().valueToTree(bidExt);
         if (skadnObject != null && !skadnObject.isEmpty()) {
-            updatedBidExt.set("skadn", skadnObject);
+            updatedBidExt.set(SKADN_PROPERTY, skadnObject);
         }
 
         bid.setExt(updatedBidExt);

--- a/src/test/java/org/prebid/server/auction/BidResponseCreatorTest.java
+++ b/src/test/java/org/prebid/server/auction/BidResponseCreatorTest.java
@@ -2,6 +2,7 @@ package org.prebid.server.auction;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.Asset;
@@ -80,6 +81,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -600,6 +602,48 @@ public class BidResponseCreatorTest extends VertxTest {
                         .build());
 
         verify(cacheService, never()).cacheBidsOpenrtb(anyList(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotWriteSkadnAttributeToBidderSection() {
+        // given
+        final AuctionContext auctionContext = givenAuctionContext(givenBidRequest(givenImp()));
+        final Map<String, Object> bidExtProperties = new HashMap<>();
+        bidExtProperties.put("skadn", singletonMap("soeSkadnKey", "soeSkadnValue"));
+        bidExtProperties.put("anotherProp", "anotherPropValue");
+        final Bid bid = Bid.builder()
+                .id("bidId")
+                .price(BigDecimal.ONE)
+                .adm(BID_ADM)
+                .impid(IMP_ID)
+                .ext(mapper.valueToTree(bidExtProperties))
+                .build();
+
+        final String bidder = "bidder1";
+        final List<BidderResponse> bidderResponses = singletonList(BidderResponse.of(bidder,
+                givenSeatBid(BidderBid.of(bid, banner, "USD")), 100));
+
+        // when
+        final BidResponse bidResponse =
+                bidResponseCreator.create(bidderResponses, auctionContext, CACHE_INFO, false).result();
+
+        // then
+        final ObjectNode expectedBidExt = mapper.valueToTree(ExtPrebid.of(
+                ExtBidPrebid.builder().type(banner).build(),
+                singletonMap("anotherProp", "anotherPropValue")));
+        expectedBidExt.set("skadn", mapper.convertValue(singletonMap("soeSkadnKey", "soeSkadnValue"), JsonNode.class));
+        assertThat(bidResponse.getSeatbid())
+                .containsOnly(SeatBid.builder()
+                        .seat(bidder)
+                        .group(0)
+                        .bid(singletonList(Bid.builder()
+                                .id("bidId")
+                                .impid(IMP_ID)
+                                .price(BigDecimal.ONE)
+                                .adm(BID_ADM)
+                                .ext(expectedBidExt)
+                                .build()))
+                        .build());
     }
 
     @Test

--- a/src/test/java/org/prebid/server/auction/BidResponseCreatorTest.java
+++ b/src/test/java/org/prebid/server/auction/BidResponseCreatorTest.java
@@ -609,7 +609,7 @@ public class BidResponseCreatorTest extends VertxTest {
         // given
         final AuctionContext auctionContext = givenAuctionContext(givenBidRequest(givenImp()));
         final Map<String, Object> bidExtProperties = new HashMap<>();
-        bidExtProperties.put("skadn", singletonMap("soeSkadnKey", "soeSkadnValue"));
+        bidExtProperties.put("skadn", singletonMap("skadnKey", "skadnValue"));
         bidExtProperties.put("anotherProp", "anotherPropValue");
         final Bid bid = Bid.builder()
                 .id("bidId")
@@ -631,19 +631,11 @@ public class BidResponseCreatorTest extends VertxTest {
         final ObjectNode expectedBidExt = mapper.valueToTree(ExtPrebid.of(
                 ExtBidPrebid.builder().type(banner).build(),
                 singletonMap("anotherProp", "anotherPropValue")));
-        expectedBidExt.set("skadn", mapper.convertValue(singletonMap("soeSkadnKey", "soeSkadnValue"), JsonNode.class));
+        expectedBidExt.set("skadn", mapper.convertValue(singletonMap("skadnKey", "skadnValue"), JsonNode.class));
         assertThat(bidResponse.getSeatbid())
-                .containsOnly(SeatBid.builder()
-                        .seat(bidder)
-                        .group(0)
-                        .bid(singletonList(Bid.builder()
-                                .id("bidId")
-                                .impid(IMP_ID)
-                                .price(BigDecimal.ONE)
-                                .adm(BID_ADM)
-                                .ext(expectedBidExt)
-                                .build()))
-                        .build());
+                .flatExtracting(SeatBid::getBid)
+                .extracting(Bid::getExt)
+                .containsExactly(expectedBidExt);
     }
 
     @Test


### PR DESCRIPTION
This PR is temporal solution.
It will be replaced by new requirement https://github.com/prebid/prebid-server/issues/1676
which is already implemented in https://github.com/prebid/prebid-server-java/pull/1126