### PR TITLE
Connectad: change usersync type

### DIFF
--- a/src/main/resources/bidder-config/connectad.yaml
+++ b/src/main/resources/bidder-config/connectad.yaml
@@ -13,5 +13,5 @@ adapters:
       url: https://cdn.connectad.io/connectmyusers.php?gdpr={{gdpr}}&consent={{gdpr_consent}}&us_privacy={{us_privacy}}&cb=
       redirect-url: /setuid?bidder=connectad&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&&us_privacy={{us_privacy}}&uid=
       cookie-family-name: connectad
-      type: redirect
+      type: iframe
       support-cors: false


### PR DESCRIPTION
Found that connect ad's sync is an iframe, not a redirect. 