### PR TITLE
Remove bidder pbs-enforces-gdpr property

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -119,7 +119,6 @@ Removes and downloads file again if depending service cant process probably corr
 There are several typical keys:
 - `adapters.<BIDDER_NAME>.enabled` - indicates the bidder should be active and ready for auction. By default all bidders are disabled.
 - `adapters.<BIDDER_NAME>.endpoint` - the url for submitting bids.
-- `adapters.<BIDDER_NAME>.pbs-enforces-gdpr` - indicates if PBS server provides GDPR support for bidder or bidder will handle it itself.
 - `adapters.<BIDDER_NAME>.pbs-enforces-ccpa` - indicates if PBS server provides CCPA support for bidder or bidder will handle it itself.
 - `adapters.<BIDDER_NAME>.modifying-vast-xml-allowed` - indicates if PBS server is allowed to modify VAST creatives received from this bidder.
 - `adapters.<BIDDER_NAME>.deprecated-names` - comma separated deprecated names of bidder.

--- a/src/main/java/org/prebid/server/proto/response/BidderInfo.java
+++ b/src/main/java/org/prebid/server/proto/response/BidderInfo.java
@@ -35,7 +35,6 @@ public class BidderInfo {
                                     List<String> siteMediaTypes,
                                     List<String> supportedVendors,
                                     int vendorId,
-                                    boolean enforceGdpr,
                                     boolean ccpaEnforced,
                                     boolean modifyingVastXmlAllowed) {
 
@@ -46,7 +45,7 @@ public class BidderInfo {
                 new MaintainerInfo(maintainerEmail),
                 new CapabilitiesInfo(platformInfo(appMediaTypes), platformInfo(siteMediaTypes)),
                 supportedVendors,
-                new GdprInfo(vendorId, enforceGdpr),
+                new GdprInfo(vendorId),
                 ccpaEnforced,
                 modifyingVastXmlAllowed);
     }
@@ -91,11 +90,5 @@ public class BidderInfo {
          */
         @JsonProperty("vendorId")
         int vendorId;
-
-        /**
-         * Flag, which true value means that PBS will keep gdpr logic for bidder, otherwise bidder will keep
-         * gdpr support and request should be sent without gdpr changes.
-         */
-        boolean enforced;
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -28,8 +28,6 @@ public class BidderConfigurationProperties {
     @NotBlank
     private String endpoint;
 
-    private Boolean pbsEnforcesGdpr;
-
     private Boolean pbsEnforcesCcpa;
 
     private Boolean modifyingVastXmlAllowed;
@@ -55,7 +53,6 @@ public class BidderConfigurationProperties {
     @PostConstruct
     private void init() {
         enabled = ObjectUtils.defaultIfNull(enabled, defaultProperties.getEnabled());
-        pbsEnforcesGdpr = ObjectUtils.defaultIfNull(pbsEnforcesGdpr, defaultProperties.getPbsEnforcesGdpr());
         pbsEnforcesCcpa = ObjectUtils.defaultIfNull(pbsEnforcesCcpa, defaultProperties.getPbsEnforcesCcpa());
         modifyingVastXmlAllowed = ObjectUtils.defaultIfNull(modifyingVastXmlAllowed,
                 defaultProperties.getModifyingVastXmlAllowed());

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/DefaultBidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/DefaultBidderConfigurationProperties.java
@@ -16,9 +16,6 @@ public class DefaultBidderConfigurationProperties {
     private Boolean enabled;
 
     @NotNull
-    private Boolean pbsEnforcesGdpr;
-
-    @NotNull
     private Boolean pbsEnforcesCcpa;
 
     @NotNull

--- a/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/util/BidderInfoCreator.java
@@ -25,7 +25,6 @@ public class BidderInfoCreator {
                 metaInfo.getSiteMediaTypes(),
                 metaInfo.getSupportedVendors(),
                 metaInfo.getVendorId(),
-                configurationProperties.getPbsEnforcesGdpr(),
                 configurationProperties.getPbsEnforcesCcpa(),
                 configurationProperties.getModifyingVastXmlAllowed());
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -100,7 +100,6 @@ data-center: dataCenter
 profile: profile
 adapter-defaults:
   enabled: false
-  pbs-enforces-gdpr: true
   pbs-enforces-ccpa: true
   modifying-vast-xml-allowed: true
 auction:

--- a/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/PrivacyEnforcementServiceTest.java
@@ -1764,7 +1764,7 @@ public class PrivacyEnforcementServiceTest extends VertxTest {
                 null,
                 null,
                 null,
-                new BidderInfo.GdprInfo(gdprVendorId, true),
+                new BidderInfo.GdprInfo(gdprVendorId),
                 enforceCcpa,
                 false);
     }

--- a/src/test/java/org/prebid/server/bidder/BidderCatalogTest.java
+++ b/src/test/java/org/prebid/server/bidder/BidderCatalogTest.java
@@ -94,7 +94,6 @@ public class BidderCatalogTest {
                 null,
                 99,
                 true,
-                true,
                 false);
 
         final BidderDeps bidderDeps = BidderDeps.of(singletonList(BidderInstanceDeps.builder()
@@ -168,7 +167,6 @@ public class BidderCatalogTest {
                 singletonList("video"),
                 null,
                 99,
-                true,
                 true,
                 false);
 

--- a/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
@@ -1316,24 +1316,19 @@ public class CookieSyncHandlerTest extends VertxTest {
     }
 
     @Test
-    public void shouldRespondWithNoCookieWhenBothCcpaAndGdprRejectBidders() throws IOException {
+    public void shouldRespondWithNoCookieWhenCcpaRejectsBidder() throws IOException {
         // given
         given(uidsCookieService.parseFromRequest(any(RoutingContext.class))).willReturn(new UidsCookie(
                 Uids.builder().uids(emptyMap()).build(), jacksonMapper));
 
         given(routingContext.getBody())
-                .willReturn(givenRequestBody(CookieSyncRequest.builder().bidders(asList(RUBICON, APPNEXUS)).build()));
+                .willReturn(givenRequestBody(CookieSyncRequest.builder().bidders(singletonList(RUBICON)).build()));
 
         rubiconUsersyncer = createUsersyncer(RUBICON, "", null);
-        appnexusUsersyncer = createUsersyncer(APPNEXUS_COOKIE, "", null);
         givenUsersyncersReturningFamilyName();
 
         given(bidderCatalog.isActive(RUBICON)).willReturn(true);
-        given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
-
         given(bidderCatalog.bidderInfoByName(RUBICON)).willReturn(
-                BidderInfo.create(true, null, null, null, null, null, null, 2, true, false));
-        given(bidderCatalog.bidderInfoByName(APPNEXUS)).willReturn(
                 BidderInfo.create(true, null, null, null, null, null, null, 2, true, false));
 
         given(privacyEnforcementService.isCcpaEnforced(any(), any())).willReturn(true);
@@ -1347,9 +1342,9 @@ public class CookieSyncHandlerTest extends VertxTest {
         // then
         final CookieSyncResponse cookieSyncResponse = captureCookieSyncResponse();
         assertThat(cookieSyncResponse.getStatus()).isEqualTo("no_cookie");
-        assertThat(cookieSyncResponse.getBidderStatus()).hasSize(2)
+        assertThat(cookieSyncResponse.getBidderStatus()).hasSize(1)
                 .extracting(BidderUsersyncStatus::getBidder, BidderUsersyncStatus::getError)
-                .containsOnly(tuple(APPNEXUS, "Rejected by TCF"), tuple(RUBICON, "Rejected by CCPA"));
+                .containsOnly(tuple(RUBICON, "Rejected by CCPA"));
     }
 
     private void givenTcfServiceReturningVendorIdResult(Set<Integer> vendorIds) {

--- a/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/CookieSyncHandlerTest.java
@@ -664,7 +664,7 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
-                .willReturn(BidderInfo.create(true, null, null, null, null, null, null, 2, true, true, false));
+                .willReturn(BidderInfo.create(true, null, null, null, null, null, null, 2, true, false));
 
         givenTcfServiceReturningVendorIdResult(singleton(1));
         givenTcfServiceReturningBidderNamesResult(singleton(RUBICON));
@@ -730,7 +730,7 @@ public class CookieSyncHandlerTest extends VertxTest {
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
                 .willReturn(BidderInfo.create(true, null, null, null,
-                        null, null, null, 2, true, true, false));
+                        null, null, null, 2, true, false));
 
         givenTcfServiceReturningBidderNamesResult(singleton(RUBICON));
 
@@ -760,7 +760,7 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(APPNEXUS))
-                .willReturn(BidderInfo.create(true, null, null, null, null, null, null, 2, true, true, false));
+                .willReturn(BidderInfo.create(true, null, null, null, null, null, null, 2, true, false));
 
         givenTcfServiceReturningVendorIdResult(singleton(1));
         givenTcfServiceReturningBidderNamesResult(singleton(RUBICON));
@@ -1332,9 +1332,9 @@ public class CookieSyncHandlerTest extends VertxTest {
         given(bidderCatalog.isActive(APPNEXUS)).willReturn(true);
 
         given(bidderCatalog.bidderInfoByName(RUBICON)).willReturn(
-                BidderInfo.create(true, null, null, null, null, null, null, 2, true, true, false));
+                BidderInfo.create(true, null, null, null, null, null, null, 2, true, false));
         given(bidderCatalog.bidderInfoByName(APPNEXUS)).willReturn(
-                BidderInfo.create(true, null, null, null, null, null, null, 2, true, false, false));
+                BidderInfo.create(true, null, null, null, null, null, null, 2, true, false));
 
         given(privacyEnforcementService.isCcpaEnforced(any(), any())).willReturn(true);
 

--- a/src/test/java/org/prebid/server/handler/info/BidderDetailsHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/info/BidderDetailsHandlerTest.java
@@ -189,7 +189,6 @@ public class BidderDetailsHandlerTest extends VertxTest {
                 null,
                 0,
                 true,
-                true,
                 false);
     }
 

--- a/src/test/java/org/prebid/server/validation/BidderParamValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/BidderParamValidatorTest.java
@@ -450,7 +450,6 @@ public class BidderParamValidatorTest extends VertxTest {
                 null,
                 0,
                 true,
-                true,
                 false);
     }
 


### PR DESCRIPTION
This property was used in TCF 1.1 which is already not supported by PBS.