### PR TITLE
Add version to spring-boot-maven-plugin in bundle POM

### DIFF
--- a/extra/bundle/pom.xml
+++ b/extra/bundle/pom.xml
@@ -75,6 +75,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <configuration>
                     <mainClass>org.prebid.server.Application</mainClass>
                     <executable>true</executable>


### PR DESCRIPTION
Rid off warning:
```
'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. 
@ line 75, column 21

It is highly recommended to fix these problems because they threaten the stability of your build.
For this reason, future Maven versions might no longer support building such malformed projects.
```