### PR TITLE
OneTag: enable endpoint-compression

### DIFF
--- a/src/main/resources/bidder-config/onetag.yaml
+++ b/src/main/resources/bidder-config/onetag.yaml
@@ -1,6 +1,7 @@
 adapters:
   onetag:
     endpoint: https://prebid-server.onetag-sys.com/prebid-server/{{publisherId}}
+    endpoint-compression: gzip
     meta-info:
       maintainer-email: devops@onetag.com
       app-media-types:


### PR DESCRIPTION
We would like to add the same compression config in PBS-Go.