### PR TITLE
Fix AuctionContext model to be suitable for JSON encoding

### DIFF
--- a/src/main/java/org/prebid/server/auction/model/AuctionContext.java
+++ b/src/main/java/org/prebid/server/auction/model/AuctionContext.java
@@ -1,5 +1,6 @@
 package org.prebid.server.auction.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.iab.openrtb.request.BidRequest;
 import lombok.Builder;
 import lombok.Value;
@@ -22,10 +23,12 @@ public class AuctionContext {
 
     HttpRequestContext httpRequest;
 
+    @JsonIgnore
     UidsCookie uidsCookie;
 
     BidRequest bidRequest;
 
+    @JsonIgnore
     Timeout timeout;
 
     Account account;

--- a/src/test/java/org/prebid/server/analytics/pubstack/PubstackEventHandlerTest.java
+++ b/src/test/java/org/prebid/server/analytics/pubstack/PubstackEventHandlerTest.java
@@ -11,8 +11,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.prebid.server.VertxTest;
+import org.prebid.server.analytics.model.AuctionEvent;
 import org.prebid.server.analytics.model.SetuidEvent;
 import org.prebid.server.analytics.pubstack.model.PubstackAnalyticsProperties;
+import org.prebid.server.auction.model.AuctionContext;
+import org.prebid.server.cookie.UidsCookie;
+import org.prebid.server.execution.Timeout;
 import org.prebid.server.vertx.http.HttpClient;
 import org.prebid.server.vertx.http.model.HttpClientResponse;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -22,10 +26,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -143,6 +149,21 @@ public class PubstackEventHandlerTest extends VertxTest {
 
         // then
         verify(httpClient).request(any(), anyString(), any(), (byte[]) any(), anyLong());
+    }
+
+    @Test
+    public void handleShouldBeAbleToEncodeAuctionEvent() {
+        // given
+        final AuctionEvent event = AuctionEvent.builder()
+                .auctionContext(AuctionContext.builder()
+                        .uidsCookie(mock(UidsCookie.class))
+                        .timeout(mock(Timeout.class))
+                        .build())
+                .build();
+
+        // when and then
+        assertThatCode(() -> pubstackEventHandler.handle(event))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
Fixes error:
```
java.lang.IllegalArgumentException: No serializer found for class org.prebid.server.execution.Timeout and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: org.prebid.server.analytics.model.AuctionEvent["auction_context"]->org.prebid.server.auction.model.AuctionContext["timeout"])
        at com.fasterxml.jackson.databind.ObjectMapper.valueToTree(ObjectMapper.java:2969)
        at org.prebid.server.analytics.pubstack.PubstackEventHandler.buffer(PubstackEventHandler.java:104)
        at org.prebid.server.analytics.pubstack.PubstackEventHandler.handle(PubstackEventHandler.java:84)
        at org.prebid.server.analytics.pubstack.PubstackAnalyticsReporter.processEvent(PubstackAnalyticsReporter.java:100)
        at org.prebid.server.analytics.AnalyticsReporterDelegator.processEventByReporter(AnalyticsReporterDelegator.java:193)
        at org.prebid.server.analytics.AnalyticsReporterDelegator.lambda$delegateEvent$2(AnalyticsReporterDelegator.java:97)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:369)
        at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:466)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Unknown Source)
```