### PR TITLE
Core: Telemetry jmx support

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
@@ -27,6 +27,7 @@ public class VertxConfiguration {
                 @Value("${vertx.enable-per-client-endpoint-metrics}") boolean enablePerClientEndpointMetrics) {
         final DropwizardMetricsOptions metricsOptions = new DropwizardMetricsOptions()
                 .setEnabled(true)
+                .setJmxEnabled(true)
                 .setRegistryName(MetricsConfiguration.METRIC_REGISTRY_NAME);
         if (enablePerClientEndpointMetrics) {
             metricsOptions.addMonitoredHttpClientEndpoint(new Match().setValue(".*").setType(MatchType.REGEX));

--- a/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
@@ -25,7 +25,7 @@ public class VertxConfiguration {
     @Bean
     Vertx vertx(@Value("${vertx.worker-pool-size}") int workerPoolSize,
                 @Value("${vertx.enable-per-client-endpoint-metrics}") boolean enablePerClientEndpointMetrics,
-                @Value("${metrics.jmxEnabled}") boolean jmxEnabled) {
+                @Value("${metrics.jmx.enabled}") boolean jmxEnabled) {
         final DropwizardMetricsOptions metricsOptions = new DropwizardMetricsOptions()
                 .setEnabled(true)
                 .setJmxEnabled(jmxEnabled)

--- a/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
@@ -24,10 +24,11 @@ public class VertxConfiguration {
 
     @Bean
     Vertx vertx(@Value("${vertx.worker-pool-size}") int workerPoolSize,
-                @Value("${vertx.enable-per-client-endpoint-metrics}") boolean enablePerClientEndpointMetrics) {
+                @Value("${vertx.enable-per-client-endpoint-metrics}") boolean enablePerClientEndpointMetrics,
+                @Value("${metrics.jmxEnabled}") boolean jmxEnabled) {
         final DropwizardMetricsOptions metricsOptions = new DropwizardMetricsOptions()
                 .setEnabled(true)
-                .setJmxEnabled(true)
+                .setJmxEnabled(jmxEnabled)
                 .setRegistryName(MetricsConfiguration.METRIC_REGISTRY_NAME);
         if (enablePerClientEndpointMetrics) {
             metricsOptions.addMonitoredHttpClientEndpoint(new Match().setValue(".*").setType(MatchType.REGEX));

--- a/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
@@ -108,11 +108,11 @@ public class MetricsConfiguration {
     }
 
     @Bean
-    MetricRegistry metricRegistry() {
+    MetricRegistry metricRegistry(@Value("${metrics.jmxEnabled}") boolean jmxEnabled) {
         final boolean alreadyExists = SharedMetricRegistries.names().contains(METRIC_REGISTRY_NAME);
         final MetricRegistry metricRegistry = SharedMetricRegistries.getOrCreate(METRIC_REGISTRY_NAME);
 
-        if (!alreadyExists) {
+        if (!alreadyExists && jmxEnabled) {
             metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
             metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
         }

--- a/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
@@ -108,7 +108,7 @@ public class MetricsConfiguration {
     }
 
     @Bean
-    MetricRegistry metricRegistry(@Value("${metrics.jmxEnabled}") boolean jmxEnabled) {
+    MetricRegistry metricRegistry(@Value("${metrics.jmx.enabled}") boolean jmxEnabled) {
         final boolean alreadyExists = SharedMetricRegistries.names().contains(METRIC_REGISTRY_NAME);
         final MetricRegistry metricRegistry = SharedMetricRegistries.getOrCreate(METRIC_REGISTRY_NAME);
 

--- a/src/main/resources/metrics-config/metrics.yaml
+++ b/src/main/resources/metrics-config/metrics.yaml
@@ -2,3 +2,4 @@ metrics:
   metricType: flushingCounter
   accounts:
     default-verbosity: none
+  jmxEnabled: true

--- a/src/main/resources/metrics-config/metrics.yaml
+++ b/src/main/resources/metrics-config/metrics.yaml
@@ -2,4 +2,5 @@ metrics:
   metricType: flushingCounter
   accounts:
     default-verbosity: none
-  jmxEnabled: true
+  jmx:
+    enabled: false


### PR DESCRIPTION
Removed 'metricRegistry' presence check, forced usage of JVM-related metrics set, enabled JMX for Vertx metrics config.