### PR TITLE
AmpSpec fix flaky test

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/AmpSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/AmpSpec.groovy
@@ -1,5 +1,7 @@
 package org.prebid.server.functional.tests
 
+import io.vertx.core.logging.Logger
+import io.vertx.core.logging.LoggerFactory
 import org.prebid.server.functional.model.db.StoredRequest
 import org.prebid.server.functional.model.db.StoredResponse
 import org.prebid.server.functional.model.request.amp.AmpRequest
@@ -17,6 +19,7 @@ class AmpSpec extends BaseSpec {
 
     private static final int DEFAULT_TIMEOUT = getRandomTimeout()
     private static final String PBS_VERSION_HEADER = "pbs-java/$PBS_VERSION"
+    private static final Logger logger = LoggerFactory.getLogger(AmpSpec.class)
 
     @Shared
     PrebidServerService prebidServerService = pbsServiceFactory.getService(["auction.max-timeout-ms"    : MAX_TIMEOUT as String,
@@ -287,7 +290,9 @@ class AmpSpec extends BaseSpec {
         def ampResponse = pbsService.sendAmpRequest(ampRequest)
 
         then: "Actual bid request ID should be different from incoming bid request id"
-        def bidderRequest = bidder.getBidderRequest(ampResponse.ext?.debug?.resolvedRequest?.id)
+        logger.info(String.format("AmpSpec after request - ampResponse.ext?.debug?.resolvedRequest?.id = %s",
+                ampResponse.ext?.debug?.resolvedRequest?.id))
+        def bidderRequest = bidder.getBidderRequest("ampResponse.ext?.debug?.resolvedRequest?.id")
         assert bidderRequest.id != bidRequestId
 
         where:


### PR DESCRIPTION
Trying to figure out why this test is failing.

```
java.lang.IllegalStateException: Expecting exactly 1 bidder call. Got 0
	at org.prebid.server.functional.tests.AmpSpec.PBS should generate UUID for BidRequest id and merge StoredRequest when generate-storedrequest-bidrequest-id = #generateBidRequestId(AmpSpec.groovy:290)
```