### PR TITLE
Add PG bidder request, bid response, user details specs

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/pg/PgBidResponseSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/PgBidResponseSpec.groovy
@@ -1,0 +1,164 @@
+package org.prebid.server.functional.pg
+
+
+import org.prebid.server.functional.model.deals.lineitem.LineItemSize
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.request.auction.BidRequest
+import org.prebid.server.functional.model.request.auction.Format
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.model.response.auction.BidResponse
+import org.prebid.server.functional.util.PBSUtils
+import spock.lang.Unroll
+
+import static org.prebid.server.functional.model.response.auction.ErrorType.GENERIC
+
+class PgBidResponseSpec extends BasePgSpec {
+
+    def cleanup() {
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+
+    def "PBS should allow valid bidder response with deals info continue taking part in auction"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+        def lineItemCount = plansResponse.lineItems.size()
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Set bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "Bidder returned valid response with deals info during auction"
+        assert auctionResponse.ext?.debug?.pgmetrics?.sentToClient?.size() == lineItemCount
+        assert auctionResponse.ext?.debug?.pgmetrics?.sentToClientAsTopMatch?.size() == lineItemCount
+    }
+
+    @Unroll
+    def "PBS should invalidate bidder response when '#field' doesn't match with the bid request"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Set bid response"
+        def bidResponse = bidResponseGeneric(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "Bidder response is invalid"
+        def bidderError = auctionResponse.ext?.errors?.get(GENERIC)
+        assert bidderError?.size() == 1
+        assert bidderError[0].message.startsWith(errorMessage(bidResponse))
+
+        where:
+        field     |
+                bidResponseGeneric |
+                errorMessage
+
+        "bid id"  |
+                { BidRequest bidReq, PlansResponse plansResp ->
+                    BidResponse.getDefaultPgBidResponse(bidReq, plansResp).tap {
+                        seatbid[0].bid[0].impid = PBSUtils.randomNumber as String
+                    }
+                }                  |
+                { BidResponse bidResp -> "Bid \"${bidResp.seatbid[0].bid[0].id}\" has no corresponding imp in request" }
+
+        "deal id" |
+                { BidRequest bidReq, PlansResponse plansResp ->
+                    BidResponse.getDefaultPgBidResponse(bidReq, plansResp).tap {
+                        seatbid[0].bid[0].dealid = PBSUtils.randomNumber as String
+                    }
+                }                  |
+                { BidResponse bidResp ->
+                    "WARNING: Bid \"${bidResp.seatbid[0].bid[0].id}\" has 'dealid' not present in corresponding imp in request."
+                }
+    }
+
+    def "PBS should invalidate bidder response when non-matched to the bid request size is returned"() {
+        given: "Bid request with set sizes"
+        def bidRequest = BidRequest.defaultBidRequest.tap {
+            imp[0].banner.format = [Format.defaultFormat]
+        }
+        def impFormat = bidRequest.imp[0].banner.format[0]
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Set bid response with unmatched to the bid request size"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse).tap {
+            seatbid[0].bid[0].w = PBSUtils.randomNumber
+        }
+        def bid = bidResponse.seatbid[0].bid[0]
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "Bidder response is invalid"
+        assert auctionResponse.ext?.debug?.pgmetrics?.responseInvalidated?.size() == plansResponse.lineItems.size()
+
+        and: "PBS invalidated response as unmatched by size"
+        def bidderError = auctionResponse.ext?.errors?.get(GENERIC)
+        assert bidderError?.size() == 1
+        assert bidderError[0].message == "Bid \"$bid.id\" has 'w' and 'h' not supported by " +
+                "corresponding imp in request. Bid dimensions: '${bid.w}x$bid.h', formats in imp: '${impFormat.w}x$impFormat.h'"
+    }
+
+    def "PBS should invalidate bidder response when non-matched to the PBS line item size response is returned"() {
+        given: "Bid request"
+        def newFormat = new Format(w: PBSUtils.randomNumber, h: PBSUtils.randomNumber)
+        def bidRequest = BidRequest.defaultBidRequest.tap {
+            imp[0].banner.format = [Format.defaultFormat, newFormat]
+        }
+
+        and: "Planner Mock line items with a default size"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id).tap {
+            lineItems[0].sizes = [LineItemSize.defaultLineItemSize]
+        }
+        def lineItemSize = plansResponse.lineItems[0].sizes[0]
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Set bid response with non-matched to the line item size"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse).tap {
+            seatbid[0].bid[0].w = newFormat.w
+            seatbid[0].bid[0].h = newFormat.h
+        }
+        def bid = bidResponse.seatbid[0].bid[0]
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "Bidder response is invalid"
+        assert auctionResponse.ext?.debug?.pgmetrics?.responseInvalidated?.size() == plansResponse.lineItems.size()
+
+        and: "PBS invalidated response as not matched by size"
+        def bidderError = auctionResponse.ext?.errors?.get(GENERIC)
+        assert bidderError?.size() == 1
+        assert bidderError[0].message == "Bid \"$bid.id\" has 'w' and 'h' not matched to Line Item. " +
+                "Bid dimensions: '${bid.w}x$bid.h', Line Item sizes: '${lineItemSize.w}x$lineItemSize.h'"
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/pg/PgBidderRequestSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/PgBidderRequestSpec.groovy
@@ -52,12 +52,13 @@ class PgBidderRequestSpec extends BasePgSpec {
         pgPbsService.sendAuctionRequest(bidRequest, cookieHeader)
 
         then: "PBS sent a request to the bidder with added device info"
-        def bidderRequest = bidder.getBidderRequest(bidRequest.id)
-        assert bidderRequest.user?.ext?.fcapids == userResponse.user.ext.fcapIds
-        assert bidderRequest.user.data?.size() == userResponse.user.data.size()
-        assert bidderRequest.user.data[0].id == userResponse.user.data[0].name
-        assert bidderRequest.user.data[0].segment?.size() == userResponse.user.data[0].segment.size()
-        assert bidderRequest.user.data[0].segment[0].id == userResponse.user.data[0].segment[0].id
+        verifyAll(bidder.getBidderRequest(bidRequest.id)) { bidderRequest ->
+            bidderRequest.user?.ext?.fcapids == userResponse.user.ext.fcapIds
+            bidderRequest.user.data?.size() == userResponse.user.data.size()
+            bidderRequest.user.data[0].id == userResponse.user.data[0].name
+            bidderRequest.user.data[0].segment?.size() == userResponse.user.data[0].segment.size()
+            bidderRequest.user.data[0].segment[0].id == userResponse.user.data[0].segment[0].id
+        }
     }
 
     def "PBS should be able to add pmp deals part to the bidder request when PG is enabled"() {
@@ -81,17 +82,21 @@ class PgBidderRequestSpec extends BasePgSpec {
 
         then: "PBS sent a request to the bidder with added deals"
         def bidderRequest = bidder.getBidderRequest(bidRequest.id)
+
         assert bidderRequest.imp?.size() == bidRequest.imp.size()
         assert bidderRequest.imp[0].pmp?.deals?.size() == plansResponse.lineItems.size()
         assert bidderRequest.imp[0].pmp?.deals
         assert plansResponse.lineItems.each { lineItem ->
             def deal = bidderRequest.imp[0]?.pmp?.deals?.find { it.id == lineItem.dealId }
+
             assert deal
-            assert deal?.ext?.line?.lineItemId == lineItem.lineItemId
-            assert deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
-            assert deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
-            assert deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
-            assert deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+            verifyAll(deal) {
+                deal?.ext?.line?.lineItemId == lineItem.lineItemId
+                deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
+                deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
+                deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
+                deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+            }
         }
     }
 
@@ -128,12 +133,15 @@ class PgBidderRequestSpec extends BasePgSpec {
         assert firstRequestImp?.pmp?.deals?.size() == plansResponse.lineItems.size()
         assert plansResponse.lineItems.each { lineItem ->
             def deal = firstRequestImp.pmp.deals.find { it.id == lineItem.dealId }
+
             assert deal
-            assert deal?.ext?.line?.lineItemId == lineItem.lineItemId
-            assert deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
-            assert deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
-            assert deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
-            assert deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+            verifyAll(deal) {
+                deal?.ext?.line?.lineItemId == lineItem.lineItemId
+                deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
+                deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
+                deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
+                deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+            }
         }
 
         def topMatchLineItemId = firstRequestImp.pmp.deals.first().ext.line.lineItemId
@@ -145,12 +153,15 @@ class PgBidderRequestSpec extends BasePgSpec {
 
         assert plansResponse.lineItems.findAll { it.lineItemId != topMatchLineItemId }.each { lineItem ->
             def deal = secondRequestImp.pmp.deals.find { it.id == lineItem.dealId }
+
             assert deal
-            assert deal?.ext?.line?.lineItemId == lineItem.lineItemId
-            assert deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
-            assert deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
-            assert deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
-            assert deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+            verifyAll(deal) {
+                deal?.ext?.line?.lineItemId == lineItem.lineItemId
+                deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
+                deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
+                deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
+                deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+            }
         }
     }
 }

--- a/src/test/groovy/org/prebid/server/functional/pg/PgBidderRequestSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/PgBidderRequestSpec.groovy
@@ -1,0 +1,156 @@
+package org.prebid.server.functional.pg
+
+import org.prebid.server.functional.model.UidsCookie
+import org.prebid.server.functional.model.bidder.Generic
+import org.prebid.server.functional.model.deals.lineitem.LineItem
+import org.prebid.server.functional.model.deals.userdata.UserDetailsResponse
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.request.auction.BidRequest
+import org.prebid.server.functional.model.request.auction.Bidder
+import org.prebid.server.functional.model.request.auction.Device
+import org.prebid.server.functional.model.request.auction.Imp
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.model.response.auction.BidResponse
+import org.prebid.server.functional.util.HttpUtil
+import org.prebid.server.functional.util.PBSUtils
+import spock.lang.Ignore
+
+class PgBidderRequestSpec extends BasePgSpec {
+
+    def cleanup() {
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+    }
+
+    def "PBS should be able to add given device info to the bidder request"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest.tap {
+            device = new Device(ua: PBSUtils.randomString,
+                    make: PBSUtils.randomString,
+                    model: PBSUtils.randomString)
+        }
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "User Service response is set"
+        def userResponse = UserDetailsResponse.defaultUserResponse
+        userData.setUserDataResponse(userResponse)
+
+        and: "Cookies with user ids"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS"
+        pgPbsService.sendAuctionRequest(bidRequest, cookieHeader)
+
+        then: "PBS sent a request to the bidder with added device info"
+        def bidderRequest = bidder.getBidderRequest(bidRequest.id)
+        assert bidderRequest.user?.ext?.fcapids == userResponse.user.ext.fcapIds
+        assert bidderRequest.user.data?.size() == userResponse.user.data.size()
+        assert bidderRequest.user.data[0].id == userResponse.user.data[0].name
+        assert bidderRequest.user.data[0].segment?.size() == userResponse.user.data[0].segment.size()
+        assert bidderRequest.user.data[0].segment[0].id == userResponse.user.data[0].segment[0].id
+    }
+
+    def "PBS should be able to add pmp deals part to the bidder request when PG is enabled"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items"
+        def accountId = bidRequest.site.publisher.id
+        def plansResponse = new PlansResponse(lineItems: [LineItem.getDefaultLineItem(accountId), LineItem.getDefaultLineItem(accountId)])
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        when: "Sending auction request to PBS"
+        pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "PBS sent a request to the bidder with added deals"
+        def bidderRequest = bidder.getBidderRequest(bidRequest.id)
+        assert bidderRequest.imp?.size() == bidRequest.imp.size()
+        assert bidderRequest.imp[0].pmp?.deals?.size() == plansResponse.lineItems.size()
+        assert bidderRequest.imp[0].pmp?.deals
+        assert plansResponse.lineItems.each { lineItem ->
+            def deal = bidderRequest.imp[0]?.pmp?.deals?.find { it.id == lineItem.dealId }
+            assert deal
+            assert deal?.ext?.line?.lineItemId == lineItem.lineItemId
+            assert deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
+            assert deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
+            assert deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
+            assert deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+        }
+    }
+
+    @Ignore(value = "https://jira.magnite-core.com/browse/HB-13821")
+    def "PBS shouldn't add already top matched line item by first impression to the second impression deals bidder request section"() {
+        given: "Bid request with two impressions"
+        def bidRequest = BidRequest.defaultBidRequest.tap {
+            imp[0].ext.prebid.bidder = new Bidder(generic: new Generic())
+            imp << Imp.defaultImpression
+            imp[1].ext.prebid.bidder = new Bidder(generic: new Generic())
+        }
+
+        and: "Planner Mock line items"
+        def accountId = bidRequest.site.publisher.id
+        def plansResponse = new PlansResponse(lineItems: [LineItem.getDefaultLineItem(accountId), LineItem.getDefaultLineItem(accountId)])
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest)
+
+        then: "PBS sent a request to the bidder with two impressions"
+        def bidderRequest = bidder.getBidderRequest(bidRequest.id)
+        assert bidderRequest.imp?.size() == bidRequest.imp.size()
+
+        and: "First impression contains 2 deals according to the line items"
+        def firstRequestImp = bidderRequest.imp.find { it.id == bidRequest.imp[0].id }
+        assert firstRequestImp?.pmp?.deals?.size() == plansResponse.lineItems.size()
+        assert plansResponse.lineItems.each { lineItem ->
+            def deal = firstRequestImp.pmp.deals.find { it.id == lineItem.dealId }
+            assert deal
+            assert deal?.ext?.line?.lineItemId == lineItem.lineItemId
+            assert deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
+            assert deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
+            assert deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
+            assert deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+        }
+
+        def topMatchLineItemId = firstRequestImp.pmp.deals.first().ext.line.lineItemId
+        def secondRequestImp = bidderRequest.imp.find { it.id == bidRequest.imp[1].id }
+
+        and: "Second impression contains only 1 deal excluding already top matched line items by the first impression"
+        assert secondRequestImp.pmp.deals.size() == plansResponse.lineItems.size() - 1
+        assert !(secondRequestImp.pmp.deals.collect { it.ext.line.lineItemId } in topMatchLineItemId)
+
+        assert plansResponse.lineItems.findAll { it.lineItemId != topMatchLineItemId }.each { lineItem ->
+            def deal = secondRequestImp.pmp.deals.find { it.id == lineItem.dealId }
+            assert deal
+            assert deal?.ext?.line?.lineItemId == lineItem.lineItemId
+            assert deal?.ext?.line?.extLineItemId == lineItem.extLineItemId
+            assert deal?.ext?.line?.sizes?.size() == lineItem.sizes.size()
+            assert deal?.ext?.line?.sizes[0].w == lineItem.sizes[0].w
+            assert deal?.ext?.line?.sizes[0].h == lineItem.sizes[0].h
+        }
+    }
+}

--- a/src/test/groovy/org/prebid/server/functional/pg/UserDetailsSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/UserDetailsSpec.groovy
@@ -331,19 +331,19 @@ class UserDetailsSpec extends BasePgSpec {
         pgPbsService.sendAuctionRequest(bidRequest)
 
         and: "Sending event request to PBS"
-        pgPbsService.sendEventRequest(eventRequest, cookieHeader)
+        pgPbsService.sendEventRequest(eventRequest, HttpUtil.getCookieHeader(mapper, uidsCookie))
 
         then: "PBS hasn't sent a win notification to the User Service"
         assert userData.requestCount == initialRequestCount
 
         where:
-        reason              | cookieHeader
+        reason              | uidsCookie
 
-        "empty cookie"      | HttpUtil.getCookieHeader(mapper, new UidsCookie())
+        "empty cookie"      | new UidsCookie()
 
-        "empty uids cookie" | HttpUtil.getCookieHeader(mapper, UidsCookie.defaultUidsCookie.tap {
+        "empty uids cookie" | UidsCookie.defaultUidsCookie.tap {
             uids = null
             tempUIDs = null
-        })
+        }
     }
 }

--- a/src/test/groovy/org/prebid/server/functional/pg/UserDetailsSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/UserDetailsSpec.groovy
@@ -236,18 +236,19 @@ class UserDetailsSpec extends BasePgSpec {
 
         and: "Win request corresponds to the payload"
         def timeFormatter = DateTimeFormatter.ofPattern(TIME_PATTERN)
-        def winNotificationRequest = userData.recordedWinEventRequest
-        assert winNotificationRequest.bidderCode == GENERIC.value
-        assert winNotificationRequest.bidId == winEventRequest.bidId
-        assert winNotificationRequest.lineItemId == lineItemId
-        assert winNotificationRequest.region == pgPbsProperties.region
-        assert winNotificationRequest.userIds?.size() == 1
-        assert winNotificationRequest.userIds[0].id == uidsCookie.tempUIDs.get(GENERIC.value).uid
-        assert winNotificationRequest.userIds[0].type == pgPbsProperties.userIdType
-        assert timeFormatter.format(winNotificationRequest.lineUpdatedDateTime) ==
-                timeFormatter.format(lineItemUpdateTime)
-        assert winNotificationRequest.winEventDateTime.isAfter(winNotificationRequest.lineUpdatedDateTime)
-        assert !winNotificationRequest.frequencyCaps
+
+        verifyAll(userData.recordedWinEventRequest) { winNotificationRequest ->
+            winNotificationRequest.bidderCode == GENERIC.value
+            winNotificationRequest.bidId == winEventRequest.bidId
+            winNotificationRequest.lineItemId == lineItemId
+            winNotificationRequest.region == pgPbsProperties.region
+            winNotificationRequest.userIds?.size() == 1
+            winNotificationRequest.userIds[0].id == uidsCookie.tempUIDs.get(GENERIC.value).uid
+            winNotificationRequest.userIds[0].type == pgPbsProperties.userIdType
+            timeFormatter.format(winNotificationRequest.lineUpdatedDateTime) == timeFormatter.format(lineItemUpdateTime)
+            winNotificationRequest.winEventDateTime.isAfter(winNotificationRequest.lineUpdatedDateTime)
+            !winNotificationRequest.frequencyCaps
+        }
     }
 
     @Unroll

--- a/src/test/groovy/org/prebid/server/functional/pg/UserDetailsSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/pg/UserDetailsSpec.groovy
@@ -1,0 +1,349 @@
+package org.prebid.server.functional.pg
+
+import org.prebid.server.functional.model.UidsCookie
+import org.prebid.server.functional.model.deals.lineitem.FrequencyCap
+import org.prebid.server.functional.model.deals.userdata.UserDetailsResponse
+import org.prebid.server.functional.model.mock.services.generalplanner.PlansResponse
+import org.prebid.server.functional.model.mock.services.httpsettings.HttpAccountsResponse
+import org.prebid.server.functional.model.request.auction.BidRequest
+import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
+import org.prebid.server.functional.model.request.event.EventRequest
+import org.prebid.server.functional.model.response.auction.BidResponse
+import org.prebid.server.functional.testcontainers.Dependencies
+import org.prebid.server.functional.testcontainers.scaffolding.HttpSettings
+import org.prebid.server.functional.util.HttpUtil
+import org.prebid.server.functional.util.PBSUtils
+import spock.lang.Shared
+import spock.lang.Unroll
+
+import java.time.format.DateTimeFormatter
+
+import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500
+import static org.mockserver.model.HttpStatusCode.NOT_FOUND_404
+import static org.mockserver.model.HttpStatusCode.NO_CONTENT_204
+import static org.prebid.server.functional.model.bidder.BidderName.GENERIC
+import static org.prebid.server.functional.model.deals.lineitem.LineItem.TIME_PATTERN
+
+class UserDetailsSpec extends BasePgSpec {
+
+    private static final String USER_SERVICE_NAME = "userservice"
+
+    @Shared
+    HttpSettings httpSettings = new HttpSettings(Dependencies.networkServiceContainer, mapper)
+
+    def "PBS should send user details request to the User Service during deals auction"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id))
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial user details request count is taken"
+        def initialRequestCount = userData.recordedUserDetailsRequestCount
+
+        and: "Cookies with user ids"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS"
+        pgPbsService.sendAuctionRequest(bidRequest, cookieHeader)
+
+        then: "PBS sends a request to the User Service"
+        def updatedRequestCount = userData.recordedUserDetailsRequestCount
+        assert updatedRequestCount == initialRequestCount + 1
+
+        and: "Request corresponds to the payload"
+        def userDetailsRequest = userData.recordedUserDetailsRequest
+        assert userDetailsRequest.time?.isAfter(uidsCookie.bday)
+        assert userDetailsRequest.ids?.size() == 1
+        assert userDetailsRequest.ids[0].id == uidsCookie.tempUIDs.get(GENERIC.value).uid
+        assert userDetailsRequest.ids[0].type == pgPbsProperties.userIdType
+    }
+
+    @Unroll
+    def "PBS should validate bad user details response status code ('#statusCode')"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial user details request count is taken"
+        def initialRequestCount = userData.recordedUserDetailsRequestCount
+
+        and: "User Service response is set"
+        userData.setUserDataResponse(UserDetailsResponse.defaultUserResponse, statusCode)
+
+        and: "Cookies with user ids"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest, cookieHeader)
+
+        then: "PBS sends a request to the User Service during auction"
+        assert userData.recordedUserDetailsRequestCount == initialRequestCount + 1
+        def userServiceCall = auctionResponse.ext?.debug?.httpcalls?.get(USER_SERVICE_NAME)
+        assert userServiceCall?.size() == 1
+
+        assert !userServiceCall[0].status
+        assert !userServiceCall[0].responsebody
+
+        cleanup:
+        userData.setUserDataResponse(UserDetailsResponse.defaultUserResponse)
+
+        where:
+        statusCode << [NO_CONTENT_204, NOT_FOUND_404, INTERNAL_SERVER_ERROR_500]
+    }
+
+    @Unroll
+    def "PBS should invalidate user details response body when response has absent #fieldName field"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial user details request count is taken"
+        def initialRequestCount = userData.recordedUserDetailsRequestCount
+
+        and: "User Service response is set"
+        userData.setUserDataResponse(userDataResponse)
+
+        and: "Cookies with user ids"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest, cookieHeader)
+
+        then: "PBS sends a request to the User Service"
+        assert userData.recordedUserDetailsRequestCount == initialRequestCount + 1
+
+        and: "Call to the user service was made"
+        assert auctionResponse.ext?.debug?.httpcalls?.get(USER_SERVICE_NAME)?.size() == 1
+
+        and: "Data from the user service response wasn't added to the bid request by PBS"
+        assert !auctionResponse.ext?.debug?.resolvedrequest?.user?.data
+        assert !auctionResponse.ext?.debug?.resolvedrequest?.user?.ext?.fcapids
+
+        cleanup:
+        userData.setUserDataResponse(UserDetailsResponse.defaultUserResponse)
+
+        where:
+        fieldName   | userDataResponse
+        "user"      | new UserDetailsResponse(user: null)
+        "user.data" | UserDetailsResponse.defaultUserResponse.tap { user.data = null }
+        "user.ext"  | UserDetailsResponse.defaultUserResponse.tap { user.ext = null }
+    }
+
+    def "PBS should abandon line items with user fCap ids take part in auction when user details response failed"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Planner Mock line items with added frequency cap"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id).tap {
+            lineItems[0].frequencyCaps = [FrequencyCap.defaultFrequencyCap.tap { fcapId = PBSUtils.randomNumber as String }]
+        }
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultPgBidResponse(bidRequest, plansResponse)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Bad User Service Response is set"
+        userData.setUserDataResponse(new UserDetailsResponse(user: null))
+
+        and: "Cookies header"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS"
+        def auctionResponse = pgPbsService.sendAuctionRequest(bidRequest, cookieHeader)
+
+        then: "PBS hasn't started processing PG deals as line item targeting frequency capped lookup failed"
+        assert auctionResponse.ext?.debug?.pgmetrics?.matchedTargetingFcapLookupFailed?.size() ==
+                plansResponse.lineItems.size()
+
+        cleanup:
+        userData.setUserDataResponse(UserDetailsResponse.defaultUserResponse)
+    }
+
+    def "PBS should send win notification request to the User Service on bidder wins"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        def lineItemId = plansResponse.lineItems[0].lineItemId
+        def lineItemUpdateTime = plansResponse.lineItems[0].updatedTimeStamp
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial win notification request count"
+        def initialRequestCount = userData.requestCount
+
+        and: "Enabled event request"
+        def winEventRequest = EventRequest.defaultEventRequest.tap {
+            it.lineItemId = lineItemId
+            analytics = 0
+        }
+
+        and: "Default account response"
+        def httpSettingsResponse = HttpAccountsResponse.getDefaultHttpAccountsResponse(winEventRequest.accountId.toString())
+        httpSettings.setResponse(winEventRequest.accountId.toString(), httpSettingsResponse)
+
+        and: "Cookies header"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS where the winner is instantiated"
+        pgPbsService.sendAuctionRequest(bidRequest)
+
+        and: "Sending event request to PBS"
+        pgPbsService.sendEventRequest(winEventRequest, cookieHeader)
+
+        then: "PBS sends a win notification to the User Service"
+        PBSUtils.waitUntil { userData.requestCount == initialRequestCount + 1 }
+
+        and: "Win request corresponds to the payload"
+        def timeFormatter = DateTimeFormatter.ofPattern(TIME_PATTERN)
+        def winNotificationRequest = userData.recordedWinEventRequest
+        assert winNotificationRequest.bidderCode == GENERIC.value
+        assert winNotificationRequest.bidId == winEventRequest.bidId
+        assert winNotificationRequest.lineItemId == lineItemId
+        assert winNotificationRequest.region == pgPbsProperties.region
+        assert winNotificationRequest.userIds?.size() == 1
+        assert winNotificationRequest.userIds[0].id == uidsCookie.tempUIDs.get(GENERIC.value).uid
+        assert winNotificationRequest.userIds[0].type == pgPbsProperties.userIdType
+        assert timeFormatter.format(winNotificationRequest.lineUpdatedDateTime) ==
+                timeFormatter.format(lineItemUpdateTime)
+        assert winNotificationRequest.winEventDateTime.isAfter(winNotificationRequest.lineUpdatedDateTime)
+        assert !winNotificationRequest.frequencyCaps
+    }
+
+    @Unroll
+    def "PBS shouldn't send win notification request to the User Service when #reason line item id is given"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items"
+        generalPlanner.initPlansResponse(PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id))
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial win notification request count"
+        def initialRequestCount = userData.requestCount
+
+        and: "Enabled event request"
+        def eventRequest = EventRequest.defaultEventRequest.tap {
+            it.lineItemId = lineItemId
+            analytics = 0
+        }
+
+        and: "Default account response"
+        def httpSettingsResponse = HttpAccountsResponse.getDefaultHttpAccountsResponse(eventRequest.accountId.toString())
+        httpSettings.setResponse(eventRequest.accountId.toString(), httpSettingsResponse)
+
+        and: "Cookies header"
+        def uidsCookie = UidsCookie.defaultUidsCookie
+        def cookieHeader = HttpUtil.getCookieHeader(mapper, uidsCookie)
+
+        when: "Sending auction request to PBS where the winner is instantiated"
+        pgPbsService.sendAuctionRequest(bidRequest)
+
+        and: "Sending event request to PBS"
+        pgPbsService.sendEventRequest(eventRequest, cookieHeader)
+
+        then: "PBS hasn't sent a win notification to the User Service"
+        assert userData.requestCount == initialRequestCount
+
+        where:
+        reason         | lineItemId
+        "null"         | null
+        "non-existent" | PBSUtils.randomNumber as String
+    }
+
+    @Unroll
+    def "PBS shouldn't send win notification request to the User Service when #reason cookies header was given"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+
+        and: "Bid response"
+        def bidResponse = BidResponse.getDefaultBidResponse(bidRequest)
+        bidder.setResponse(bidRequest.id, bidResponse)
+
+        and: "Planner Mock line items"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(bidRequest.site.publisher.id)
+        def lineItemId = plansResponse.lineItems[0].lineItemId
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "Line items are fetched by PBS"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.updateLineItemsRequest)
+
+        and: "Initial win notification request count"
+        def initialRequestCount = userData.requestCount
+
+        and: "Enabled event request"
+        def eventRequest = EventRequest.defaultEventRequest.tap {
+            it.lineItemId = lineItemId
+            analytics = 0
+        }
+
+        and: "Default account response"
+        def httpSettingsResponse = HttpAccountsResponse.getDefaultHttpAccountsResponse(eventRequest.accountId.toString())
+        httpSettings.setResponse(eventRequest.accountId.toString(), httpSettingsResponse)
+
+        when: "Sending auction request to PBS where the winner is instantiated"
+        pgPbsService.sendAuctionRequest(bidRequest)
+
+        and: "Sending event request to PBS"
+        pgPbsService.sendEventRequest(eventRequest, cookieHeader)
+
+        then: "PBS hasn't sent a win notification to the User Service"
+        assert userData.requestCount == initialRequestCount
+
+        where:
+        reason              | cookieHeader
+
+        "empty cookie"      | HttpUtil.getCookieHeader(mapper, new UidsCookie())
+
+        "empty uids cookie" | HttpUtil.getCookieHeader(mapper, UidsCookie.defaultUidsCookie.tap {
+            uids = null
+            tempUIDs = null
+        })
+    }
+}


### PR DESCRIPTION
Add tests for PG bid response, bidder request, user details

Not only those PG tests, but all (also from other PRs) have passed
[WARNING] Tests run: 246, Failures: 0, Errors: 0, Skipped: 10
[INFO] prebid-server ...................................... SUCCESS [06:02 min]