### PR TITLE
Algorix: add Server Region Support

### DIFF
--- a/src/main/java/org/prebid/server/bidder/algorix/AlgorixBidder.java
+++ b/src/main/java/org/prebid/server/bidder/algorix/AlgorixBidder.java
@@ -40,6 +40,7 @@ public class AlgorixBidder implements Bidder<BidRequest> {
             new TypeReference<ExtPrebid<?, ExtImpAlgorix>>() {
             };
 
+    private static final String URL_REGION_MACRO = "{HOST}";
     private static final String URL_SID_MACRO = "{SID}";
     private static final String URL_TOKEN_MACRO = "{TOKEN}";
 
@@ -133,6 +134,27 @@ public class AlgorixBidder implements Bidder<BidRequest> {
     }
 
     /**
+     * get Region Info From Algorix Ext Imp
+     * Default For Global EP, APAC for apse EP, USE for use EP
+     *
+     * @param extImp Algorix Ext Imp
+     * @return Region String
+     */
+    private static String getRegionInfo(ExtImpAlgorix extImp) {
+        if (Objects.isNull(extImp.getRegion())) {
+            return "xyz";
+        }
+        switch (extImp.getRegion()) {
+            case "APAC":
+                return "apac.xyz";
+            case "USE":
+                return "use.xyz";
+            default:
+                return "xyz";
+        }
+    }
+
+    /**
      * Replace url macro
      *
      * @param endpoint endpoint Url
@@ -141,6 +163,7 @@ public class AlgorixBidder implements Bidder<BidRequest> {
      */
     private static String resolveUrl(String endpoint, ExtImpAlgorix extImp) {
         return endpoint
+                .replace(URL_REGION_MACRO, getRegionInfo(extImp))
                 .replace(URL_SID_MACRO, extImp.getSid())
                 .replace(URL_TOKEN_MACRO, extImp.getToken());
     }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/algorix/ExtImpAlgorix.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/algorix/ExtImpAlgorix.java
@@ -20,4 +20,7 @@ public class ExtImpAlgorix {
 
     @JsonProperty("appId")
     String appId;
+
+    @JsonProperty("region")
+    String region;
 }

--- a/src/main/resources/bidder-config/algorix.yaml
+++ b/src/main/resources/bidder-config/algorix.yaml
@@ -1,6 +1,6 @@
 adapters:
   algorix:
-    endpoint: https://xyz.svr-algorix.com/rtb/sa?sid={SID}&token={TOKEN}
+    endpoint: https://{HOST}.svr-algorix.com/rtb/sa?sid={SID}&token={TOKEN}
     meta-info:
       maintainer-email: prebid@algorix.co
       app-media-types:

--- a/src/main/resources/static/bidder-params/algorix.json
+++ b/src/main/resources/static/bidder-params/algorix.json
@@ -21,6 +21,10 @@
     "appId": {
       "type": "string",
       "description": "An ID which identifies this app of the impression"
+    },
+    "region": {
+      "type": "string",
+      "description": "Server region for PBS request, null for global, APAC for SG Region, US for USE Region"
     }
   },
   "required": ["sid", "token"]

--- a/src/test/java/org/prebid/server/bidder/algorix/AlgorixBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/algorix/AlgorixBidderTest.java
@@ -40,7 +40,7 @@ import static org.prebid.server.proto.openrtb.ext.response.BidType.xNative;
  */
 public class AlgorixBidderTest extends VertxTest {
 
-    private static final String ENDPOINT_URL = "https://xyz.svr-algorix.com/rtb/sa?sid={SID}&token={TOKEN}";
+    private static final String ENDPOINT_URL = "https://{HOST}.svr-algorix.com/rtb/sa?sid={SID}&token={TOKEN}";
 
     private AlgorixBidder algorixBidder;
 
@@ -99,7 +99,7 @@ public class AlgorixBidderTest extends VertxTest {
         assertThat(result.getValue())
                 .hasSize(1)
                 .extracting(HttpRequest::getUri)
-                .containsExactly("https://xyz.svr-algorix.com/rtb/sa?sid=testSid&token=testToken");
+                .containsExactly("https://apac.xyz.svr-algorix.com/rtb/sa?sid=testSid&token=testToken");
     }
 
     @Test
@@ -261,7 +261,7 @@ public class AlgorixBidderTest extends VertxTest {
                 .id("123")
                 .banner(Banner.builder().id("banner_id").build())
                 .ext(mapper.valueToTree(ExtPrebid.of(null,
-                        ExtImpAlgorix.of("testSid", "testToken", "testPlacementId", "testAppId")))))
+                        ExtImpAlgorix.of("testSid", "testToken", "testPlacementId", "testAppId", "APAC")))))
                 .build();
     }
 

--- a/src/test/resources/org/prebid/server/it/openrtb2/algorix/test-algorix-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/algorix/test-algorix-bid-request.json
@@ -13,7 +13,8 @@
           "sid": "testSid",
           "token": "testToken",
           "placementId": "testPlacementId",
-          "appId": "testAppId"
+          "appId": "testAppId",
+          "region": "APAC"
         }
       }
     }

--- a/src/test/resources/org/prebid/server/it/openrtb2/algorix/test-auction-algorix-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/algorix/test-auction-algorix-request.json
@@ -13,7 +13,8 @@
           "sid": "testSid",
           "token": "testToken",
           "placementId": "testPlacementId",
-          "appId": "testAppId"
+          "appId": "testAppId",
+          "region": "APAC"
         }
       }
     }


### PR DESCRIPTION
Add Server Region Support:
* add region in ext.bidder: APAC for request to SG EP, USE for request to US EP, other for request to Global EP

The same with PBS-Go: https://github.com/prebid/prebid-server/pull/2096