### PR TITLE
Update AnalyticsReporterDelegator to tolerate with missing BidRequest

### DIFF
--- a/src/main/java/org/prebid/server/analytics/AnalyticsReporterDelegator.java
+++ b/src/main/java/org/prebid/server/analytics/AnalyticsReporterDelegator.java
@@ -111,8 +111,9 @@ public class AnalyticsReporterDelegator {
     }
 
     private void logUnknownAdapters(AuctionEvent auctionEvent) {
-        final BidRequest bidRequest = auctionEvent.getAuctionContext().getBidRequest();
-        final ExtRequest extRequest = bidRequest.getExt();
+        final AuctionContext auctionContext = auctionEvent.getAuctionContext();
+        final BidRequest bidRequest = auctionContext != null ? auctionContext.getBidRequest() : null;
+        final ExtRequest extRequest = bidRequest != null ? bidRequest.getExt() : null;
         final ExtRequestPrebid extPrebid = extRequest != null ? extRequest.getPrebid() : null;
         final JsonNode analytics = extPrebid != null ? extPrebid.getAnalytics() : null;
         final Iterator<String> analyticsFieldNames = isNotEmptyObjectNode(analytics) ? analytics.fieldNames() : null;
@@ -149,13 +150,14 @@ public class AnalyticsReporterDelegator {
     }
 
     private static AuctionContext updateAuctionContextAdapter(AuctionContext context, String adapter) {
-        final BidRequest updatedBidRequest = updateBidRequest(context.getBidRequest(), adapter);
+        final BidRequest bidRequest = context != null ? context.getBidRequest() : null;
+        final BidRequest updatedBidRequest = updateBidRequest(bidRequest, adapter);
 
         return updatedBidRequest != null ? context.toBuilder().bidRequest(updatedBidRequest).build() : null;
     }
 
     private static BidRequest updateBidRequest(BidRequest bidRequest, String adapterName) {
-        final ExtRequest requestExt = bidRequest.getExt();
+        final ExtRequest requestExt = bidRequest != null ? bidRequest.getExt() : null;
         final ExtRequestPrebid extPrebid = requestExt != null ? requestExt.getPrebid() : null;
         final JsonNode analytics = extPrebid != null ? extPrebid.getAnalytics() : null;
         ObjectNode preparedAnalytics = null;

--- a/src/test/java/org/prebid/server/analytics/AnalyticsReporterDelegatorTest.java
+++ b/src/test/java/org/prebid/server/analytics/AnalyticsReporterDelegatorTest.java
@@ -128,6 +128,22 @@ public class AnalyticsReporterDelegatorTest {
     }
 
     @Test
+    public void shouldTolerateWithMissingBidRequest() {
+        // given
+        final AuctionEvent givenAuctionEventWithoutContext = AuctionEvent.builder().build();
+        final AuctionEvent givenAuctionEventWithoutBidRequest = AuctionEvent.builder()
+                .auctionContext(AuctionContext.builder().build())
+                .build();
+
+        // when
+        target.processEvent(givenAuctionEventWithoutContext, TcfContext.empty());
+        target.processEvent(givenAuctionEventWithoutBidRequest, TcfContext.empty());
+
+        // then
+        verify(vertx, times(4)).runOnContext(any());
+    }
+
+    @Test
     public void shouldPassOnlyAdapterRelatedEntriesToAnalyticReporters() {
         // given
         final ObjectNode analyticsNode = new ObjectMapper().createObjectNode();


### PR DESCRIPTION
Fixes NPE:
```
2021-06-08 02:59:02.352 ERROR 13870 --- [vert.x-eventloop-thread-2] io.vertx.core.impl.ContextImpl : Unhandled exception

java.lang.NullPointerException: null
at org.prebid.server.analytics.AnalyticsReporterDelegator.logUnknownAdapters(AnalyticsReporterDelegator.java:114)
at org.prebid.server.analytics.AnalyticsReporterDelegator.checkUnknownAdaptersForAuctionEvent(AnalyticsReporterDelegator.java:109)
at org.prebid.server.analytics.AnalyticsReporterDelegator.delegateEvent(AnalyticsReporterDelegator.java:87)
at org.prebid.server.analytics.AnalyticsReporterDelegator.lambda$processEvent$1(AnalyticsReporterDelegator.java:78)
at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:80)
```