### PR TITLE
AMX Bid Adapter Config: Set AMX vendor ID to 737

### DIFF
--- a/src/main/resources/bidder-config/amx.yaml
+++ b/src/main/resources/bidder-config/amx.yaml
@@ -10,7 +10,7 @@ adapters:
         - banner
         - video
       supported-vendors:
-      vendor-id: 0
+      vendor-id: 737
     usersync:
       url: https://prebid.a-mo.net/cchain/0?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&cb=
       redirect-url: /setuid?bidder=amx&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&uid=


### PR DESCRIPTION
The AMX adapter config is set to have "vendor-id: 0" -- this updates the ID to 737, to match TCF/IAB Europe and "prebid-server" (https://github.com/prebid/prebid-server/blob/master/static/bidder-info/amx.yaml)