### PR TITLE
Test: Fix `PG` flaky functional tests

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
@@ -42,7 +42,7 @@ class ReportSpec extends BasePgSpec {
         pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
 
         then: "Delivery Statistics Service request count is not changed"
-        assert deliveryStatistics.requestCount == initialRequestCount
+        PBSUtils.waitUntil { deliveryStatistics.requestCount == initialRequestCount }
     }
 
     def "PBS shouldn't send delivery statistics when delivery report batch is created but doesn't have reports to send"() {
@@ -56,7 +56,7 @@ class ReportSpec extends BasePgSpec {
         pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
 
         then: "Delivery Statistics Service request count is not changed"
-        assert deliveryStatistics.requestCount == initialRequestCount
+        PBSUtils.waitUntil { deliveryStatistics.requestCount == initialRequestCount }
     }
 
     def "PBS should send a report request with appropriate headers"() {


### PR DESCRIPTION
Error message:
```
	org.spockframework.runtime.SpockComparisonFailure: Condition not satisfied:

deliveryStatistics.requestCount == initialRequestCount
|                  |            |  |
|                  1            |  0
|                               false
<org.prebid.server.functional.testcontainers.scaffolding.pg.DeliveryStatistics@62041909 mockServerClient=org.mockserver.client.MockServerClient@e0989ce endpoint=/deals/report/delivery>
```
                                                                                                                                                                               