### PR TITLE
Fix failing PG alert spec test

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/pg/AlertSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/AlertSpec.groovy
@@ -5,7 +5,6 @@ import org.prebid.server.functional.model.mock.services.generalplanner.PlansResp
 import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
 import org.prebid.server.functional.util.HttpUtil
 import org.prebid.server.functional.util.PBSUtils
-import spock.lang.Ignore
 
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -33,7 +32,6 @@ class AlertSpec extends BasePgSpec {
     private static final String PBS_DELIVERY_CLIENT_ERROR = "pbs-delivery-stats-client-error"
     private static final Integer DEFAULT_ALERT_PERIOD = 15
 
-    @Ignore
     def "PBS should send alert request when the threshold is reached"() {
         given: "Changed Planner Register endpoint response to return bad status code"
         generalPlanner.initRegisterResponse(NOT_FOUND_404)


### PR DESCRIPTION
Test failure in 'AlertSpec.PBS should send alert request when the threshold is reached' is not reproduced on a local machine. Testing it here to find out the reason and fix it.
EDIT: it looks like that is some bug with Awaitility when it doesn't execute Groovy closures, decided to replace awaitility waiter with a plain while loop and sleep().