### PR TITLE
Add string support to UID

### DIFF
--- a/src/main/resources/static/bidder-params/visx.json
+++ b/src/main/resources/static/bidder-params/visx.json
@@ -5,7 +5,8 @@
   "type": "object",
   "properties": {
     "uid": {
-      "type": "integer",
+      "type": ["integer", "string"],
+      "pattern": "^\\d+$",
       "description": "An ID which identifies this placement of the impression"
     },
     "size": {
@@ -18,7 +19,5 @@
       "description": "An array of two integer containing the dimension"
     }
   },
-  "required": [
-    "uid"
-  ]
+  "required": ["uid"]
 }

--- a/src/test/java/org/prebid/server/validation/BidderParamValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/BidderParamValidatorTest.java
@@ -47,6 +47,7 @@ public class BidderParamValidatorTest extends VertxTest {
     private static final String OPENX = "openx";
     private static final String EPLANNING = "eplanning";
     private static final String BEACHFRONT = "beachfront";
+    private static final String VISX = "visx";
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -68,7 +69,8 @@ public class BidderParamValidatorTest extends VertxTest {
                 FACEBOOK,
                 OPENX,
                 EPLANNING,
-                BEACHFRONT)));
+                BEACHFRONT,
+                VISX)));
         given(bidderCatalog.bidderInfoByName(anyString())).willReturn(givenBidderInfo());
         given(bidderCatalog.bidderInfoByName(eq(APPNEXUS_ALIAS))).willReturn(givenBidderInfo(APPNEXUS));
 
@@ -380,6 +382,33 @@ public class BidderParamValidatorTest extends VertxTest {
         // then
         assertThat(result).isEqualTo(ResourceUtil.readFromClasspath(
                 "org/prebid/server/validation/schema//valid/test-schemas.json"));
+    }
+
+    @Test
+    public void validateShouldReturnValidationMessagesWhenVisxUidNotValid() {
+        // given
+        final JsonNode node = mapper.createObjectNode().put("uid", "1a2b3c");
+
+        // when
+        final Set<String> messages = bidderParamValidator.validate(VISX, node);
+
+        // then
+        assertThat(messages.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void validateShouldReturnNoValidationMessagesWhenVisxUidValid() {
+        // given
+        final JsonNode stringUidNode = mapper.createObjectNode().put("uid", "123");
+        final JsonNode integerUidNode = mapper.createObjectNode().put("uid", 567);
+
+        // when
+        final Set<String> messagesStringUid = bidderParamValidator.validate(VISX, stringUidNode);
+        final Set<String> messagesIntegerUid = bidderParamValidator.validate(VISX, integerUidNode);
+
+        // then
+        assertThat(messagesStringUid).isEmpty();
+        assertThat(messagesIntegerUid).isEmpty();
     }
 
     private static BidderInfo givenBidderInfo(String aliasOf) {


### PR DESCRIPTION
Updating UID to support both integer and string.

- Updated schema to support string and integer types
- Added regex to schema for UID format validation
- Added schema validation tests for VISX