### PR TITLE
Fix PG intersects expression to avoid NPE

### DIFF
--- a/src/main/java/org/prebid/server/deals/targeting/interpret/Intersects.java
+++ b/src/main/java/org/prebid/server/deals/targeting/interpret/Intersects.java
@@ -22,7 +22,8 @@ public abstract class Intersects<T> implements TerminalExpression {
 
     @Override
     public boolean matches(RequestContext context) {
-        return !Collections.disjoint(values, lookupActualValues(context));
+        final List<T> actualValues = lookupActualValues(context);
+        return actualValues != null && !Collections.disjoint(values, actualValues);
     }
 
     protected abstract List<T> lookupActualValues(RequestContext context);

--- a/src/main/java/org/prebid/server/deals/targeting/interpret/IntersectsStrings.java
+++ b/src/main/java/org/prebid/server/deals/targeting/interpret/IntersectsStrings.java
@@ -16,7 +16,8 @@ public class IntersectsStrings extends Intersects<String> {
 
     @Override
     public List<String> lookupActualValues(RequestContext context) {
-        return toLowerCase(context.lookupStrings(category));
+        final List<String> values = context.lookupStrings(category);
+        return values != null ? toLowerCase(values) : null;
     }
 
     private static List<String> toLowerCase(List<String> values) {

--- a/src/test/java/org/prebid/server/deals/targeting/interpret/IntersectsIntegersTest.java
+++ b/src/test/java/org/prebid/server/deals/targeting/interpret/IntersectsIntegersTest.java
@@ -62,4 +62,13 @@ public class IntersectsIntegersTest {
         // when and then
         assertThat(expression.matches(context)).isFalse();
     }
+
+    @Test
+    public void matchesShouldReturnFalseWhenActualValueIsNotDefined() {
+        // given
+        willReturn(null).given(context).lookupIntegers(any());
+
+        // when and then
+        assertThat(expression.matches(context)).isFalse();
+    }
 }

--- a/src/test/java/org/prebid/server/deals/targeting/interpret/IntersectsSizesTest.java
+++ b/src/test/java/org/prebid/server/deals/targeting/interpret/IntersectsSizesTest.java
@@ -63,4 +63,13 @@ public class IntersectsSizesTest {
         // when and then
         assertThat(expression.matches(context)).isFalse();
     }
+
+    @Test
+    public void matchesShouldReturnFalseWhenActualValueIsNotDefined() {
+        // given
+        willReturn(null).given(context).lookupSizes(any());
+
+        // when and then
+        assertThat(expression.matches(context)).isFalse();
+    }
 }

--- a/src/test/java/org/prebid/server/deals/targeting/interpret/IntersectsStringsTest.java
+++ b/src/test/java/org/prebid/server/deals/targeting/interpret/IntersectsStringsTest.java
@@ -71,4 +71,13 @@ public class IntersectsStringsTest {
         // when and then
         assertThat(expression.matches(context)).isFalse();
     }
+
+    @Test
+    public void matchesShouldReturnFalseWhenActualValueIsNotDefined() {
+        // given
+        willReturn(null).given(context).lookupStrings(any());
+
+        // when and then
+        assertThat(expression.matches(context)).isFalse();
+    }
 }


### PR DESCRIPTION
This PR fixes `NullPointerException`:
```
ERROR [ntloop-thread-4] o.p.s.handler.openrtb2.AuctionHandler : Critical error while running the auction
java.lang.NullPointerException: null
at org.prebid.server.deals.targeting.interpret.IntersectsStrings.toLowerCase(IntersectsStrings.java:23)
at org.prebid.server.deals.targeting.interpret.IntersectsStrings.lookupActualValues(IntersectsStrings.java:19)
at org.prebid.server.deals.targeting.interpret.Intersects.matches(Intersects.java:25)
at org.prebid.server.deals.targeting.interpret.And.matches(And.java:21)
at org.prebid.server.deals.TargetingService.matchesTargeting(TargetingService.java:70)
```

It was occurred when FPD is not defined in request:
```
"site": {
  "publisher": {
    "id": "ACCOUNT"
  }
```

Until adding site FPD:
```
"site": {
  "publisher": {
    "id": "ACCOUNT"
  },
  "ext": {
    "data": {
      "key1": [ "value" ]
    }
  }
}
```

For PG targeting like:
```
"sfpd.key1": {
    "$intersects": [
        "value",
        "value2"
    ]
}
```