### PR TITLE
Fix Jackson dependency in bundle submodule

### DIFF
--- a/extra/bundle/pom.xml
+++ b/extra/bundle/pom.xml
@@ -3,12 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
-        <relativePath/> <!-- lookup parent from repository -->
-    </parent>
     <groupId>org.prebid</groupId>
     <artifactId>prebid-server-bundle</artifactId>
     <version>1.73.0-SNAPSHOT</version>
@@ -17,7 +11,50 @@
 
     <properties>
         <java.version>1.8</java.version>
+
+        <spring.boot.version>2.1.1.RELEASE</spring.boot.version>
+        <jackson.version>2.10.0</jackson.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Spring dependencies -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-afterburner</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <!-- Spring dependencies -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
`PBS-Bundle` submodule used Spring Boot 2.1.1 as a parent which has older jackson dependency.
Build logs (`mvn clean compile -f extra/pom.xml -X`):
```
[DEBUG] com.fasterxml.jackson.core:jackson-core:jar:2.9.7:compile (version managed from 2.10.0)
[DEBUG] com.fasterxml.jackson.core:jackson-databind:jar:2.9.7:compile (version managed from 2.10.0)
[DEBUG] com.fasterxml.jackson.core:jackson-annotations:jar:2.9.0:compile (version managed from 2.10.0)
[DEBUG] com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.9.7:compile (version managed from 2.10.0)
[DEBUG] com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.9.7:compile (version managed from 2.10.0)
```
PBS requires newer version - `2.10.0`.

Built with old Jackson produces error:
```
2021-09-06 17:20:19.014 ERROR 28327 --- [ntloop-thread-1] o.p.s.handler.openrtb2.AuctionHandler
    : Critical error while running the auction

java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.node.ObjectNode.isEmpty()Z
```