### PR TITLE
Usersync URL supports format parameter

### DIFF
--- a/src/main/java/org/prebid/server/bidder/UsersyncInfoAssembler.java
+++ b/src/main/java/org/prebid/server/bidder/UsersyncInfoAssembler.java
@@ -16,7 +16,8 @@ public class UsersyncInfoAssembler {
     public static UsersyncInfoAssembler from(Usersyncer.UsersyncMethod usersyncMethod) {
         final UsersyncInfoAssembler usersyncInfoAssembler = new UsersyncInfoAssembler();
         usersyncInfoAssembler.usersyncUrl = usersyncMethod.getUsersyncUrl();
-        usersyncInfoAssembler.redirectUrl = ObjectUtils.defaultIfNull(usersyncMethod.getRedirectUrl(), "");
+        usersyncInfoAssembler.redirectUrl = UsersyncUtil.enrichUsersyncUrlWithFormat(
+                StringUtils.stripToEmpty(usersyncMethod.getRedirectUrl()), usersyncMethod.getType());
         usersyncInfoAssembler.type = usersyncMethod.getType();
         usersyncInfoAssembler.supportCORS = usersyncMethod.isSupportCORS();
         return usersyncInfoAssembler;

--- a/src/main/java/org/prebid/server/bidder/UsersyncUtil.java
+++ b/src/main/java/org/prebid/server/bidder/UsersyncUtil.java
@@ -1,0 +1,67 @@
+package org.prebid.server.bidder;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class UsersyncUtil {
+
+    public static final String FORMAT_PARAMETER = "f";
+    public static final String BLANK_FORMAT = "b";
+    public static final String IMG_FORMAT = "i";
+
+    private UsersyncUtil() {
+    }
+
+    /**
+     * Places format query string param into the given url.
+     * <p>
+     * Caution: it doesn't care if it already exists in url, just adds new one.
+     * <p>
+     * Note: format is inserted before the last param for safety reason because of
+     * usersync url can be appended with UID on the exchange side without parsing query string.
+     */
+    public static String enrichUsersyncUrlWithFormat(String url, String type) {
+        final String result;
+
+        if (StringUtils.isNotEmpty(url) && StringUtils.isNotEmpty(type)) {
+            final String formatValue = resolveFormatValueByType(type);
+
+            result = hasTwoOrMoreParameters(url)
+                    ? insertFormatParameter(url, formatValue)
+                    : appendFormatParameter(url, formatValue);
+        } else {
+            result = url;
+        }
+
+        return result;
+    }
+
+    private static String resolveFormatValueByType(String type) {
+        switch (type) {
+            case Usersyncer.UsersyncMethod.REDIRECT_TYPE:
+                return IMG_FORMAT;
+            case Usersyncer.UsersyncMethod.IFRAME_TYPE:
+                return BLANK_FORMAT;
+            default:
+                return StringUtils.EMPTY; // never should happen
+        }
+    }
+
+    private static boolean hasTwoOrMoreParameters(String url) {
+        return url.indexOf('&') != -1;
+    }
+
+    private static String insertFormatParameter(String url, String formatValue) {
+        final int lastParamIndex = url.lastIndexOf('&');
+
+        return url.substring(0, lastParamIndex)
+                + "&" + FORMAT_PARAMETER + "=" + formatValue
+                + url.substring(lastParamIndex);
+    }
+
+    private static String appendFormatParameter(String url, String formatValue) {
+        String result;
+        final String separator = url.indexOf('?') != -1 ? "&" : "?";
+        result = url + separator + FORMAT_PARAMETER + "=" + formatValue;
+        return result;
+    }
+}

--- a/src/main/java/org/prebid/server/bidder/UsersyncUtil.java
+++ b/src/main/java/org/prebid/server/bidder/UsersyncUtil.java
@@ -20,19 +20,15 @@ public class UsersyncUtil {
      * usersync url can be appended with UID on the exchange side without parsing query string.
      */
     public static String enrichUsersyncUrlWithFormat(String url, String type) {
-        final String result;
-
-        if (StringUtils.isNotEmpty(url) && StringUtils.isNotEmpty(type)) {
-            final String formatValue = resolveFormatValueByType(type);
-
-            result = hasTwoOrMoreParameters(url)
-                    ? insertFormatParameter(url, formatValue)
-                    : appendFormatParameter(url, formatValue);
-        } else {
-            result = url;
+        if (StringUtils.isAnyEmpty(url, type)) {
+            return url;
         }
 
-        return result;
+        final String formatValue = resolveFormatValueByType(type);
+
+        return hasTwoOrMoreParameters(url)
+                ? insertFormatParameter(url, formatValue)
+                : appendFormatParameter(url, formatValue);
     }
 
     private static String resolveFormatValueByType(String type) {
@@ -59,9 +55,7 @@ public class UsersyncUtil {
     }
 
     private static String appendFormatParameter(String url, String formatValue) {
-        String result;
         final String separator = url.indexOf('?') != -1 ? "&" : "?";
-        result = url + separator + FORMAT_PARAMETER + "=" + formatValue;
-        return result;
+        return url + separator + FORMAT_PARAMETER + "=" + formatValue;
     }
 }

--- a/src/main/java/org/prebid/server/handler/SetuidHandler.java
+++ b/src/main/java/org/prebid/server/handler/SetuidHandler.java
@@ -17,6 +17,7 @@ import org.prebid.server.analytics.model.SetuidEvent;
 import org.prebid.server.auction.PrivacyEnforcementService;
 import org.prebid.server.auction.model.SetuidContext;
 import org.prebid.server.bidder.BidderCatalog;
+import org.prebid.server.bidder.UsersyncUtil;
 import org.prebid.server.bidder.Usersyncer;
 import org.prebid.server.cookie.UidsCookie;
 import org.prebid.server.cookie.UidsCookieService;
@@ -45,13 +46,9 @@ public class SetuidHandler implements Handler<RoutingContext> {
 
     private static final String BIDDER_PARAM = "bidder";
     private static final String UID_PARAM = "uid";
-    private static final String FORMAT_PARAM = "f";
-    private static final String IMG_FORMAT_PARAM = "i";
-    private static final String BLANK_FORMAT_PARAM = "b";
     private static final String PIXEL_FILE_PATH = "static/tracking-pixel.png";
     private static final String ACCOUNT_PARAM = "account";
     private static final int UNAVAILABLE_FOR_LEGAL_REASONS = 451;
-    private static final String REDIRECT = "redirect";
 
     private final long defaultTimeout;
     private final UidsCookieService uidsCookieService;
@@ -254,8 +251,7 @@ public class SetuidHandler implements Handler<RoutingContext> {
 
         final int status = HttpResponseStatus.OK.code();
 
-        // Send pixel file to response if "format=img"
-        final String format = routingContext.request().getParam(FORMAT_PARAM);
+        final String format = routingContext.request().getParam(UsersyncUtil.FORMAT_PARAMETER);
         if (shouldRespondWithPixel(format, setuidContext.getSyncType())) {
             routingContext.response().sendFile(PIXEL_FILE_PATH);
         } else {
@@ -272,8 +268,9 @@ public class SetuidHandler implements Handler<RoutingContext> {
     }
 
     private boolean shouldRespondWithPixel(String format, String syncType) {
-        return StringUtils.equals(format, IMG_FORMAT_PARAM)
-                || !StringUtils.equals(format, BLANK_FORMAT_PARAM) && StringUtils.equals(syncType, REDIRECT);
+        return StringUtils.equals(format, UsersyncUtil.IMG_FORMAT)
+                || (!StringUtils.equals(format, UsersyncUtil.BLANK_FORMAT)
+                && StringUtils.equals(syncType, Usersyncer.UsersyncMethod.REDIRECT_TYPE));
     }
 
     private void handleErrors(Throwable error, RoutingContext routingContext, TcfContext tcfContext) {

--- a/src/main/resources/bidder-config/smartyads.yaml
+++ b/src/main/resources/bidder-config/smartyads.yaml
@@ -21,7 +21,7 @@ adapters:
       vendor-id: 0
     usersync:
       url: https://as.ck-ie.com/prebid.gif?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&redir=
-      redirect-url: /setuid?bidder=smartyads&uid=[uid]
+      redirect-url: /setuid?bidder=smartyads&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&uid=[uid]
       cookie-family-name: smartyads
       type: redirect
       support-cors: false

--- a/src/test/java/org/prebid/server/bidder/UsersyncUtilTest.java
+++ b/src/test/java/org/prebid/server/bidder/UsersyncUtilTest.java
@@ -1,0 +1,72 @@
+package org.prebid.server.bidder;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UsersyncUtilTest {
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldNotChangeUrlIfMissing() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat(null, "iframe");
+
+        // then
+        assertThat(url).isNull();
+    }
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldNotChangeUrlIfEmpty() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat("", "iframe");
+
+        // then
+        assertThat(url).isEmpty();
+    }
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldNotChangeUrlIfTypeMissing() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat("", null);
+
+        // then
+        assertThat(url).isEmpty();
+    }
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldNotChangeUrlIfTypeEmpty() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat("", "");
+
+        // then
+        assertThat(url).isEmpty();
+    }
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldAddFormat() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat("//url", "iframe");
+
+        // then
+        assertThat(url).isEqualTo("//url?f=b");
+    }
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldAppendFormat() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat("http://url?param1=value1", "redirect");
+
+        // then
+        assertThat(url).isEqualTo("http://url?param1=value1&f=i");
+    }
+
+    @Test
+    public void enrichUsersyncUrlWithFormatShouldInsertFormat() {
+        // given and when
+        final String url = UsersyncUtil.enrichUsersyncUrlWithFormat("http://url?param1=value1&param2=value2",
+                "redirect");
+
+        // then
+        assertThat(url).isEqualTo("http://url?param1=value1&f=i&param2=value2");
+    }
+}

--- a/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
@@ -980,7 +980,7 @@ public class CookieSyncHandlerTest extends VertxTest {
                 .extracting(BidderUsersyncStatus::getUsersync)
                 .containsOnly(
                         UsersyncInfo.of("http://external-url/setuid?bidder=rubicon&gdpr=&gdpr_consent=&us_privacy="
-                                + "&uid=host%2Fcookie%2Fvalue&f=i", "redirect", false));
+                                + "&f=i&uid=host%2Fcookie%2Fvalue", "redirect", false));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/it/ApplicationTest.java
+++ b/src/test/java/org/prebid/server/it/ApplicationTest.java
@@ -389,8 +389,8 @@ public class ApplicationTest extends IntegrationTest {
                                         "http://localhost:8080/setuid?bidder=rubicon"
                                                 + "&gdpr=1&gdpr_consent=" + gdprConsent
                                                 + "&us_privacy=1YNN"
-                                                + "&uid=host-cookie-uid"
-                                                + "&f=i",
+                                                + "&f=i"
+                                                + "&uid=host-cookie-uid",
                                         "redirect", false))
                                 .build(),
                         BidderUsersyncStatus.builder()
@@ -400,6 +400,7 @@ public class ApplicationTest extends IntegrationTest {
                                         "//usersync-url/getuid?http%3A%2F%2Flocalhost%3A8080%2Fsetuid%3Fbidder"
                                                 + "%3Dadnxs%26gdpr%3D1%26gdpr_consent%3D" + gdprConsent
                                                 + "%26us_privacy%3D1YNN"
+                                                + "%26f%3Di"
                                                 + "%26uid%3D%24UID",
                                         "redirect", false))
                                 .build(),


### PR DESCRIPTION
Relates to https://github.com/prebid/prebid-server/issues/1554
```
/cookie_sync needs to tell /setuid which kind of response to make.

- For iframe syncs, it should add f=b into the /setuid URL.
- For image syncs, it should add f=i into the /setuid URL.
```