### PR TITLE
Fix ext.prebid.analytics flag to be tolerant for invalid input

### DIFF
--- a/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
+++ b/src/main/java/org/prebid/server/bidder/beachfront/BeachfrontBidder.java
@@ -421,7 +421,7 @@ public class BeachfrontBidder implements Bidder<Void> {
             return mapper.mapper().readValue(
                     responseBody,
                     mapper.mapper().getTypeFactory().constructCollectionType(List.class, BeachfrontResponseSlot.class));
-        } catch (IOException ex) {
+        } catch (IOException e) {
             throw new PreBidException("server response failed to unmarshal "
                     + "as valid rtb. Run with request.debug = 1 for more info");
         }

--- a/src/main/java/org/prebid/server/handler/CookieSyncHandler.java
+++ b/src/main/java/org/prebid/server/handler/CookieSyncHandler.java
@@ -215,8 +215,8 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
             final TcfContext tcfContext = cookieSyncContext.getPrivacyContext().getTcfContext();
             try {
                 validateCookieSyncContext(cookieSyncContext);
-            } catch (InvalidRequestException | UnauthorizedUidsException ex) {
-                handleErrors(ex, routingContext, tcfContext);
+            } catch (InvalidRequestException | UnauthorizedUidsException e) {
+                handleErrors(e, routingContext, tcfContext);
                 return;
             }
 
@@ -648,7 +648,6 @@ public class CookieSyncHandler implements Handler<RoutingContext> {
             metrics.updateUserSyncOptoutMetric();
             status = HttpResponseStatus.UNAUTHORIZED.code();
             body = String.format("Unauthorized: %s", message);
-
         } else {
             status = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
             body = String.format("Unexpected setuid processing error: %s", message);

--- a/src/main/java/org/prebid/server/handler/SetuidHandler.java
+++ b/src/main/java/org/prebid/server/handler/SetuidHandler.java
@@ -142,8 +142,8 @@ public class SetuidHandler implements Handler<RoutingContext> {
 
             try {
                 validateSetuidContext(setuidContext, bidder);
-            } catch (InvalidRequestException | UnauthorizedUidsException ex) {
-                handleErrors(ex, routingContext, tcfContext);
+            } catch (InvalidRequestException | UnauthorizedUidsException e) {
+                handleErrors(e, routingContext, tcfContext);
                 return;
             }
 

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebid.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebid.java
@@ -1,5 +1,6 @@
 package org.prebid.server.proto.openrtb.ext.request;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Builder;
@@ -120,5 +121,5 @@ public class ExtRequestPrebid {
     /**
      * Defines the contract for bidrequest.ext.prebid.analytics
      */
-    ObjectNode analytics;
+    JsonNode analytics;
 }


### PR DESCRIPTION
Fixes wrong input request like:
```
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: 
com.iab.openrtb.request.BidRequest["ext"]->
org.prebid.server.proto.openrtb.ext.request.ExtRequest["prebid"]->
org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid["analytics"]), 

[ntloop-thread-4] o.p.s.handler.openrtb2.AuctionHandler    : Invalid request format: Error decoding bidRequest: 
Cannot deserialize instance of `com.fasterxml.jackson.databind.node.ObjectNode` out of START_ARRAY token
```