### PR TITLE
Test: Fix `GGP` flaky functional tests

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/GppAuctionSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/GppAuctionSpec.groovy
@@ -4,12 +4,13 @@ import org.prebid.server.functional.model.request.auction.BidRequest
 import org.prebid.server.functional.model.request.auction.Regs
 import org.prebid.server.functional.model.request.auction.User
 import org.prebid.server.functional.model.response.auction.ErrorType
-import org.prebid.server.functional.tests.BaseSpec
 import org.prebid.server.functional.util.PBSUtils
 import org.prebid.server.functional.util.privacy.CcpaConsent
 import org.prebid.server.functional.util.privacy.TcfConsent
 import org.prebid.server.functional.util.privacy.gpp.TcfEuV2Consent
 import org.prebid.server.functional.util.privacy.gpp.UspV1Consent
+import spock.lang.IgnoreRest
+import spock.lang.RepeatUntilFailure
 
 import static org.prebid.server.functional.model.request.GppSectionId.TCF_EU_V2
 import static org.prebid.server.functional.model.request.GppSectionId.USP_V1
@@ -18,7 +19,7 @@ import static org.prebid.server.functional.util.privacy.CcpaConsent.Signal.NOT_E
 import static org.prebid.server.functional.util.privacy.TcfConsent.GENERIC_VENDOR_ID
 import static org.prebid.server.functional.util.privacy.TcfConsent.PurposeId.BASIC_ADS
 
-class GppAuctionSpec extends BaseSpec {
+class GppAuctionSpec extends PrivacyBaseSpec {
 
     def "PBS should populate gdpr to 1 when regs.gdpr is not specified and gppSid contains 2"() {
         given: "Default bid request with gppSid and without gdpr"
@@ -158,7 +159,7 @@ class GppAuctionSpec extends BaseSpec {
         }
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bid response should contain warning"
         assert response.ext?.warnings[ErrorType.PREBID]?.collect { it.code } == [999]

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/GppAuctionSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/GppAuctionSpec.groovy
@@ -9,8 +9,6 @@ import org.prebid.server.functional.util.privacy.CcpaConsent
 import org.prebid.server.functional.util.privacy.TcfConsent
 import org.prebid.server.functional.util.privacy.gpp.TcfEuV2Consent
 import org.prebid.server.functional.util.privacy.gpp.UspV1Consent
-import spock.lang.IgnoreRest
-import spock.lang.RepeatUntilFailure
 
 import static org.prebid.server.functional.model.request.GppSectionId.TCF_EU_V2
 import static org.prebid.server.functional.model.request.GppSectionId.USP_V1
@@ -29,7 +27,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        def bidResponse = defaultPbsService.sendAuctionRequest(bidRequest)
+        def bidResponse = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Resolved request regs should contain regs.gdpr and gppSid from request"
         def regs = bidResponse.ext.debug.resolvedRequest.regs
@@ -49,7 +47,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bidder request should contain regs.gdpr and gppSid from request"
         def bidderRequest = bidder.getBidderRequest(bidRequest.id)
@@ -67,7 +65,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bid response should contain warning"
         assert response.ext?.warnings[ErrorType.PREBID]?.collect { it.code } == [999]
@@ -90,7 +88,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bid response should contain warning"
         assert response.ext?.warnings[ErrorType.PREBID]?.collect { it.code } == [999]
@@ -115,7 +113,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bid response should contain warning"
         assert response.ext?.warnings[ErrorType.PREBID]?.collect { it.code } == [999]
@@ -137,7 +135,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bidder request should contain user.consent from regs.gpp"
         def bidderRequest = bidder.getBidderRequest(bidRequest.id)
@@ -181,7 +179,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bidder request should contain regs.usPrivacy from regs.gpp"
         def bidderRequest = bidder.getBidderRequest(bidRequest.id)
@@ -198,7 +196,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bidder request shouldn't contain user and regs.usPrivacy from regs.gpp"
         def bidderRequest = bidder.getBidderRequest(bidRequest.id)
@@ -220,7 +218,7 @@ class GppAuctionSpec extends PrivacyBaseSpec {
         }
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bid response should contain warning"
         assert response.ext?.warnings[ErrorType.PREBID]?.collect { it.code } == [999]


### PR DESCRIPTION
Error message: 
`PBS should emit warning when gppSid contains 2, gpp is TCF2-EU and regs.gpp and user.consent are different`  
Time elapsed: 0.501 s  <<< ERROR! java.lang.IllegalStateException: Expecting exactly 1 bidder call. Got 0