### PR TITLE
Tests: Resend a report when del stats respond with 409

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
@@ -15,6 +15,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 import static java.time.ZoneOffset.UTC
+import static org.mockserver.model.HttpStatusCode.CONFLICT_409
 import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500
 import static org.mockserver.model.HttpStatusCode.OK_200
 import static org.prebid.server.functional.model.deals.lineitem.LineItem.TIME_PATTERN
@@ -441,6 +442,41 @@ class ReportSpec extends BasePgSpec {
 
         then: "PBS for the second time sends the same report to the Delivery Statistics Service"
         PBSUtils.waitUntil { deliveryStatistics.requestCount == initialRequestCount + 2 }
+    }
+
+    def "PBS shouldn't save reports for later sending when Delivery Statistics response is Conflict 409"() {
+        given: "Bid request"
+        def bidRequest = BidRequest.defaultBidRequest
+        def accountId = bidRequest.site.publisher.id
+
+        and: "Initial Delivery Statistics Service request count"
+        def initialRequestCount = deliveryStatistics.requestCount
+
+        and: "Set Planner response to return 1 line item"
+        def plansResponse = PlansResponse.getDefaultPlansResponse(accountId)
+        generalPlanner.initPlansResponse(plansResponse)
+
+        and: "PBS requests Planner line items"
+        updateLineItemsAndWait()
+
+        and: "PBS generates delivery report batch"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.createReportRequest)
+
+        and: "Delivery Statistics Service response is set to return a Conflict status code"
+        deliveryStatistics.reset()
+        deliveryStatistics.setResponse(CONFLICT_409)
+
+        when: "PBS is requested to send a report to Delivery Statistics"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
+
+        then: "PBS sends a report to Delivery Statistics"
+        PBSUtils.waitUntil { deliveryStatistics.requestCount == initialRequestCount + 1 }
+
+        and: "PBS is requested to send a report to Delivery Statistics for the second time"
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
+
+        then: "PBS doesn't request Delivery Statistics Service for the second time"
+        assert deliveryStatistics.requestCount == initialRequestCount + 1
     }
 
     def "PBS should change active delivery plan when the current plan lifetime expires"() {


### PR DESCRIPTION
Add test to cover PBS doesn't resend a report when del stats responses with 409