### PR TITLE
Fix JDBC connection timeout error

### DIFF
--- a/src/test/resources/org/prebid/server/functional/db_schema.sql
+++ b/src/test/resources/org/prebid/server/functional/db_schema.sql
@@ -46,3 +46,6 @@ CREATE TABLE stored_responses
     storedAuctionResponse varchar(1024),
     storedBidResponse varchar(1024)
 );
+
+-- set session wait timeout to 1 minute
+SET SESSION wait_timeout = 60000;


### PR DESCRIPTION
Fix for:

> java.sql.SQLException: An attempt by a client to checkout a Connection has timed out

when PBS containers for functional tests execution are failing to start which occurs when executing functional tests on slow devices.
The default MySQL wait timeout is 28s and is increased to 60s in that PR.