### PR TITLE
Dependencies: Update base docker jdk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM amazoncorretto:17
 
 WORKDIR /app/prebid-server
 


### PR DESCRIPTION
Unfortunately official OpenJDK image is now deprecated as per https://hub.docker.com/_/openjdk