### PR TITLE
Add lookup of account from stored requests

### DIFF
--- a/src/main/java/org/prebid/server/auction/requestfactory/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/AmpRequestFactory.java
@@ -120,6 +120,7 @@ public class AmpRequestFactory {
                         routingContext,
                         bidRequestWithErrors.getLeft(),
                         MetricName.amp,
+                        false,
                         startTime,
                         bidRequestWithErrors.getRight()))
 

--- a/src/main/java/org/prebid/server/auction/requestfactory/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/AuctionRequestFactory.java
@@ -78,6 +78,7 @@ public class AuctionRequestFactory {
                         routingContext,
                         bidRequest,
                         requestTypeMetric(bidRequest),
+                        true,
                         startTime,
                         errors))
 

--- a/src/main/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactory.java
@@ -14,6 +14,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.prebid.server.auction.StoredRequestProcessor;
 import org.prebid.server.auction.TimeoutResolver;
 import org.prebid.server.auction.model.AuctionContext;
 import org.prebid.server.cookie.UidsCookieService;
@@ -55,6 +56,7 @@ public class Ortb2RequestFactory {
     private final UidsCookieService uidsCookieService;
     private final RequestValidator requestValidator;
     private final TimeoutFactory timeoutFactory;
+    private final StoredRequestProcessor storedRequestProcessor;
     private final ApplicationSettings applicationSettings;
     private final TimeoutResolver timeoutResolver;
 
@@ -64,6 +66,7 @@ public class Ortb2RequestFactory {
                                RequestValidator requestValidator,
                                TimeoutResolver timeoutResolver,
                                TimeoutFactory timeoutFactory,
+                               StoredRequestProcessor storedRequestProcessor,
                                ApplicationSettings applicationSettings) {
 
         this.enforceValidAccount = enforceValidAccount;
@@ -73,15 +76,17 @@ public class Ortb2RequestFactory {
         this.timeoutResolver = Objects.requireNonNull(timeoutResolver);
         this.timeoutFactory = Objects.requireNonNull(timeoutFactory);
         this.applicationSettings = Objects.requireNonNull(applicationSettings);
+        this.storedRequestProcessor = Objects.requireNonNull(storedRequestProcessor);
     }
 
     public Future<AuctionContext> fetchAccountAndCreateAuctionContext(RoutingContext routingContext,
                                                                       BidRequest bidRequest,
                                                                       MetricName requestTypeMetric,
+                                                                      boolean isLookupStoredRequest,
                                                                       long startTime,
                                                                       List<String> errors) {
         final Timeout timeout = timeout(bidRequest, startTime, timeoutResolver);
-        return accountFrom(bidRequest, timeout, routingContext)
+        return accountFrom(bidRequest, timeout, routingContext, isLookupStoredRequest)
                 .map(account -> AuctionContext.builder()
                         .routingContext(routingContext)
                         .uidsCookie(uidsCookieService.parseFromRequest(routingContext))
@@ -135,21 +140,45 @@ public class Ortb2RequestFactory {
     }
 
     /**
+     * Make lookup for storedRequest if isLookupStoredRequest is true
+     * and account id is not found in original {@link BidRequest}.
+     * <p>
      * Returns {@link Account} fetched by {@link ApplicationSettings}.
      */
-    private Future<Account> accountFrom(BidRequest bidRequest, Timeout timeout, RoutingContext routingContext) {
+    private Future<Account> accountFrom(BidRequest bidRequest,
+                                        Timeout timeout,
+                                        RoutingContext routingContext,
+                                        boolean isLookupStoredRequest) {
+        return findAccountIdFrom(bidRequest, isLookupStoredRequest)
+                .map(this::validateIfAccountBlacklisted)
+                .compose(accountId -> fetchAccount(timeout, routingContext, accountId));
+    }
+
+    private Future<String> findAccountIdFrom(BidRequest bidRequest, boolean isLookupStoredRequest) {
         final String accountId = accountIdFrom(bidRequest);
-        final boolean isAccountIdBlank = StringUtils.isBlank(accountId);
+        return StringUtils.isNotBlank(accountId) || !isLookupStoredRequest
+                ? Future.succeededFuture(accountId)
+                : storedRequestProcessor.processStoredRequests(accountId, bidRequest)
+                        .map(this::accountIdFrom)
+                        .otherwise(StringUtils.EMPTY);
+    }
 
+    private String validateIfAccountBlacklisted(String accountId) {
         if (CollectionUtils.isNotEmpty(blacklistedAccounts)
-                && !isAccountIdBlank
+                && StringUtils.isNotBlank(accountId)
                 && blacklistedAccounts.contains(accountId)) {
-            return Future.failedFuture(new BlacklistedAccountException(
-                    String.format("Prebid-server has blacklisted Account ID: %s, please "
-                            + "reach out to the prebid server host.", accountId)));
-        }
 
-        return isAccountIdBlank
+            throw new BlacklistedAccountException(
+                    String.format("Prebid-server has blacklisted Account ID: %s, please "
+                            + "reach out to the prebid server host.", accountId));
+        }
+        return accountId;
+    }
+
+    private Future<Account> fetchAccount(Timeout timeout,
+                                         RoutingContext routingContext,
+                                         String accountId) {
+        return StringUtils.isBlank(accountId)
                 ? responseForEmptyAccount(routingContext)
                 : applicationSettings.getAccountById(accountId, timeout)
                         .compose(this::ensureAccountActive,

--- a/src/main/java/org/prebid/server/auction/requestfactory/VideoRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/VideoRequestFactory.java
@@ -81,6 +81,7 @@ public class VideoRequestFactory {
                         routingContext,
                         bidRequestWithErrors.getData(),
                         MetricName.video,
+                        false,
                         startTime,
                         new ArrayList<>())
 

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -209,6 +209,7 @@ public class ServiceConfiguration {
             RequestValidator requestValidator,
             TimeoutResolver timeoutResolver,
             TimeoutFactory timeoutFactory,
+            StoredRequestProcessor storedRequestProcessor,
             ApplicationSettings applicationSettings) {
 
         final List<String> blacklistedAccounts = splitToList(blacklistedAccountsString);
@@ -220,6 +221,7 @@ public class ServiceConfiguration {
                 requestValidator,
                 timeoutResolver,
                 timeoutFactory,
+                storedRequestProcessor,
                 applicationSettings);
     }
 

--- a/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
@@ -68,6 +68,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1287,7 +1288,7 @@ public class AmpRequestFactoryTest extends VertxTest {
         // then
         @SuppressWarnings("unchecked") final ArgumentCaptor<List<String>> errorsCaptor = ArgumentCaptor.forClass(
                 List.class);
-        verify(ortb2RequestFactory).fetchAccountAndCreateAuctionContext(any(), any(), any(), anyLong(),
+        verify(ortb2RequestFactory).fetchAccountAndCreateAuctionContext(any(), any(), any(), anyBoolean(), anyLong(),
                 errorsCaptor.capture());
         assertThat(errorsCaptor.getValue()).contains("Amp request parameter consent_string or gdpr_consent have"
                 + " invalid format: consent-value");
@@ -1550,7 +1551,8 @@ public class AmpRequestFactoryTest extends VertxTest {
                 .willReturn(Future.succeededFuture(bidRequest));
 
         final MetricName metricName = MetricName.amp;
-        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), eq(metricName), anyLong(), any()))
+        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), eq(metricName), anyBoolean(),
+                anyLong(), any()))
                 .willAnswer(invocationOnMock -> Future.succeededFuture(
                         AuctionContext.builder()
                                 .bidRequest((BidRequest) invocationOnMock.getArguments()[1])

--- a/src/test/java/org/prebid/server/auction/requestfactory/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AuctionRequestFactoryTest.java
@@ -47,6 +47,7 @@ import static java.util.Collections.singletonMap;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -292,8 +293,8 @@ public class AuctionRequestFactoryTest extends VertxTest {
     public void shouldReturnFailedFutureIfOrtb2RequestFactoryReturnedFailedFuture() {
         // given
         givenBidRequest(BidRequest.builder().build());
-        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), any(), anyLong(), any()))
-                .willReturn(Future.failedFuture("error"));
+        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), any(), anyBoolean(), anyLong(),
+                any())).willReturn(Future.failedFuture("error"));
 
         // when
         final Future<?> future = target.fromRequest(routingContext, 0L);
@@ -315,7 +316,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
 
         // then
         verify(ortb2RequestFactory).fetchAccountAndCreateAuctionContext(eq(routingContext), eq(bidRequest),
-                eq(MetricName.openrtb2web), anyLong(), any());
+                eq(MetricName.openrtb2web), eq(true), anyLong(), any());
     }
 
     @Test
@@ -330,7 +331,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
 
         // then
         verify(ortb2RequestFactory).fetchAccountAndCreateAuctionContext(eq(routingContext), eq(bidRequest),
-                eq(MetricName.openrtb2app), anyLong(), any());
+                eq(MetricName.openrtb2app), eq(true), anyLong(), any());
     }
 
     @Test
@@ -433,7 +434,8 @@ public class AuctionRequestFactoryTest extends VertxTest {
     }
 
     private void givenAuctionContext(BidRequest bidRequest, Account account) {
-        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), any(), anyLong(), any()))
+        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), any(), anyBoolean(), anyLong(),
+                any()))
                 .willReturn(Future.succeededFuture(defaultActionContext.toBuilder()
                         .bidRequest(bidRequest)
                         .account(account)

--- a/src/test/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactoryTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.prebid.server.VertxTest;
+import org.prebid.server.auction.StoredRequestProcessor;
 import org.prebid.server.auction.TimeoutResolver;
 import org.prebid.server.auction.model.AuctionContext;
 import org.prebid.server.cookie.UidsCookie;
@@ -75,6 +76,8 @@ public class Ortb2RequestFactoryTest extends VertxTest {
     @Mock
     private TimeoutFactory timeoutFactory;
     @Mock
+    private StoredRequestProcessor storedRequestProcessor;
+    @Mock
     private ApplicationSettings applicationSettings;
 
     private Ortb2RequestFactory target;
@@ -105,6 +108,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
                 requestValidator,
                 timeoutResolver,
                 timeoutFactory,
+                storedRequestProcessor,
                 applicationSettings);
     }
 
@@ -118,17 +122,18 @@ public class Ortb2RequestFactoryTest extends VertxTest {
                 requestValidator,
                 timeoutResolver,
                 timeoutFactory,
+                storedRequestProcessor,
                 applicationSettings);
 
         // when
-        final Future<?> future = target.fetchAccountAndCreateAuctionContext(routingContext, defaultBidRequest, null,
-                2000, new ArrayList<>());
+        final Future<?> result = target.fetchAccountAndCreateAuctionContext(routingContext, defaultBidRequest, null,
+                false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings, never()).getAccountById(any(), any());
 
-        assertThat(future.failed()).isTrue();
-        assertThat(future.cause())
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause())
                 .isInstanceOf(UnauthorizedAccountException.class)
                 .hasMessage("Unauthorized account id: ");
     }
@@ -143,6 +148,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
                 requestValidator,
                 timeoutResolver,
                 timeoutFactory,
+                storedRequestProcessor,
                 applicationSettings);
 
         given(applicationSettings.getAccountById(any(), any()))
@@ -156,14 +162,14 @@ public class Ortb2RequestFactoryTest extends VertxTest {
                 .build();
 
         // when
-        final Future<?> future = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest, null,
-                2000, new ArrayList<>());
+        final Future<?> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest, null,
+                false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq(accountId), any());
 
-        assertThat(future.failed()).isTrue();
-        assertThat(future.cause())
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause())
                 .isInstanceOf(UnauthorizedAccountException.class)
                 .hasMessage("Unauthorized account id: absentId");
     }
@@ -185,13 +191,12 @@ public class Ortb2RequestFactoryTest extends VertxTest {
                         .build()));
 
         // when
-        final Future<AuctionContext> future = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null,
-                2000, new ArrayList<>());
+        final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
+                null, false, 2000, new ArrayList<>());
 
         // then
-        assertThat(future.failed()).isTrue();
-        assertThat(future.cause())
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause())
                 .isInstanceOf(UnauthorizedAccountException.class)
                 .hasMessage("Account accountId is inactive");
     }
@@ -207,7 +212,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
                 null,
-                2000, new ArrayList<>());
+                false, 2000, new ArrayList<>());
 
         // then
         assertThat(result.failed()).isTrue();
@@ -235,7 +240,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq(parentAccount), any());
@@ -258,7 +263,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq(accountId), any());
@@ -283,7 +288,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq(accountId), any());
@@ -308,7 +313,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq("accountId"), any());
@@ -333,7 +338,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq(parentAccount), any());
@@ -356,7 +361,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
         verify(applicationSettings).getAccountById(eq(accountId), any());
@@ -374,9 +379,115 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                null, 2000, new ArrayList<>());
+                null, false, 2000, new ArrayList<>());
 
         // then
+        verifyZeroInteractions(applicationSettings);
+
+        assertThat(result.result().getAccount()).isEqualTo(Account.empty(""));
+    }
+
+    @Test
+    public void shouldFetchAccountFromStoredIfStoredLookupIsTrueAndAccountIsNotFoundPreviously() {
+        // given
+        final BidRequest receivedBidRequest = BidRequest.builder().build();
+
+        final String accountId = "accountId";
+        final BidRequest mergedBidRequest = BidRequest.builder()
+                .site(Site.builder()
+                        .publisher(Publisher.builder().id(accountId).build())
+                        .build())
+                .build();
+
+        given(storedRequestProcessor.processStoredRequests(any(), any()))
+                .willReturn(Future.succeededFuture(mergedBidRequest));
+
+        final Account fetchedAccount = Account.builder().id(accountId).status(AccountStatus.active).build();
+        given(applicationSettings.getAccountById(any(), any()))
+                .willReturn(Future.succeededFuture(fetchedAccount));
+
+        // when
+        final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext,
+                receivedBidRequest, null, true, 2000, new ArrayList<>());
+
+        // then
+        verify(storedRequestProcessor).processStoredRequests("", receivedBidRequest);
+        verify(applicationSettings).getAccountById(eq(accountId), any());
+
+        assertThat(result.result().getAccount()).isEqualTo(fetchedAccount);
+    }
+
+    @Test
+    public void shouldFetchAccountFromStoredAndReturnFailedFutureWhenAccountIdIsBlacklisted() {
+        // given
+        final BidRequest receivedBidRequest = BidRequest.builder().build();
+
+        final BidRequest mergedBidRequest = BidRequest.builder()
+                .site(Site.builder()
+                        .publisher(Publisher.builder().id("bad_acc").build()).build())
+                .build();
+        given(storedRequestProcessor.processStoredRequests(any(), any()))
+                .willReturn(Future.succeededFuture(mergedBidRequest));
+
+        // when
+        final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext,
+                receivedBidRequest, null, true, 2000, new ArrayList<>());
+
+        // then
+        verify(storedRequestProcessor).processStoredRequests("", receivedBidRequest);
+        verifyZeroInteractions(applicationSettings);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause())
+                .isInstanceOf(BlacklistedAccountException.class)
+                .hasMessage("Prebid-server has blacklisted Account ID: bad_acc, please reach out to the prebid "
+                        + "server host.");
+    }
+
+    @Test
+    public void shouldFetchAccountFromStoredAndReturnFailedFutureIfValidIsEnforcedAndStoredLookupIsFailed() {
+        // given
+        target = new Ortb2RequestFactory(
+                true,
+                BLACKLISTED_ACCOUNTS,
+                uidsCookieService,
+                requestValidator,
+                timeoutResolver,
+                timeoutFactory,
+                storedRequestProcessor,
+                applicationSettings);
+
+        final BidRequest receivedBidRequest = BidRequest.builder().build();
+        given(storedRequestProcessor.processStoredRequests(any(), any()))
+                .willReturn(Future.failedFuture(new RuntimeException("error")));
+
+        // when
+        final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext,
+                receivedBidRequest, null, true, 2000, new ArrayList<>());
+
+        // then
+        verify(storedRequestProcessor).processStoredRequests("", receivedBidRequest);
+        verifyZeroInteractions(applicationSettings);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause())
+                .isInstanceOf(UnauthorizedAccountException.class)
+                .hasMessage("Unauthorized account id: ");
+    }
+
+    @Test
+    public void shouldFetchAccountFromStoredAndReturnEmptyAccountIfStoredLookupIsFailed() {
+        // given
+        final BidRequest receivedBidRequest = BidRequest.builder().build();
+        given(storedRequestProcessor.processStoredRequests(any(), any()))
+                .willReturn(Future.failedFuture(new RuntimeException("error")));
+
+        // when
+        final Future<AuctionContext> result = target.fetchAccountAndCreateAuctionContext(routingContext,
+                receivedBidRequest, null, true, 2000, new ArrayList<>());
+
+        // then
+        verify(storedRequestProcessor).processStoredRequests("", receivedBidRequest);
         verifyZeroInteractions(applicationSettings);
 
         assertThat(result.result().getAccount()).isEqualTo(Account.empty(""));
@@ -415,8 +526,7 @@ public class Ortb2RequestFactoryTest extends VertxTest {
 
         // when
         final Future<AuctionContext> future = target.fetchAccountAndCreateAuctionContext(routingContext, bidRequest,
-                metricName,
-                startTime, errors);
+                metricName, false, startTime, errors);
 
         // then
         verify(timeoutResolver).resolve(tmax);

--- a/src/test/java/org/prebid/server/auction/requestfactory/VideoRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/VideoRequestFactoryTest.java
@@ -50,6 +50,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -239,7 +240,7 @@ public class VideoRequestFactoryTest extends VertxTest {
         verify(routingContext).getBodyAsString();
         verify(videoStoredRequestProcessor).processVideoRequest("", null, emptySet(), requestVideo);
         verify(ortb2RequestFactory).fetchAccountAndCreateAuctionContext(
-                routingContext, bidRequest, MetricName.video, 0, new ArrayList<>());
+                routingContext, bidRequest, MetricName.video, false, 0, new ArrayList<>());
         verify(ortb2RequestFactory).validateRequest(bidRequest);
         verify(paramsResolver).resolve(bidRequest, routingContext, timeoutResolver);
         verify(ortb2RequestFactory).enrichBidRequestWithAccountAndPrivacyData(eq(bidRequest), any(), any());
@@ -289,7 +290,8 @@ public class VideoRequestFactoryTest extends VertxTest {
     private void givenBidRequest(BidRequest bidRequest, List<PodError> podErrors) {
         given(videoStoredRequestProcessor.processVideoRequest(any(), any(), any(), any()))
                 .willReturn(Future.succeededFuture(WithPodErrors.of(bidRequest, podErrors)));
-        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), any(), anyLong(), any()))
+        given(ortb2RequestFactory.fetchAccountAndCreateAuctionContext(any(), any(), any(), anyBoolean(), anyLong(),
+                any()))
                 .willAnswer(invocationOnMock -> Future.succeededFuture(
                         AuctionContext.builder()
                                 .bidRequest((BidRequest) invocationOnMock.getArguments()[1])


### PR DESCRIPTION
For now, it is not the best code that I've written, but we still need to discuss AMP accountId processing, and this is the simplest solution.
Later we will extract accountId parsing into separate module and extend logic into Video and Amp, so we can remove boolean parameter.