### PR TITLE
Bidders: Fix missing equals in sync `redirect-url`

### DIFF
--- a/src/main/resources/bidder-config/richaudience.yaml
+++ b/src/main/resources/bidder-config/richaudience.yaml
@@ -13,7 +13,7 @@ adapters:
       vendor-id: 108
     usersync:
       url: https://sync.richaudience.com/74889303289e27f327ad0c6de7be7264/?consentString={{gdpr_consent}}&r=
-      redirect-url: /setuid?bidder=richaudience&gdpr={{gdpr}}&gdpr_consent{{gdpr_consent}}&us_privacy={{us_privacy}}&uid=[PDID]
+      redirect-url: /setuid?bidder=richaudience&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&uid=[PDID]
       cookie-family-name: richaudience
       type: iframe
       support-cors: false

--- a/src/main/resources/bidder-config/smartrtb.yaml
+++ b/src/main/resources/bidder-config/smartrtb.yaml
@@ -13,7 +13,7 @@ adapters:
       vendor-id: 0
     usersync:
       url: https://market-global.smrtb.com/sync/all?nid=smartrtb&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&rr=
-      redirect-url: /setuid?bidder=smartrtb&gdpr={{gdpr}}&gdpr_consent{{gdpr_consent}}&us_privacy={{us_privacy}}&uid={XID}
+      redirect-url: /setuid?bidder=smartrtb&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&uid={XID}
       cookie-family-name: smartrtb
       type: redirect
       support-cors: false


### PR DESCRIPTION
It was pointed out to us that we were missing an equal sign in the /setuid call