### PR TITLE
VerizonMedia rebranding into YSSP

### DIFF
--- a/src/main/java/org/prebid/server/bidder/yssp/YsspBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yssp/YsspBidder.java
@@ -1,0 +1,203 @@
+package org.prebid.server.bidder.yssp;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.iab.openrtb.request.App;
+import com.iab.openrtb.request.Banner;
+import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.request.Device;
+import com.iab.openrtb.request.Format;
+import com.iab.openrtb.request.Imp;
+import com.iab.openrtb.request.Site;
+import com.iab.openrtb.response.BidResponse;
+import com.iab.openrtb.response.SeatBid;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.prebid.server.bidder.Bidder;
+import org.prebid.server.bidder.model.BidderBid;
+import org.prebid.server.bidder.model.BidderError;
+import org.prebid.server.bidder.model.HttpCall;
+import org.prebid.server.bidder.model.HttpRequest;
+import org.prebid.server.bidder.model.Result;
+import org.prebid.server.exception.PreBidException;
+import org.prebid.server.json.DecodeException;
+import org.prebid.server.json.JacksonMapper;
+import org.prebid.server.proto.openrtb.ext.ExtPrebid;
+import org.prebid.server.proto.openrtb.ext.request.yssp.ExtImpYssp;
+import org.prebid.server.proto.openrtb.ext.response.BidType;
+import org.prebid.server.util.HttpUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class YsspBidder implements Bidder<BidRequest> {
+
+    private static final TypeReference<ExtPrebid<?, ExtImpYssp>> YSSP_EXT_TYPE_REFERENCE =
+            new TypeReference<ExtPrebid<?, ExtImpYssp>>() {
+            };
+
+    private final String endpointUrl;
+    private final JacksonMapper mapper;
+
+    public YsspBidder(String endpointUrl, JacksonMapper mapper) {
+        this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
+        this.mapper = Objects.requireNonNull(mapper);
+    }
+
+    @Override
+    public Result<List<HttpRequest<BidRequest>>> makeHttpRequests(BidRequest bidRequest) {
+        final List<HttpRequest<BidRequest>> bidRequests = new ArrayList<>();
+        final List<BidderError> errors = new ArrayList<>();
+
+        final List<Imp> impList = bidRequest.getImp();
+        for (int i = 0; i < impList.size(); i++) {
+            try {
+                final Imp imp = impList.get(i);
+                final ExtImpYssp extImpYssp = parseAndValidateImpExt(imp.getExt(), i);
+                final BidRequest modifiedRequest = modifyRequest(bidRequest, imp, extImpYssp);
+                bidRequests.add(makeHttpRequest(modifiedRequest));
+            } catch (PreBidException e) {
+                errors.add(BidderError.badInput(e.getMessage()));
+            }
+        }
+
+        return Result.of(bidRequests, errors);
+    }
+
+    private ExtImpYssp parseAndValidateImpExt(ObjectNode impExtNode, int index) {
+        final ExtImpYssp extImpYssp;
+        try {
+            extImpYssp = mapper.mapper().convertValue(impExtNode, YSSP_EXT_TYPE_REFERENCE).getBidder();
+        } catch (IllegalArgumentException e) {
+            throw new PreBidException(String.format("imp #%s: %s", index, e.getMessage()));
+        }
+
+        final String dcn = extImpYssp.getDcn();
+        if (StringUtils.isBlank(dcn)) {
+            throw new PreBidException(String.format("imp #%s: missing param dcn", index));
+        }
+
+        final String pos = extImpYssp.getPos();
+        if (StringUtils.isBlank(pos)) {
+            throw new PreBidException(String.format("imp #%s: missing param pos", index));
+        }
+
+        return extImpYssp;
+    }
+
+    private static BidRequest modifyRequest(BidRequest request, Imp imp, ExtImpYssp extImpYssp) {
+        final Banner banner = imp.getBanner();
+        final boolean hasBanner = banner != null;
+
+        final Integer bannerWidth = hasBanner ? banner.getW() : null;
+        final Integer bannerHeight = hasBanner ? banner.getH() : null;
+        final boolean hasBannerWidthAndHeight = bannerWidth != null && bannerHeight != null;
+
+        if (hasBannerWidthAndHeight && (bannerWidth == 0 || bannerHeight == 0)) {
+            throw new PreBidException(String.format(
+                    "Invalid sizes provided for Banner %sx%s", bannerWidth, bannerHeight));
+        }
+
+        final Imp.ImpBuilder impBuilder = imp.toBuilder()
+                .tagid(extImpYssp.getPos());
+
+        if (hasBanner && !hasBannerWidthAndHeight) {
+            impBuilder.banner(modifyBanner(banner));
+        }
+
+        final BidRequest.BidRequestBuilder requestBuilder = request.toBuilder();
+
+        final Site site = request.getSite();
+        final App app = request.getApp();
+        if (site != null) {
+            requestBuilder.site(site.toBuilder().id(extImpYssp.getDcn()).build());
+        } else if (app != null) {
+            requestBuilder.app(app.toBuilder().id(extImpYssp.getDcn()).build());
+        }
+
+        return requestBuilder
+                .imp(Collections.singletonList(impBuilder.build()))
+                .build();
+    }
+
+    private static Banner modifyBanner(Banner banner) {
+        final List<Format> bannerFormats = banner.getFormat();
+        if (CollectionUtils.isEmpty(bannerFormats)) {
+            throw new PreBidException("No sizes provided for Banner");
+        }
+        final Format firstFormat = bannerFormats.get(0);
+
+        return banner.toBuilder()
+                .w(firstFormat.getW())
+                .h(firstFormat.getH())
+                .build();
+    }
+
+    private HttpRequest<BidRequest> makeHttpRequest(BidRequest outgoingRequest) {
+        return HttpRequest.<BidRequest>builder()
+                .method(HttpMethod.POST)
+                .uri(endpointUrl)
+                .body(mapper.encode(outgoingRequest))
+                .headers(makeHeaders(outgoingRequest.getDevice()))
+                .payload(outgoingRequest)
+                .build();
+    }
+
+    private static MultiMap makeHeaders(Device device) {
+        final MultiMap headers = HttpUtil.headers()
+                .add(HttpUtil.X_OPENRTB_VERSION_HEADER, "2.5");
+
+        final String deviceUa = device != null ? device.getUa() : null;
+        HttpUtil.addHeaderIfValueIsNotEmpty(headers, HttpUtil.USER_AGENT_HEADER, deviceUa);
+
+        return headers;
+    }
+
+    @Override
+    public Result<List<BidderBid>> makeBids(HttpCall<BidRequest> httpCall, BidRequest bidRequest) {
+        try {
+            final BidResponse bidResponse = mapper.decodeValue(httpCall.getResponse().getBody(), BidResponse.class);
+            return Result.of(extractBids(bidResponse, httpCall.getRequest().getPayload()), Collections.emptyList());
+        } catch (DecodeException | PreBidException e) {
+            return Result.withError(BidderError.badServerResponse(e.getMessage()));
+        }
+    }
+
+    private static List<BidderBid> extractBids(BidResponse bidResponse, BidRequest bidRequest) {
+        final List<SeatBid> seatBids = bidResponse != null ? bidResponse.getSeatbid() : null;
+        if (seatBids == null) {
+            return Collections.emptyList();
+        }
+
+        if (seatBids.isEmpty()) {
+            throw new PreBidException(String.format("Invalid SeatBids count: %d", seatBids.size()));
+        }
+        return bidsFromResponse(bidResponse, bidRequest.getImp());
+    }
+
+    private static List<BidderBid> bidsFromResponse(BidResponse bidResponse, List<Imp> imps) {
+        return bidResponse.getSeatbid().stream()
+                .filter(Objects::nonNull)
+                .map(SeatBid::getBid)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(bid -> checkBid(bid.getImpid(), imps))
+                .map(bid -> BidderBid.of(bid, BidType.banner, bidResponse.getCur()))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean checkBid(String bidImpId, List<Imp> imps) {
+        for (Imp imp : imps) {
+            if (imp.getId().equals(bidImpId)) {
+                return imp.getBanner() != null;
+            }
+        }
+        throw new PreBidException(String.format("Unknown ad unit code '%s'", bidImpId));
+    }
+}

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/yssp/ExtImpYssp.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/yssp/ExtImpYssp.java
@@ -1,0 +1,16 @@
+package org.prebid.server.proto.openrtb.ext.request.yssp;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Defines the contract for bidRequest.imp[i].ext.yssp
+ */
+@AllArgsConstructor(staticName = "of")
+@Value
+public class ExtImpYssp {
+
+    String dcn;
+
+    String pos;
+}

--- a/src/main/java/org/prebid/server/spring/config/bidder/YsspConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/YsspConfiguration.java
@@ -1,0 +1,51 @@
+package org.prebid.server.spring.config.bidder;
+
+import org.prebid.server.bidder.BidderDeps;
+import org.prebid.server.bidder.yssp.YsspBidder;
+import org.prebid.server.json.JacksonMapper;
+import org.prebid.server.spring.config.bidder.model.BidderConfigurationProperties;
+import org.prebid.server.spring.config.bidder.util.BidderDepsAssembler;
+import org.prebid.server.spring.config.bidder.util.UsersyncerCreator;
+import org.prebid.server.spring.env.YamlPropertySourceFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import javax.validation.constraints.NotBlank;
+
+@Configuration
+@PropertySource(value = "classpath:/bidder-config/yssp.yaml", factory = YamlPropertySourceFactory.class)
+public class YsspConfiguration {
+
+    private static final String BIDDER_NAME = "yssp";
+
+    @Value("${external-url}")
+    @NotBlank
+    private String externalUrl;
+
+    @Autowired
+    private JacksonMapper mapper;
+
+    @Autowired
+    @Qualifier("ysspConfigurationProperties")
+    private BidderConfigurationProperties configProperties;
+
+    @Bean("ysspConfigurationProperties")
+    @ConfigurationProperties("adapters.yssp")
+    BidderConfigurationProperties configurationProperties() {
+        return new BidderConfigurationProperties();
+    }
+
+    @Bean
+    BidderDeps ysspBidderDeps() {
+        return BidderDepsAssembler.forBidder(BIDDER_NAME)
+                .withConfig(configProperties)
+                .usersyncerCreator(UsersyncerCreator.create(externalUrl))
+                .bidderCreator(config -> new YsspBidder(config.getEndpoint(), mapper))
+                .assemble();
+    }
+}

--- a/src/main/resources/bidder-config/yssp.yaml
+++ b/src/main/resources/bidder-config/yssp.yaml
@@ -1,0 +1,23 @@
+adapters:
+  yssp:
+    enabled: false
+    endpoint: https://s2shb.ssp.yahoo.com/admax/bid/partners/MAG
+    pbs-enforces-gdpr: true
+    pbs-enforces-ccpa: true
+    modifying-vast-xml-allowed: true
+    deprecated-names:
+    aliases: {}
+    meta-info:
+      maintainer-email: hb-fe-tech@oath.com
+      app-media-types:
+        - banner
+      site-media-types:
+        - banner
+      supported-vendors:
+      vendor-id: 25
+    usersync:
+      url: https://ups.analytics.yahoo.com/ups/58401/sync?redir=true&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}
+      redirect-url:
+      cookie-family-name: yssp
+      type: redirect
+      support-cors: false

--- a/src/main/resources/static/bidder-params/yssp.json
+++ b/src/main/resources/static/bidder-params/yssp.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "YSSP Adapter Params",
+  "description": "A schema which validates params accepted by the YSSP adapter",
+  "type": "object",
+  "properties": {
+    "dcn": {
+      "type": "string",
+      "description": "Site ID provided by One Mobile"
+    },
+    "pos": {
+      "type": "string",
+      "description": "Placement ID"
+    }
+  },
+  "required": [
+    "dcn",
+    "pos"
+  ]
+}

--- a/src/test/java/org/prebid/server/bidder/yssp/YsspBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/yssp/YsspBidderTest.java
@@ -1,0 +1,405 @@
+package org.prebid.server.bidder.yssp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.iab.openrtb.request.App;
+import com.iab.openrtb.request.Banner;
+import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.request.Device;
+import com.iab.openrtb.request.Format;
+import com.iab.openrtb.request.Imp;
+import com.iab.openrtb.request.Site;
+import com.iab.openrtb.response.Bid;
+import com.iab.openrtb.response.BidResponse;
+import com.iab.openrtb.response.SeatBid;
+import org.junit.Before;
+import org.junit.Test;
+import org.prebid.server.VertxTest;
+import org.prebid.server.bidder.model.BidderBid;
+import org.prebid.server.bidder.model.BidderError;
+import org.prebid.server.bidder.model.HttpCall;
+import org.prebid.server.bidder.model.HttpRequest;
+import org.prebid.server.bidder.model.HttpResponse;
+import org.prebid.server.bidder.model.Result;
+import org.prebid.server.proto.openrtb.ext.ExtPrebid;
+import org.prebid.server.proto.openrtb.ext.request.yssp.ExtImpYssp;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.prebid.server.proto.openrtb.ext.response.BidType.banner;
+
+public class YsspBidderTest extends VertxTest {
+
+    private static final String ENDPOINT_URL = "https://test.endpoint.com";
+
+    private YsspBidder ysspBidder;
+
+    @Before
+    public void setUp() {
+        ysspBidder = new YsspBidder(ENDPOINT_URL, jacksonMapper);
+    }
+
+    @Test
+    public void creationShouldFailOnInvalidEndpointUrl() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new YsspBidder("invalid_url", jacksonMapper));
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnErrorIfImpExtCouldNotBeParsed() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder
+                        .ext(mapper.valueToTree(ExtPrebid.of(null, mapper.createArrayNode()))),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getMessage()).startsWith("imp #0: Cannot deserialize instance");
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnErrorWhenDcnIsEmpty() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder
+                        .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpYssp.of("", null)))),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badInput("imp #0: missing param dcn"));
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnErrorWhenPosIsEmpty() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder
+                        .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpYssp.of("dcn", "")))),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badInput("imp #0: missing param pos"));
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeHttpRequestsShouldCreateARequestForEachImpAndSkipImpsWithErrors() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(asList(
+                        givenImp(impBuilder -> impBuilder.id("imp1")),
+                        givenImp(impBuilder -> impBuilder.id("imp2")
+                                .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpYssp.of("dcn", ""))))),
+                        givenImp(impBuilder -> impBuilder.id("imp3"))))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badInput("imp #1: missing param pos"));
+        assertThat(result.getValue()).hasSize(2)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp).hasSize(2)
+                .extracting(Imp::getId)
+                .containsOnly("imp1", "imp3");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldAlwaysSetImpTagIdFromImpExt() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(identity(), identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue())
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp).hasSize(1)
+                .extracting(Imp::getTagid)
+                .containsExactly("pos");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldSetSiteIdIfSiteIsPresentInTheRequest() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(identity(), identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .extracting(BidRequest::getSite)
+                .extracting(Site::getId)
+                .containsExactly("dcn");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldSetAppIdIfAppIsPresentInTheRequest() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(identity(),
+                bidRequestBuilder -> bidRequestBuilder.site(null).app(App.builder().build()));
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .extracting(BidRequest::getApp)
+                .extracting(App::getId)
+                .containsExactly("dcn");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnErrorWhenBannerWidthIsZero() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder.banner(Banner.builder().w(0).h(100).build()),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getValue()).isEmpty();
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badInput("Invalid sizes provided for Banner 0x100"));
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnErrorWhenBannerHeightIsZero() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder.banner(Banner.builder().w(100).h(0).build()),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getValue()).isEmpty();
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badInput("Invalid sizes provided for Banner 100x0"));
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnErrorWhenBannerHasNoFormats() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder.banner(Banner.builder().build()),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getValue()).isEmpty();
+        assertThat(result.getErrors()).hasSize(1).containsOnly(BidderError.badInput("No sizes provided for Banner"));
+    }
+
+    @Test
+    public void makeHttpRequestsSetFirstImpressionBannerWidthAndHeightWhenFromFirstFormatIfTheyAreNull() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                impBuilder -> impBuilder
+                        .banner(Banner.builder().format(singletonList(Format.builder().w(250).h(300).build())).build()),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp)
+                .extracting(Imp::getBanner)
+                .extracting(Banner::getW, Banner::getH)
+                .containsOnly(tuple(250, 300));
+    }
+
+    @Test
+    public void makeHttpRequestsShouldSetExpectedHeaders() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(identity(),
+                requestBuilder -> requestBuilder.site(null).device(Device.builder().ua("UA").build()));
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = ysspBidder.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue().get(0).getHeaders())
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsOnly(tuple("User-Agent", "UA"),
+                        tuple("x-openrtb-version", "2.5"),
+                        tuple("Content-Type", "application/json;charset=utf-8"),
+                        tuple("Accept", "application/json"));
+    }
+
+    @Test
+    public void makeBidsShouldReturnErrorIfResponseBodyCouldNotBeParsed() {
+        // given
+        final HttpCall<BidRequest> httpCall = givenHttpCall(null, "invalid");
+
+        // when
+        final Result<List<BidderBid>> result = ysspBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getMessage()).startsWith("Failed to decode: Unrecognized token");
+        assertThat(result.getErrors().get(0).getType()).isEqualTo(BidderError.Type.bad_server_response);
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeBidsShouldReturnEmptyListIfBidResponseIsNull() throws JsonProcessingException {
+        // given
+        final HttpCall<BidRequest> httpCall = givenHttpCall(null,
+                mapper.writeValueAsString(null));
+
+        // when
+        final Result<List<BidderBid>> result = ysspBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeBidsShouldReturnEmptyListIfBidResponseSeatBidIsNull() throws JsonProcessingException {
+        // given
+        final HttpCall<BidRequest> httpCall = givenHttpCall(null,
+                mapper.writeValueAsString(BidResponse.builder().build()));
+
+        // when
+        final Result<List<BidderBid>> result = ysspBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeBidsShouldReturnErrorIfBidResponseSeatBidIsEmpty() throws JsonProcessingException {
+        // given
+        final HttpCall<BidRequest> httpCall = givenHttpCall(null,
+                mapper.writeValueAsString(BidResponse.builder().seatbid(emptyList()).build()));
+
+        // when
+        final Result<List<BidderBid>> result = ysspBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badServerResponse("Invalid SeatBids count: 0"));
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeBidsShouldReturnErrorWhenBidImpIdIsNotPresent() throws JsonProcessingException {
+        // given
+        final HttpCall<BidRequest> httpCall = givenHttpCall(
+                BidRequest.builder()
+                        .imp(singletonList(Imp.builder()
+                                .banner(Banner.builder().build())
+                                .id("123").build()))
+                        .build(),
+                mapper.writeValueAsString(
+                        givenBidResponse(bidBuilder -> bidBuilder.impid("321"))));
+
+        // when
+        final Result<List<BidderBid>> result = ysspBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result.getErrors()).hasSize(1)
+                .containsOnly(BidderError.badServerResponse("Unknown ad unit code '321'"));
+        assertThat(result.getValue()).isEmpty();
+    }
+
+    @Test
+    public void makeBidsShouldSkipNotBannerImpAndReturnBannerBidWhenBannerPresent() throws JsonProcessingException {
+        // given
+        final HttpCall<BidRequest> httpCall = givenHttpCall(
+                BidRequest.builder()
+                        .imp(asList(Imp.builder().id("123").build(),
+                                Imp.builder().banner(Banner.builder().build()).id("321").build()))
+                        .build(),
+                mapper.writeValueAsString(BidResponse.builder()
+                        .cur("USD")
+                        .seatbid(singletonList(SeatBid.builder()
+                                .bid(asList(Bid.builder().impid("123").build(),
+                                        Bid.builder().impid("321").build()))
+                                .build()))
+                        .build()));
+
+        // when
+        final Result<List<BidderBid>> result = ysspBidder.makeBids(httpCall, null);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue())
+                .containsOnly(BidderBid.of(Bid.builder().impid("321").build(), banner, "USD"));
+    }
+
+    private static BidRequest givenBidRequest(
+            Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer,
+            Function<BidRequest.BidRequestBuilder, BidRequest.BidRequestBuilder> requestCustomizer) {
+        return requestCustomizer.apply(BidRequest.builder()
+                .site(Site.builder().id("123").build())
+                .imp(singletonList(givenImp(impCustomizer))))
+                .build();
+    }
+
+    private static Imp givenImp(Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
+        return impCustomizer.apply(Imp.builder()
+                .tagid("tagId")
+                .banner(Banner.builder().w(100).h(100).build())
+                .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpYssp.of("dcn", "pos")))))
+                .build();
+    }
+
+    private static BidResponse givenBidResponse(Function<Bid.BidBuilder, Bid.BidBuilder> bidCustomizer) {
+        return BidResponse.builder()
+                .cur("USD")
+                .seatbid(singletonList(SeatBid.builder()
+                        .bid(singletonList(bidCustomizer.apply(Bid.builder()).build()))
+                        .build()))
+                .build();
+    }
+
+    private static HttpCall<BidRequest> givenHttpCall(BidRequest bidRequest, String body) {
+        return HttpCall.success(
+                HttpRequest.<BidRequest>builder().payload(bidRequest).build(),
+                HttpResponse.of(200, null, body),
+                null);
+    }
+}

--- a/src/test/java/org/prebid/server/it/YsspTest.java
+++ b/src/test/java/org/prebid/server/it/YsspTest.java
@@ -1,0 +1,38 @@
+package org.prebid.server.it;
+
+import io.restassured.response.Response;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.server.model.Endpoint;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.util.Collections.singletonList;
+
+@RunWith(SpringRunner.class)
+public class YsspTest extends IntegrationTest {
+
+    @Test
+    public void openrtb2AuctionShouldRespondWithBidsFromYssp() throws IOException, JSONException {
+        // given
+        WIRE_MOCK_RULE.stubFor(post(urlPathEqualTo("/yssp-exchange"))
+                .withRequestBody(equalToJson(
+                        jsonFrom("openrtb2/yssp/test-yssp-bid-request.json")))
+                .willReturn(aResponse().withBody(
+                        jsonFrom("openrtb2/yssp/test-yssp-bid-response.json"))));
+
+        // when
+        final Response response = responseFor("openrtb2/yssp/test-auction-yssp-request.json",
+                Endpoint.openrtb2_auction);
+
+        // then
+        assertJsonEquals("openrtb2/yssp/test-auction-yssp-response.json", response,
+                singletonList("yssp"));
+    }
+}

--- a/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-auction-yssp-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-auction-yssp-request.json
@@ -1,0 +1,24 @@
+{
+  "id": "request_id",
+  "imp": [
+    {
+      "id": "imp_id",
+      "banner": {
+        "w": 300,
+        "h": 250
+      },
+      "ext": {
+        "yssp": {
+          "dcn": "dcn",
+          "pos": "pos"
+        }
+      }
+    }
+  ],
+  "tmax": 5000,
+  "regs": {
+    "ext": {
+      "gdpr": 0
+    }
+  }
+}

--- a/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-auction-yssp-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-auction-yssp-response.json
@@ -1,0 +1,36 @@
+{
+  "id": "request_id",
+  "seatbid": [
+    {
+      "bid": [
+        {
+          "id": "bid_id",
+          "impid": "imp_id",
+          "price": 1.25,
+          "adm": "adm001",
+          "crid": "crid",
+          "w": 300,
+          "h": 250,
+          "ext": {
+            "prebid": {
+              "type": "banner"
+            },
+            "origbidcpm": 1.25
+          }
+        }
+      ],
+      "seat": "yssp",
+      "group": 0
+    }
+  ],
+  "cur": "USD",
+  "ext": {
+    "responsetimemillis": {
+      "yssp": "{{ yssp.response_time_ms }}"
+    },
+    "prebid": {
+      "auctiontimestamp": 0
+    },
+    "tmaxrequest": 5000
+  }
+}

--- a/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-yssp-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-yssp-bid-request.json
@@ -1,0 +1,44 @@
+{
+  "id": "request_id",
+  "imp": [
+    {
+      "id": "imp_id",
+      "banner": {
+        "w": 300,
+        "h": 250
+      },
+      "tagid": "pos",
+      "ext": {
+        "bidder": {
+          "dcn": "dcn",
+          "pos": "pos"
+        }
+      }
+    }
+  ],
+  "site": {
+    "id": "dcn",
+    "domain": "www.example.com",
+    "page": "http://www.example.com",
+    "publisher": {
+      "domain": "example.com"
+    },
+    "ext": {
+      "amp": 0
+    }
+  },
+  "at": 1,
+  "tmax": 5000,
+  "cur": [
+    "USD"
+  ],
+  "device": {
+    "ua": "userAgent",
+    "ip": "193.168.244.1"
+  },
+  "regs": {
+    "ext": {
+      "gdpr": 0
+    }
+  }
+}

--- a/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-yssp-bid-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yssp/test-yssp-bid-response.json
@@ -1,0 +1,19 @@
+{
+  "id": "request_id",
+  "seatbid": [
+    {
+      "bid": [
+        {
+          "id": "bid_id",
+          "impid": "imp_id",
+          "price": 1.25,
+          "crid": "crid",
+          "adm": "adm001",
+          "h": 250,
+          "w": 300
+        }
+      ]
+    }
+  ],
+  "bidid": "bid_id"
+}

--- a/src/test/resources/org/prebid/server/it/test-application.properties
+++ b/src/test/resources/org/prebid/server/it/test-application.properties
@@ -249,6 +249,8 @@ adapters.yieldmo.enabled=true
 adapters.yieldmo.endpoint=http://localhost:8090/yieldmo-exchange
 adapters.yieldone.enabled=true
 adapters.yieldone.endpoint=http://localhost:8090/yieldone-exchange
+adapters.yssp.enabled=true
+adapters.yssp.endpoint=http://localhost:8090/yssp-exchange
 adapters.zeroclickfraud.enabled=true
 adapters.zeroclickfraud.endpoint=http://{{Host}}/zeroclickfraud-exchange?sid={{SourceId}}
 http-client.circuit-breaker.enabled=true


### PR DESCRIPTION
We have to drop the verizonmedia brand, for this the following steps will be done:
- clone VerizonMedia adapter into the YSSP adapter
- move any publishers to the new yssp adapter
- when everybody was migrated, we'll delete the VerizonMedia adapter 