### PR TITLE
Workflow: Add Java distribution name to the workflow

### DIFF
--- a/.github/workflows/pr-functional-tests.yml
+++ b/.github/workflows/pr-functional-tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           cache: 'maven'
           java-version: ${{ matrix.java }}
 

--- a/.github/workflows/pr-java-ci.yml
+++ b/.github/workflows/pr-java-ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           cache: 'maven'
           java-version: ${{ matrix.java }}
 


### PR DESCRIPTION
Adding Temurin as a Java distribution as this is now a mandatory field. Temurin is an old AdoptOpenJDK and is a part of the Eclipse foundation.