### PR TITLE
Fix IPv6 processing according to privacy ip masking

### DIFF
--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -290,8 +290,7 @@ public class BidResponseCreator {
                 .allMatch(CollectionUtils::isEmpty);
     }
 
-    private static List<BidderResponseInfo> toBidderResponseInfos(List<BidderResponse> bidderResponses,
-                                                                  List<Imp> imps) {
+    private List<BidderResponseInfo> toBidderResponseInfos(List<BidderResponse> bidderResponses, List<Imp> imps) {
         final List<BidderResponseInfo> result = new ArrayList<>();
         for (BidderResponse bidderResponse : bidderResponses) {
             final String bidder = bidderResponse.getBidder();
@@ -317,7 +316,7 @@ public class BidResponseCreator {
         return result;
     }
 
-    private static BidInfo toBidInfo(Bid bid, BidType type, List<Imp> imps, String bidder) {
+    private BidInfo toBidInfo(Bid bid, BidType type, List<Imp> imps, String bidder) {
         return BidInfo.builder()
                 .bid(bid)
                 .bidType(type)
@@ -358,8 +357,8 @@ public class BidResponseCreator {
         final Set<BidInfo> winningBidInfos = targeting == null
                 ? null
                 : bidInfos.stream()
-                        .filter(bidInfo -> bidInfo.getTargetingInfo().isWinningBid())
-                        .collect(Collectors.toSet());
+                .filter(bidInfo -> bidInfo.getTargetingInfo().isWinningBid())
+                .collect(Collectors.toSet());
 
         final Set<BidInfo> bidsToCache = cacheInfo.isShouldCacheWinningBidsOnly() ? winningBidInfos : bidInfos;
 

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -210,7 +210,8 @@ public class ServiceConfiguration {
             TimeoutResolver timeoutResolver,
             TimeoutFactory timeoutFactory,
             StoredRequestProcessor storedRequestProcessor,
-            ApplicationSettings applicationSettings) {
+            ApplicationSettings applicationSettings,
+            IpAddressHelper ipAddressHelper) {
 
         final List<String> blacklistedAccounts = splitToList(blacklistedAccountsString);
 
@@ -222,7 +223,8 @@ public class ServiceConfiguration {
                 timeoutResolver,
                 timeoutFactory,
                 storedRequestProcessor,
-                applicationSettings);
+                applicationSettings,
+                ipAddressHelper);
     }
 
     @Bean


### PR DESCRIPTION
Fixes #1256 

Probably we need to consider to refactor `PrivacyContext` with adding both `ipV4` and `ipV6`. 
Or we can modify `TcfContext` model by changing `ipAddress` of `org.prebid.server.auction.model.IpAddress` type.