### PR TITLE
Openx: use bidfloor if set - prebid.js adapter behavior 

### DIFF
--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -10,6 +10,7 @@ import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
 import io.vertx.core.http.HttpMethod;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.bidder.Bidder;
 import org.prebid.server.bidder.model.BidderBid;
@@ -159,7 +160,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
         final ExtImpPrebid prebidImpExt = impExt.getPrebid();
         final Imp.ImpBuilder impBuilder = imp.toBuilder()
                 .tagid(openxImpExt.getUnit())
-                .bidfloor(openxImpExt.getCustomFloor())
+                .bidfloor(ObjectUtils.defaultIfNull(imp.getBidfloor(), openxImpExt.getCustomFloor()))
                 .ext(makeImpExt(openxImpExt.getCustomParams()));
 
         if (resolveImpType(imp) == OpenxImpType.video

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -201,16 +201,17 @@ public class OpenxBidderTest extends VertxTest {
                 .imp(asList(
                         Imp.builder()
                                 .id("impId1")
+                                .bidfloor(BigDecimal.valueOf(0.5))
                                 .banner(Banner.builder().build())
                                 .ext(mapper.valueToTree(
                                         ExtPrebid.of(null,
                                                 ExtImpOpenx.builder()
-                                                        .customFloor(BigDecimal.valueOf(0.1))
                                                         .customParams(givenCustomParams("foo1", singletonList("bar1")))
                                                         .delDomain("se-demo-d.openx.net")
                                                         .unit("unitId").build()))).build(),
                         Imp.builder()
                                 .id("impId2")
+                                .bidfloor(BigDecimal.valueOf(0.5))
                                 .banner(Banner.builder().build())
                                 .ext(mapper.valueToTree(
                                         ExtPrebid.of(null,
@@ -237,7 +238,6 @@ public class OpenxBidderTest extends VertxTest {
                                 .ext(mapper.valueToTree(
                                         ExtPrebid.of(null,
                                                 ExtImpOpenx.builder()
-                                                        .customFloor(BigDecimal.valueOf(0.1))
                                                         .customParams(givenCustomParams("foo4", "bar4"))
                                                         .platform("PLATFORM")
                                                         .unit("unitId").build()))).build(),
@@ -266,7 +266,7 @@ public class OpenxBidderTest extends VertxTest {
                                                 .id("impId1")
                                                 .banner(Banner.builder().build())
                                                 .tagid("unitId")
-                                                .bidfloor(BigDecimal.valueOf(0.1))
+                                                .bidfloor(BigDecimal.valueOf(0.5))
                                                 .ext(mapper.valueToTree(
                                                         ExtImpOpenx.builder()
                                                                 .customParams(
@@ -278,7 +278,7 @@ public class OpenxBidderTest extends VertxTest {
                                                 .id("impId2")
                                                 .banner(Banner.builder().build())
                                                 .tagid("unitId")
-                                                .bidfloor(BigDecimal.valueOf(0.1))
+                                                .bidfloor(BigDecimal.valueOf(0.5))
                                                 .ext(mapper.valueToTree(
                                                         ExtImpOpenx.builder()
                                                                 .customParams(
@@ -328,7 +328,6 @@ public class OpenxBidderTest extends VertxTest {
                                                 .id("impId4")
                                                 .video(Video.builder().build())
                                                 .tagid("unitId")
-                                                .bidfloor(BigDecimal.valueOf(0.1))
                                                 .ext(mapper.valueToTree(
                                                         ExtImpOpenx.builder()
                                                                 .customParams(


### PR DESCRIPTION
- Fixes bug that set bidfloor to null when customFloor not given (so almost always)
- Implements behavior in https://github.com/prebid/Prebid.js/blob/master/modules/openxBidAdapter.js#L495
- Ref https://github.com/prebid/prebid-server/issues/1787
- Same change as https://github.com/prebid/prebid-server/pull/1795 for PBS-Go