### PR TITLE
Add PG tests for alert, currency, plans, register services

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/model/mock/services/currencyconversion/CurrencyConversionRatesResponse.groovy
+++ b/src/test/groovy/org/prebid/server/functional/model/mock/services/currencyconversion/CurrencyConversionRatesResponse.groovy
@@ -1,0 +1,26 @@
+package org.prebid.server.functional.model.mock.services.currencyconversion
+
+import org.prebid.server.functional.model.ResponseModel
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+import static java.time.ZoneOffset.UTC
+
+class CurrencyConversionRatesResponse implements ResponseModel {
+
+    String dataAsOf
+    Map<String, Map<String, BigDecimal>> conversions
+
+    static CurrencyConversionRatesResponse getDefaultCurrencyConversionRatesResponse() {
+        new CurrencyConversionRatesResponse().tap {
+            dataAsOf = ZonedDateTime.now(ZoneId.from(UTC)).minusDays(1) as String
+            conversions = defaultConversionRates
+        }
+    }
+
+    private static getDefaultConversionRates() {
+        ["USD": ["EUR": 0.8872327211427558],
+         "EUR": ["USD": 1.3429368029739777]] as Map<String, Map<String, BigDecimal>>
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/pg/AlertSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/AlertSpec.groovy
@@ -121,22 +121,22 @@ class AlertSpec extends BasePgSpec {
         PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
 
         and: "Alert request should correspond to the payload"
-        def alertRequest = alert.recordedAlertRequest
+        verifyAll(alert.recordedAlertRequest) { alertRequest ->
+            (alertRequest.id =~ UUID_REGEX).matches()
+            alertRequest.action == RAISE
+            alertRequest.priority == MEDIUM
+            alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+            alertRequest.name == PBS_PLANNER_CLIENT_ERROR
+            alertRequest.details == "Service planner failed to send request 1 time(s) with error message :" +
+                    " Failed to retrieve line items from GP. Reason: Failed to fetch data from Planner, HTTP status code ${httpStatusCode.code()}"
 
-        assert (alertRequest.id =~ UUID_REGEX).matches()
-        assert alertRequest.action == RAISE
-        assert alertRequest.priority == MEDIUM
-        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
-        assert alertRequest.name == PBS_PLANNER_CLIENT_ERROR
-        assert alertRequest.details == "Service planner failed to send request 1 time(s) with error message :" +
-                " Failed to retrieve line items from GP. Reason: Failed to fetch data from Planner, HTTP status code ${httpStatusCode.code()}"
-
-        assert alertRequest.source.env == pgPbsProperties.env
-        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
-        assert alertRequest.source.region == pgPbsProperties.region
-        assert alertRequest.source.system == pgPbsProperties.system
-        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
-        assert alertRequest.source.hostId == pgPbsProperties.hostId
+            alertRequest.source.env == pgPbsProperties.env
+            alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+            alertRequest.source.region == pgPbsProperties.region
+            alertRequest.source.system == pgPbsProperties.system
+            alertRequest.source.subSystem == pgPbsProperties.subSystem
+            alertRequest.source.hostId == pgPbsProperties.hostId
+        }
 
         cleanup: "Return initial Planner response status code"
         generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString))
@@ -163,22 +163,23 @@ class AlertSpec extends BasePgSpec {
         PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
 
         and: "Alert request should correspond to the payload"
-        def alertRequest = alert.recordedAlertRequest
+        verifyAll(alert.recordedAlertRequest) { alertRequest ->
+            (alertRequest.id =~ UUID_REGEX).matches()
+            alertRequest.action == RAISE
+            alertRequest.priority == MEDIUM
+            alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+            alertRequest.name == PBS_REGISTER_CLIENT_ERROR
+            alertRequest.details.startsWith("Service register failed to send request 1 time(s) with error message :" +
+                    " Planner responded with non-successful code ${httpStatusCode.code()}")
 
-        assert (alertRequest.id =~ UUID_REGEX).matches()
-        assert alertRequest.action == RAISE
-        assert alertRequest.priority == MEDIUM
-        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
-        assert alertRequest.name == PBS_REGISTER_CLIENT_ERROR
-        assert alertRequest.details.startsWith("Service register failed to send request 1 time(s) with error message :" +
-                " Planner responded with non-successful code ${httpStatusCode.code()}")
+            alertRequest.source.env == pgPbsProperties.env
+            alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+            alertRequest.source.region == pgPbsProperties.region
+            alertRequest.source.system == pgPbsProperties.system
+            alertRequest.source.subSystem == pgPbsProperties.subSystem
+            alertRequest.source.hostId == pgPbsProperties.hostId
+        }
 
-        assert alertRequest.source.env == pgPbsProperties.env
-        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
-        assert alertRequest.source.region == pgPbsProperties.region
-        assert alertRequest.source.system == pgPbsProperties.system
-        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
-        assert alertRequest.source.hostId == pgPbsProperties.hostId
 
         cleanup: "Return initial Planner response status code"
         generalPlanner.initRegisterResponse()
@@ -213,23 +214,23 @@ class AlertSpec extends BasePgSpec {
         PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
 
         and: "Alert request should correspond to the payload"
-        def alertRequest = alert.recordedAlertRequest
+        verifyAll(alert.recordedAlertRequest) { alertRequest ->
+            (alertRequest.id =~ UUID_REGEX).matches()
+            alertRequest.action == RAISE
+            alertRequest.priority == MEDIUM
+            alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+            alertRequest.name == PBS_DELIVERY_CLIENT_ERROR
+            alertRequest.details.startsWith("Service deliveryStats failed to send request 1 time(s) with error message : " +
+                    "Report was not send to delivery stats service with a reason: Delivery stats service responded with " +
+                    "status code = ${httpStatusCode.code()} for report with id = ")
 
-        assert (alertRequest.id =~ UUID_REGEX).matches()
-        assert alertRequest.action == RAISE
-        assert alertRequest.priority == MEDIUM
-        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
-        assert alertRequest.name == PBS_DELIVERY_CLIENT_ERROR
-        assert alertRequest.details.startsWith("Service deliveryStats failed to send request 1 time(s) with error message : " +
-                "Report was not send to delivery stats service with a reason: Delivery stats service responded with " +
-                "status code = ${httpStatusCode.code()} for report with id = ")
-
-        assert alertRequest.source.env == pgPbsProperties.env
-        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
-        assert alertRequest.source.region == pgPbsProperties.region
-        assert alertRequest.source.system == pgPbsProperties.system
-        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
-        assert alertRequest.source.hostId == pgPbsProperties.hostId
+            alertRequest.source.env == pgPbsProperties.env
+            alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+            alertRequest.source.region == pgPbsProperties.region
+            alertRequest.source.system == pgPbsProperties.system
+            alertRequest.source.subSystem == pgPbsProperties.subSystem
+            alertRequest.source.hostId == pgPbsProperties.hostId
+        }
 
         cleanup: "Return initial Delivery Statistics response status code"
         deliveryStatistics.reset()
@@ -256,22 +257,22 @@ class AlertSpec extends BasePgSpec {
         PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
 
         and: "Alert request should correspond to the payload"
-        def alertRequest = alert.recordedAlertRequest
+        verifyAll(alert.recordedAlertRequest) { alertRequest ->
+            (alertRequest.id =~ UUID_REGEX).matches()
+            alertRequest.action == RAISE
+            alertRequest.priority == LOW
+            alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+            alertRequest.name == PBS_PLANNER_EMPTY_RESPONSE
+            alertRequest.details.startsWith("Service planner failed to send request 1 time(s) with error message : " +
+                    "Response without line items was received from planner")
 
-        assert (alertRequest.id =~ UUID_REGEX).matches()
-        assert alertRequest.action == RAISE
-        assert alertRequest.priority == LOW
-        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
-        assert alertRequest.name == PBS_PLANNER_EMPTY_RESPONSE
-        assert alertRequest.details.startsWith("Service planner failed to send request 1 time(s) with error message : " +
-                "Response without line items was received from planner")
-
-        assert alertRequest.source.env == pgPbsProperties.env
-        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
-        assert alertRequest.source.region == pgPbsProperties.region
-        assert alertRequest.source.system == pgPbsProperties.system
-        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
-        assert alertRequest.source.hostId == pgPbsProperties.hostId
+            alertRequest.source.env == pgPbsProperties.env
+            alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+            alertRequest.source.region == pgPbsProperties.region
+            alertRequest.source.system == pgPbsProperties.system
+            alertRequest.source.subSystem == pgPbsProperties.subSystem
+            alertRequest.source.hostId == pgPbsProperties.hostId
+        }
 
         cleanup: "Return initial Planner response"
         generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString))

--- a/src/test/groovy/org/prebid/server/functional/pg/AlertSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/AlertSpec.groovy
@@ -1,0 +1,279 @@
+package org.prebid.server.functional.pg
+
+import org.mockserver.matchers.Times
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.util.HttpUtil
+import org.prebid.server.functional.util.PBSUtils
+import spock.lang.Unroll
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+import static java.time.ZoneOffset.UTC
+import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500
+import static org.mockserver.model.HttpStatusCode.NOT_FOUND_404
+import static org.mockserver.model.HttpStatusCode.NO_CONTENT_204
+import static org.prebid.server.functional.model.deals.alert.Action.RAISE
+import static org.prebid.server.functional.model.deals.alert.AlertPriority.LOW
+import static org.prebid.server.functional.model.deals.alert.AlertPriority.MEDIUM
+import static org.prebid.server.functional.testcontainers.PbsPgConfig.PG_ENDPOINT_PASSWORD
+import static org.prebid.server.functional.testcontainers.PbsPgConfig.PG_ENDPOINT_USERNAME
+import static org.prebid.server.functional.util.HttpUtil.AUTHORIZATION_HEADER
+import static org.prebid.server.functional.util.HttpUtil.CONTENT_TYPE_HEADER
+import static org.prebid.server.functional.util.HttpUtil.CONTENT_TYPE_HEADER_VALUE
+import static org.prebid.server.functional.util.HttpUtil.PG_TRX_ID_HEADER
+import static org.prebid.server.functional.util.HttpUtil.UUID_REGEX
+
+class AlertSpec extends BasePgSpec {
+
+    private static final String PBS_REGISTER_CLIENT_ERROR = "pbs-register-client-error"
+    private static final String PBS_PLANNER_CLIENT_ERROR = "pbs-planner-client-error"
+    private static final String PBS_PLANNER_EMPTY_RESPONSE = "pbs-planner-empty-response-error"
+    private static final String PBS_DELIVERY_CLIENT_ERROR = "pbs-delivery-stats-client-error"
+    private static final Integer DEFAULT_ALERT_PERIOD = 15
+
+    def "PBS should send alert request when the threshold is reached"() {
+        given: "Changed Planner Register endpoint response to return bad status code"
+        generalPlanner.initRegisterResponse(NOT_FOUND_404)
+
+        and: "PBS alert counter is reset"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.resetAlertCountRequest)
+
+        and: "Initial Alert Service request count is taken"
+        def initialRequestCount = alert.requestCount
+
+        when: "Initiating PBS to register its instance through the bad Planner for the first time"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "PBS sends an alert request to the Alert Service for the first time"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
+
+        when: "Initiating PBS to register its instance through the bad Planner until the period threshold of alerts is reached"
+        (2..DEFAULT_ALERT_PERIOD).forEach {
+            pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+        }
+
+        then: "PBS sends an alert request to the Alert Service for the second time"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 2 }
+
+        and: "Request has the right number of failed register attempts"
+        def alertRequest = alert.recordedAlertRequest
+        assert alertRequest.details.startsWith("Service register failed to send request $DEFAULT_ALERT_PERIOD " +
+                "time(s) with error message")
+
+        cleanup: "Return initial Planner response status code"
+        generalPlanner.initRegisterResponse()
+    }
+
+    def "PBS should send an alert request with appropriate headers"() {
+        given: "Changed Planner Register endpoint response to return bad status code"
+        generalPlanner.initRegisterResponse(NOT_FOUND_404)
+
+        and: "PBS alert counter is reset"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.resetAlertCountRequest)
+
+        and: "Initial Alert Service request count is taken"
+        def initialRequestCount = alert.requestCount
+
+        when: "Initiating PBS to register its instance through the bad Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        and: "PBS sends an alert request to the Alert Service"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
+
+        then: "Request headers correspond to the payload"
+        def alertRequestHeaders = alert.lastRecordedAlertRequestHeaders
+        assert alertRequestHeaders
+
+        and: "Request has an authorization header with a basic auth token"
+        def basicAuthToken = HttpUtil.makeBasicAuthHeaderValue(PG_ENDPOINT_USERNAME, PG_ENDPOINT_PASSWORD)
+        assert alertRequestHeaders.get(AUTHORIZATION_HEADER) == [basicAuthToken]
+
+        and: "Request has a header with uuid value"
+        def uuidHeaderValue = alertRequestHeaders.get(PG_TRX_ID_HEADER)
+        assert uuidHeaderValue?.size() == 1
+        assert (uuidHeaderValue[0] =~ UUID_REGEX).matches()
+
+        and: "Request has a content type header"
+        assert alertRequestHeaders.get(CONTENT_TYPE_HEADER) == [CONTENT_TYPE_HEADER_VALUE]
+
+        cleanup: "Return initial Planner response status code"
+        generalPlanner.initRegisterResponse()
+    }
+
+    @Unroll
+    def "PBS should send an alert when fetching line items response status wasn't OK ('#httpStatusCode')"() {
+        given: "Changed Planner line items endpoint response to return bad status code"
+        // PBS will make 2 requests to the planner: 1 normal, 2 - recovery request
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString), httpStatusCode, Times.exactly(2))
+
+        and: "PBS alert counter is reset"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.resetAlertCountRequest)
+
+        and: "Initial Alert Service request count is taken"
+        def initialRequestCount = alert.requestCount
+
+        when: "Initiating PBS to fetch line items through the bad Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        then: "PBS sends an alert request to the Alert Service"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
+
+        and: "Alert request should correspond to the payload"
+        def alertRequest = alert.recordedAlertRequest
+
+        assert (alertRequest.id =~ UUID_REGEX).matches()
+        assert alertRequest.action == RAISE
+        assert alertRequest.priority == MEDIUM
+        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+        assert alertRequest.name == PBS_PLANNER_CLIENT_ERROR
+        assert alertRequest.details == "Service planner failed to send request 1 time(s) with error message :" +
+                " Failed to retrieve line items from GP. Reason: Failed to fetch data from Planner, HTTP status code ${httpStatusCode.code()}"
+
+        assert alertRequest.source.env == pgPbsProperties.env
+        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+        assert alertRequest.source.region == pgPbsProperties.region
+        assert alertRequest.source.system == pgPbsProperties.system
+        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
+        assert alertRequest.source.hostId == pgPbsProperties.hostId
+
+        cleanup: "Return initial Planner response status code"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString))
+
+        where: "Bad status codes"
+        httpStatusCode << [NO_CONTENT_204, NOT_FOUND_404, INTERNAL_SERVER_ERROR_500]
+    }
+
+    @Unroll
+    def "PBS should send an alert when register PBS instance response status wasn't OK ('#httpStatusCode')"() {
+        given: "Changed Planner register endpoint response to return bad status code"
+        generalPlanner.initRegisterResponse(httpStatusCode)
+
+        and: "PBS alert counter is reset"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.resetAlertCountRequest)
+
+        and: "Initial Alert Service request count is taken"
+        def initialRequestCount = alert.requestCount
+
+        when: "Initiating PBS to register its instance through the bad Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "PBS sends an alert request to the Alert Service"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
+
+        and: "Alert request should correspond to the payload"
+        def alertRequest = alert.recordedAlertRequest
+
+        assert (alertRequest.id =~ UUID_REGEX).matches()
+        assert alertRequest.action == RAISE
+        assert alertRequest.priority == MEDIUM
+        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+        assert alertRequest.name == PBS_REGISTER_CLIENT_ERROR
+        assert alertRequest.details.startsWith("Service register failed to send request 1 time(s) with error message :" +
+                " Planner responded with non-successful code ${httpStatusCode.code()}")
+
+        assert alertRequest.source.env == pgPbsProperties.env
+        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+        assert alertRequest.source.region == pgPbsProperties.region
+        assert alertRequest.source.system == pgPbsProperties.system
+        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
+        assert alertRequest.source.hostId == pgPbsProperties.hostId
+
+        cleanup: "Return initial Planner response status code"
+        generalPlanner.initRegisterResponse()
+
+        where: "Bad status codes"
+        httpStatusCode << [NOT_FOUND_404, INTERNAL_SERVER_ERROR_500]
+    }
+
+    @Unroll
+    def "PBS should send an alert when send delivery statistics report response status wasn't OK ('#httpStatusCode')"() {
+        given: "Changed Delivery Statistics endpoint response to return bad status code"
+        deliveryStatistics.reset()
+        deliveryStatistics.setResponse(httpStatusCode)
+
+        and: "Set line items response"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString))
+
+        and: "PBS alert counter is reset"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.resetAlertCountRequest)
+
+        and: "Initial Alert Service request count is taken"
+        def initialRequestCount = alert.requestCount
+
+        and: "Report to send is generated by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.createReportRequest)
+
+        when: "Initiating PBS to send delivery statistics report through the bad Delivery Statistics Service"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
+
+        then: "PBS sends an alert request to the Alert Service"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
+
+        and: "Alert request should correspond to the payload"
+        def alertRequest = alert.recordedAlertRequest
+
+        assert (alertRequest.id =~ UUID_REGEX).matches()
+        assert alertRequest.action == RAISE
+        assert alertRequest.priority == MEDIUM
+        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+        assert alertRequest.name == PBS_DELIVERY_CLIENT_ERROR
+        assert alertRequest.details.startsWith("Service deliveryStats failed to send request 1 time(s) with error message : " +
+                "Report was not send to delivery stats service with a reason: Delivery stats service responded with " +
+                "status code = ${httpStatusCode.code()} for report with id = ")
+
+        assert alertRequest.source.env == pgPbsProperties.env
+        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+        assert alertRequest.source.region == pgPbsProperties.region
+        assert alertRequest.source.system == pgPbsProperties.system
+        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
+        assert alertRequest.source.hostId == pgPbsProperties.hostId
+
+        cleanup: "Return initial Delivery Statistics response status code"
+        deliveryStatistics.reset()
+        deliveryStatistics.setResponse()
+
+        where: "Bad status codes"
+        httpStatusCode << [NOT_FOUND_404, INTERNAL_SERVER_ERROR_500]
+    }
+
+    def "PBS should send an alert when Planner returns empty response"() {
+        given: "Changed Planner get plans response to return no plans"
+        generalPlanner.initPlansResponse(new PlansResponse(lineItems: []))
+
+        and: "PBS alert counter is reset"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.resetAlertCountRequest)
+
+        and: "Initial Alert Service request count is taken"
+        def initialRequestCount = alert.requestCount
+
+        when: "Initiating PBS to fetch line items through the Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        then: "PBS sends an alert request to the Alert Service"
+        PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 1 }
+
+        and: "Alert request should correspond to the payload"
+        def alertRequest = alert.recordedAlertRequest
+
+        assert (alertRequest.id =~ UUID_REGEX).matches()
+        assert alertRequest.action == RAISE
+        assert alertRequest.priority == LOW
+        assert alertRequest.updatedAt.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+        assert alertRequest.name == PBS_PLANNER_EMPTY_RESPONSE
+        assert alertRequest.details.startsWith("Service planner failed to send request 1 time(s) with error message : " +
+                "Response without line items was received from planner")
+
+        assert alertRequest.source.env == pgPbsProperties.env
+        assert alertRequest.source.dataCenter == pgPbsProperties.dataCenter
+        assert alertRequest.source.region == pgPbsProperties.region
+        assert alertRequest.source.system == pgPbsProperties.system
+        assert alertRequest.source.subSystem == pgPbsProperties.subSystem
+        assert alertRequest.source.hostId == pgPbsProperties.hostId
+
+        cleanup: "Return initial Planner response"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString))
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/pg/CurrencySpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/CurrencySpec.groovy
@@ -1,0 +1,83 @@
+package org.prebid.server.functional.pg
+
+import org.prebid.server.functional.model.deals.lineitem.LineItem
+import org.prebid.server.functional.model.deals.lineitem.Price
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.request.auction.BidRequest
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.model.response.auction.BidResponse
+
+import static org.prebid.server.functional.model.bidder.BidderName.GENERIC
+
+class CurrencySpec extends BasePgSpec {
+
+    def setup() {
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+
+    def "PBS should convert non-default line item currency to the default one during the bidder auction"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+        def accountId = bidRequest.site.publisher.id
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items with the same CPM but different currencies"
+        def defaultCurrency = Price.defaultPrice.currency
+        def nonDefaultCurrency = "EUR"
+        def defaultCurrencyLineItem = [LineItem.getDefaultLineItem(accountId).tap { price = new Price(cpm: 1, currency: defaultCurrency) }]
+        def nonDefaultCurrencyLineItems = [LineItem.getDefaultLineItem(accountId).tap { price = new Price(cpm: 1, currency: nonDefaultCurrency) },
+                                           LineItem.getDefaultLineItem(accountId).tap { price = new Price(cpm: 1, currency: nonDefaultCurrency) },
+                                           LineItem.getDefaultLineItem(accountId).tap { price = new Price(cpm: 1, currency: nonDefaultCurrency) }]
+        def lineItems = defaultCurrencyLineItem + nonDefaultCurrencyLineItems
+        def plansResponse = new PlansResponse(lineItems: lineItems)
+        generalPlanner.initPlansResponse(plansResponse)
+        def nonDefaultCurrencyLineItemIds = nonDefaultCurrencyLineItems.collect { it.lineItemId }
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        when: "Auction is requested"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "All line items are ready to be served"
+        assert auctionResponse.ext?.debug?.pgmetrics?.readyToServe?.size() == plansResponse.lineItems.size()
+
+        and: "Line Item with EUR defaultCurrency was sent to bidder as EUR defaultCurrency rate > than USD"
+        assert auctionResponse.ext?.debug?.pgmetrics?.sentToBidder?.get(GENERIC.value)?.sort() ==
+                nonDefaultCurrencyLineItemIds.sort()
+    }
+
+    def "PBS should invalidate line item with an unknown for the conversion rate currency"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+        def accountId = bidRequest.site.publisher.id
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items with a default currency and unknown currency"
+        def defaultCurrency = Price.defaultPrice.currency
+        def unknownCurrency = "UAH"
+        def defaultCurrencyLineItem = [LineItem.getDefaultLineItem(accountId).tap { price = new Price(cpm: 1, currency: defaultCurrency) }]
+        def unknownCurrencyLineItem = [LineItem.getDefaultLineItem(accountId).tap { price = new Price(cpm: 1, currency: unknownCurrency) }]
+        def lineItems = defaultCurrencyLineItem + unknownCurrencyLineItem
+        def plansResponse = new PlansResponse(lineItems: lineItems)
+        generalPlanner.initPlansResponse(plansResponse)
+        def defaultCurrencyLineItemId = defaultCurrencyLineItem.collect { it.lineItemId }
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        when: "Auction is requested"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "Only line item with the default currency is ready to be served and was sent to bidder"
+        assert auctionResponse.ext?.debug?.pgmetrics?.readyToServe == defaultCurrencyLineItemId as Set
+        assert auctionResponse.ext?.debug?.pgmetrics?.sentToBidder?.get(GENERIC.value) ==
+                defaultCurrencyLineItemId as Set
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/pg/PlansSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/PlansSpec.groovy
@@ -1,0 +1,64 @@
+package org.prebid.server.functional.pg
+
+
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.util.HttpUtil
+import org.prebid.server.functional.util.PBSUtils
+
+import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500
+import static org.mockserver.model.HttpStatusCode.OK_200
+import static org.prebid.server.functional.testcontainers.PbsPgConfig.PG_ENDPOINT_PASSWORD
+import static org.prebid.server.functional.testcontainers.PbsPgConfig.PG_ENDPOINT_USERNAME
+import static org.prebid.server.functional.util.HttpUtil.AUTHORIZATION_HEADER
+import static org.prebid.server.functional.util.HttpUtil.PG_TRX_ID_HEADER
+import static org.prebid.server.functional.util.HttpUtil.UUID_REGEX
+
+class PlansSpec extends BasePgSpec {
+
+    def "PBS should be able to send a request to General Planner"() {
+        given: "Initial request count"
+        def initialRequestCount = generalPlanner.recordedPlansRequestCount
+
+        and: "General Planner response is set"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString), OK_200)
+
+        when: "PBS sends request to General Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        then: "Request is sent"
+        PBSUtils.waitUntil { generalPlanner.recordedPlansRequestCount == initialRequestCount + 1 }
+    }
+
+    def "PBS should retry request to General Planner when first request fails"() {
+        given: "Initial request count"
+        def initialRequestCount = generalPlanner.recordedPlansRequestCount
+
+        and: "Bad General Planner response is set"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(PBSUtils.randomString), INTERNAL_SERVER_ERROR_500)
+
+        when: "PBS sends request to General Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        then: "Request is sent two times"
+        PBSUtils.waitUntil { generalPlanner.recordedPlansRequestCount == initialRequestCount + 2 }
+    }
+
+    def "PBS should send appropriate headers when requests plans from General Planner"() {
+        when: "PBS sends request to General Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        then: "Request with headers is sent"
+        def plansRequestHeaders = generalPlanner.lastRecordedPlansRequestHeaders
+        assert plansRequestHeaders
+
+        and: "Request has an authorization header with a basic auth token"
+        def basicAuthToken = HttpUtil.makeBasicAuthHeaderValue(PG_ENDPOINT_USERNAME, PG_ENDPOINT_PASSWORD)
+        assert plansRequestHeaders.get(AUTHORIZATION_HEADER) == [basicAuthToken]
+
+        and: "Request has a header with uuid value"
+        def uuidHeader = plansRequestHeaders.get(PG_TRX_ID_HEADER)
+        assert uuidHeader?.size() == 1
+        assert (uuidHeader[0] =~ UUID_REGEX).matches()
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/pg/RegisterSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/RegisterSpec.groovy
@@ -1,0 +1,218 @@
+package org.prebid.server.functional.pg
+
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.request.auction.BidRequest
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.model.response.auction.BidResponse
+import org.prebid.server.functional.util.HttpUtil
+import org.prebid.server.functional.util.PBSUtils
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+import static java.time.ZoneOffset.UTC
+import static org.prebid.server.functional.testcontainers.PbsPgConfig.PG_ENDPOINT_PASSWORD
+import static org.prebid.server.functional.testcontainers.PbsPgConfig.PG_ENDPOINT_USERNAME
+import static org.prebid.server.functional.util.HttpUtil.AUTHORIZATION_HEADER
+import static org.prebid.server.functional.util.HttpUtil.PG_TRX_ID_HEADER
+import static org.prebid.server.functional.util.HttpUtil.UUID_REGEX
+
+class RegisterSpec extends BasePgSpec {
+
+    def setupSpec() {
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+
+    def "PBS should be able to register its instance in Planner on demand"() {
+        given: "Properties values from PBS config"
+        def host = pgPbsProperties.hostId
+        def vendor = pgPbsProperties.vendor
+        def region = pgPbsProperties.region
+
+        and: "Initial Planner request count"
+        def initialRequestCount = generalPlanner.requestCount
+
+        when: "PBS sends request to Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "Request counter is increased"
+        PBSUtils.waitUntil { generalPlanner.requestCount == initialRequestCount + 1 }
+
+        and: "PBS instance is healthy"
+        def registerRequest = generalPlanner.lastRecordedRegisterRequest
+        assert registerRequest.healthIndex >= 0 && registerRequest.healthIndex <= 1
+
+        and: "Host, vendor and region are appropriate to the config"
+        assert registerRequest.hostInstanceId == host
+        assert registerRequest.vendor == vendor
+        assert registerRequest.region == region
+
+        and: "Delivery Statistics Report doesn't have delivery specific data"
+        def delStatsReport = registerRequest.status.dealsStatus
+        assert (delStatsReport.reportId =~ UUID_REGEX).matches()
+        assert delStatsReport.instanceId == host
+        assert delStatsReport.vendor == vendor
+        assert delStatsReport.region == region
+        assert !delStatsReport.lineItemStatus
+        assert !delStatsReport.dataWindowStartTimeStamp
+        assert !delStatsReport.dataWindowEndTimeStamp
+        assert delStatsReport.reportTimeStamp.isBefore(ZonedDateTime.now(ZoneId.from(UTC)))
+    }
+
+    def "PBS should send a register request with appropriate headers"() {
+        when: "Initiating PBS to register its instance"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "Request with headers is sent"
+        def registerRequestHeaders = generalPlanner.lastRecordedRegisterRequestHeaders
+        assert registerRequestHeaders
+
+        and: "Request has an authorization header with a basic auth token"
+        def basicAuthToken = HttpUtil.makeBasicAuthHeaderValue(PG_ENDPOINT_USERNAME, PG_ENDPOINT_PASSWORD)
+        assert registerRequestHeaders.get(AUTHORIZATION_HEADER) == [basicAuthToken]
+
+        and: "Request has a header with uuid value"
+        def uuidHeader = registerRequestHeaders.get(PG_TRX_ID_HEADER)
+        assert uuidHeader?.size() == 1
+        assert (uuidHeader[0] =~ UUID_REGEX).matches()
+    }
+
+    def "PBS should be able to register its instance in Planner providing active PBS line items info"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        def lineItem = plansResponse.lineItems[0]
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial Planner request count"
+        def initialRequestCount = generalPlanner.requestCount
+
+        when: "PBS sends request to Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "Request counter is increased"
+        PBSUtils.waitUntil { generalPlanner.requestCount == initialRequestCount + 1 }
+
+        and: "Delivery Statistics Report has active line item data"
+        def registerRequest = generalPlanner.lastRecordedRegisterRequest
+        def delStatsReport = registerRequest.status?.dealsStatus
+        assert delStatsReport
+        def lineItemStatus = delStatsReport.lineItemStatus
+        assert lineItemStatus?.size() == plansResponse.lineItems.size()
+        assert lineItemStatus[0].lineItemSource == lineItem.source
+        assert lineItemStatus[0].lineItemId == lineItem.lineItemId
+        assert lineItemStatus[0].dealId == lineItem.dealId
+        assert lineItemStatus[0].extLineItemId == lineItem.extLineItemId
+
+        and: "Line item wasn't used in auction"
+        assert !lineItemStatus[0].accountAuctions
+        assert !lineItemStatus[0].targetMatched
+        assert !lineItemStatus[0].sentToBidder
+        assert !lineItemStatus[0].spentTokens
+
+        cleanup:
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+
+    def "PBS should be able to register its instance in Planner providing line items status after auction"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        def lineItem = plansResponse.lineItems[0]
+        def lineItemCount = plansResponse.lineItems.size() as Long
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial Planner request count"
+        def initialRequestCount = generalPlanner.requestCount
+
+        and: "Auction is requested"
+        pgPbsService.sendAuctionRequest(bidRequest)
+
+        when: "PBS sends request to Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "Request counter is increased"
+        PBSUtils.waitUntil { generalPlanner.requestCount == initialRequestCount + 1 }
+
+        and: "Delivery Statistics Report has info about auction"
+        def registerRequest = generalPlanner.lastRecordedRegisterRequest
+        def delStatsReport = registerRequest.status.dealsStatus
+        assert delStatsReport
+
+        and: "Delivery Statistics Report has correct line item status data"
+        def lineItemStatus = delStatsReport.lineItemStatus
+        assert lineItemStatus?.size() as Long == lineItemCount
+        assert lineItemStatus[0].lineItemSource == lineItem.source
+        assert lineItemStatus[0].lineItemId == lineItem.lineItemId
+        assert lineItemStatus[0].dealId == lineItem.dealId
+        assert lineItemStatus[0].extLineItemId == lineItem.extLineItemId
+
+        and: "Line item was used in auction"
+        assert lineItemStatus[0].accountAuctions == lineItemCount
+        assert lineItemStatus[0].targetMatched == lineItemCount
+        assert lineItemStatus[0].sentToBidder == lineItemCount
+        assert lineItemStatus[0].spentTokens == lineItemCount
+
+        cleanup:
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+
+    def "PBS should update auction count when register its instance in Planner after auction"() {
+        given: "Initial auction count"
+        def initialRequestCount = generalPlanner.requestCount
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+        PBSUtils.waitUntil { generalPlanner.requestCount == initialRequestCount + 1 }
+        def initialAuctionCount = generalPlanner.lastRecordedRegisterRequest?.status?.dealsStatus?.clientAuctions
+
+        and: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial Planner request count"
+        initialRequestCount = generalPlanner.requestCount
+
+        and: "Auction is requested"
+        pgPbsService.sendAuctionRequest(bidRequest)
+
+        when: "PBS sends request to Planner"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.registerInstanceRequest)
+
+        then: "Request counter is increased"
+        PBSUtils.waitUntil { generalPlanner.requestCount == initialRequestCount + 1 }
+
+        and: "Delivery Statistics Report has info about auction"
+        def registerRequest = generalPlanner.lastRecordedRegisterRequest
+        assert registerRequest.status?.dealsStatus?.clientAuctions == initialAuctionCount + 1
+
+        cleanup:
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/testcontainers/scaffolding/CurrencyConversion.groovy
+++ b/src/test/groovy/org/prebid/server/functional/testcontainers/scaffolding/CurrencyConversion.groovy
@@ -1,0 +1,41 @@
+package org.prebid.server.functional.testcontainers.scaffolding
+
+import org.mockserver.model.HttpRequest
+import org.prebid.server.functional.model.mock.services.currencyconversion.CurrencyConversionRatesResponse
+import org.prebid.server.functional.util.ObjectMapperWrapper
+import org.testcontainers.containers.MockServerContainer
+
+import static org.mockserver.model.HttpRequest.request
+import static org.mockserver.model.HttpResponse.response
+import static org.mockserver.model.HttpStatusCode.OK_200
+
+class CurrencyConversion extends NetworkScaffolding {
+
+    static final String CURRENCY_ENDPOINT_PATH = "/currency"
+
+    CurrencyConversion(MockServerContainer mockServerContainer, ObjectMapperWrapper mapper) {
+        super(mockServerContainer, CURRENCY_ENDPOINT_PATH, mapper)
+    }
+
+    void setCurrencyConversionRatesResponse(CurrencyConversionRatesResponse conversionRatesResponse) {
+        setResponse(request, conversionRatesResponse)
+    }
+
+    @Override
+    void setResponse() {
+        mockServerClient.when(request().withPath(endpoint))
+                        .respond(response().withStatusCode(OK_200.code()))
+    }
+
+    @Override
+    protected HttpRequest getRequest(String ignored) {
+        request().withMethod("GET")
+                 .withPath(CURRENCY_ENDPOINT_PATH)
+    }
+
+    @Override
+    protected HttpRequest getRequest() {
+        request().withMethod("GET")
+                 .withPath(CURRENCY_ENDPOINT_PATH)
+    }
+}


### PR DESCRIPTION
Add tests for PG alert, currency, plans, register services

Not only those PG tests, but all (also from other PRs) have passed
[WARNING] Tests run: 246, Failures: 0, Errors: 0, Skipped: 10
[INFO] prebid-server ...................................... SUCCESS [06:02 min]