### PR TITLE
Fix `ССE` in `OrtbTypesResolver`

### DIFF
--- a/src/main/java/org/prebid/server/auction/OrtbTypesResolver.java
+++ b/src/main/java/org/prebid/server/auction/OrtbTypesResolver.java
@@ -210,7 +210,11 @@ public class OrtbTypesResolver {
                                        String containerName,
                                        String action) {
 
-        if (fieldNode == null || fieldNode.isNull() || fieldNode.isTextual()) {
+        if (fieldNode == null || fieldNode.isNull()) {
+            return null;
+        }
+
+        if (fieldNode.isTextual()) {
             return (TextNode) fieldNode;
         }
 


### PR DESCRIPTION
Fixed `ClassCastException` while reading `TextNode` fields in `OrtbTypesResolver`.