### PR TITLE
Turn on decompression support in Vert.x HTTP server (gzip and deflate as of Netty 4.1.31)

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/WebConfiguration.java
@@ -14,13 +14,13 @@ import io.vertx.ext.web.handler.StaticHandler;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.prebid.server.analytics.AnalyticsReporterDelegator;
-import org.prebid.server.auction.requestfactory.AmpRequestFactory;
 import org.prebid.server.auction.AmpResponsePostProcessor;
-import org.prebid.server.auction.requestfactory.AuctionRequestFactory;
 import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.auction.PrivacyEnforcementService;
-import org.prebid.server.auction.requestfactory.VideoRequestFactory;
 import org.prebid.server.auction.VideoResponseFactory;
+import org.prebid.server.auction.requestfactory.AmpRequestFactory;
+import org.prebid.server.auction.requestfactory.AuctionRequestFactory;
+import org.prebid.server.auction.requestfactory.VideoRequestFactory;
 import org.prebid.server.bidder.BidderCatalog;
 import org.prebid.server.cache.CacheService;
 import org.prebid.server.cookie.UidsCookieService;
@@ -118,6 +118,7 @@ public class WebConfiguration {
                 .setHandle100ContinueAutomatically(true)
                 .setMaxHeaderSize(maxHeaderSize)
                 .setCompressionSupported(true)
+                .setDecompressionSupported(true)
                 .setIdleTimeout(10); // kick off long processing requests
 
         if (ssl) {


### PR DESCRIPTION
Implements https://github.com/prebid/prebid-server/issues/1812