### PR TITLE
Fix integration flaky tests

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/testcontainers/container/PrebidServerContainer.groovy
+++ b/src/test/groovy/org/prebid/server/functional/testcontainers/container/PrebidServerContainer.groovy
@@ -10,7 +10,7 @@ import static org.prebid.server.functional.testcontainers.PbsConfig.DEFAULT_ENV
 
 class PrebidServerContainer extends GenericContainer<PrebidServerContainer> {
 
-    public static final int PROMETHEUS_PORT = 8070
+    private static final int PROMETHEUS_PORT = 8070
     private static final int DEFAULT_PORT = 8080
     private static final int DEFAULT_ADMIN_PORT = 8060
     private static final int DEFAULT_DEBUG_PORT = 8000
@@ -27,6 +27,7 @@ class PrebidServerContainer extends GenericContainer<PrebidServerContainer> {
         super(PBS_DOCKER_IMAGE_NAME)
         withExposedPorts(PORT, DEBUG_PORT, ADMIN_PORT, PROMETHEUS_PORT)
         withFixedPorts()
+        withStartupAttempts(3)
         waitingFor(Wait.forHttp("/status")
                        .forPort(PORT)
                        .forStatusCode(200))

--- a/src/test/groovy/org/prebid/server/functional/tests/pg/AlertSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/AlertSpec.groovy
@@ -5,6 +5,7 @@ import org.prebid.server.functional.model.mock.services.generalplanner.PlansResp
 import org.prebid.server.functional.model.request.dealsupdate.ForceDealsUpdateRequest
 import org.prebid.server.functional.util.HttpUtil
 import org.prebid.server.functional.util.PBSUtils
+import spock.lang.Retry
 
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -32,6 +33,7 @@ class AlertSpec extends BasePgSpec {
     private static final String PBS_DELIVERY_CLIENT_ERROR = "pbs-delivery-stats-client-error"
     private static final Integer DEFAULT_ALERT_PERIOD = 15
 
+    @Retry(exceptions = { IllegalStateException.class })
     def "PBS should send alert request when the threshold is reached"() {
         given: "Changed Planner Register endpoint response to return bad status code"
         generalPlanner.initRegisterResponse(NOT_FOUND_404)

--- a/src/test/groovy/org/prebid/server/functional/tests/pg/AlertSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/AlertSpec.groovy
@@ -33,7 +33,7 @@ class AlertSpec extends BasePgSpec {
     private static final String PBS_DELIVERY_CLIENT_ERROR = "pbs-delivery-stats-client-error"
     private static final Integer DEFAULT_ALERT_PERIOD = 15
 
-    @Retry(exceptions = { IllegalStateException.class })
+    @Retry(exceptions = [IllegalStateException.class])
     def "PBS should send alert request when the threshold is reached"() {
         given: "Changed Planner Register endpoint response to return bad status code"
         generalPlanner.initRegisterResponse(NOT_FOUND_404)


### PR DESCRIPTION
In this PR trying to resolve the next exceptions
- org.testcontainers.containers.ContainerLaunchException: Container startup failed
- AlertSpec.PBS should send alert request when the threshold is reached Multiple Failures (4 failures)
	org.spockframework.runtime.ConditionFailedWithExceptionError: Condition failed with Exception:
PBSUtils.waitUntil { alert.requestCount == initialRequestCount + 2 }