### PR TITLE
Enable endpoint-compression for mobilefuse adapter

### DIFF
--- a/src/main/resources/bidder-config/mobilefuse.yaml
+++ b/src/main/resources/bidder-config/mobilefuse.yaml
@@ -1,6 +1,7 @@
 adapters:
   mobilefuse:
     endpoint: http://mfx.mobilefuse.com/openrtb?pub_id=
+    endpoint-compression: gzip
     meta-info:
       maintainer-email: prebid@mobilefuse.com
       app-media-types:


### PR DESCRIPTION
We will want gzip for Go as well. Thanks!