### PR TITLE
Missing header 'Content-Type' 

### DIFF
--- a/src/main/java/org/prebid/server/handler/BidderParamHandler.java
+++ b/src/main/java/org/prebid/server/handler/BidderParamHandler.java
@@ -20,6 +20,7 @@ public class BidderParamHandler implements Handler<RoutingContext> {
     public void handle(RoutingContext routingContext) {
         HttpUtil.executeSafely(routingContext, Endpoint.bidder_params,
                 response -> response
+                        .putHeader(HttpUtil.CONTENT_TYPE_HEADER, HttpUtil.APPLICATION_JSON_CONTENT_TYPE)
                         .end(bidderParamValidator.schemas()));
     }
 }


### PR DESCRIPTION
Missing header 'Content-Type' in /bidders/params response