### PR TITLE
Revert Triplelift Endpoint [open source id]

### DIFF
--- a/src/main/resources/bidder-config/triplelift.yaml
+++ b/src/main/resources/bidder-config/triplelift.yaml
@@ -1,7 +1,7 @@
 adapters:
   triplelift:
     enabled: false
-    endpoint: https://tlx.3lift.com/s2s/auction?sra=1&supplier_id=39
+    endpoint: https://tlx.3lift.com/s2s/auction?sra=1&supplier_id=20
     pbs-enforces-gdpr: true
     pbs-enforces-ccpa: true
     modifying-vast-xml-allowed: true


### PR DESCRIPTION
The recent PR [here](https://github.com/prebid/prebid-server-java/pull/1418) was a change intended specifically for Magnite (which is complete and healthy). All other Prebid Server Java hosts must continue using id=20, at least until we can figure out how to more efficiently organize our PBS partners. In the meantime however, I would like this merged as soon as possible so that no other partner begins using this new id specific to Magnite's integration with us.
cc @bretg @rpanchyk 

Putting PR in draft for now in case anything needs to be discussed that I may not be considering. 