### PR TITLE
Tests: fix connection exhaustion issue

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/testcontainers/Dependencies.groovy
+++ b/src/test/groovy/org/prebid/server/functional/testcontainers/Dependencies.groovy
@@ -16,6 +16,7 @@ class Dependencies {
     static final Network network = Network.newNetwork()
 
     static final MySQLContainer mysqlContainer = new MySQLContainer<>("mysql:8.0.30")
+            .withConfigurationOverride("org/prebid/server/functional/")
             .withDatabaseName("prebid")
             .withUsername("prebid")
             .withPassword("prebid")

--- a/src/test/groovy/org/prebid/server/functional/testcontainers/PbsServiceFactory.groovy
+++ b/src/test/groovy/org/prebid/server/functional/testcontainers/PbsServiceFactory.groovy
@@ -19,9 +19,11 @@ class PbsServiceFactory {
         this.networkServiceContainer = networkServiceContainer
     }
 
-    PrebidServerService getService(Map<String, String> config) {
+    static PrebidServerService getService(Map<String, String> config) {
         if (containers.containsKey(config)) {
-            return new PrebidServerService(containers.get(config))
+            def container = containers.get(config)
+            container.refresh()
+            return new PrebidServerService(container)
         } else {
             if (containers.size() == 1 && MAX_CONTAINER_COUNT == 1) {
                 def container = containers.entrySet().first()

--- a/src/test/groovy/org/prebid/server/functional/testcontainers/container/NetworkServiceContainer.groovy
+++ b/src/test/groovy/org/prebid/server/functional/testcontainers/container/NetworkServiceContainer.groovy
@@ -8,6 +8,7 @@ class NetworkServiceContainer extends MockServerContainer {
 
     NetworkServiceContainer(String version) {
         super(DockerImageName.parse("mockserver/mockserver:mockserver-$version"))
+        withCommand("-serverPort $PORT -logLevel WARN")
     }
 
     String getHostAndPort() {

--- a/src/test/groovy/org/prebid/server/functional/testcontainers/container/PrebidServerContainer.groovy
+++ b/src/test/groovy/org/prebid/server/functional/testcontainers/container/PrebidServerContainer.groovy
@@ -96,6 +96,14 @@ class PrebidServerContainer extends GenericContainer<PrebidServerContainer> {
                 .replace("]", "_")
     }
 
+    // This is a workaround for cases when container is killed mid-test due to OOM
+    void refresh() {
+        if (!running) {
+            stop()
+            start()
+        }
+    }
+
     @Override
     void close() {
         super.close()

--- a/src/test/groovy/org/prebid/server/functional/tests/AuctionSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/AuctionSpec.groovy
@@ -80,7 +80,7 @@ class AuctionSpec extends BaseSpec {
         and: "Initial metric count is taken"
         def accountId = bidRequest.site.publisher.id
         def fullMetricName = "account.${accountId}.requests.rejected.$metricName" as String
-        def initialMetricCount = getCurrentMetricValue(fullMetricName)
+        def initialMetricCount = getCurrentMetricValue(defaultPbsService, fullMetricName)
 
         when: "Requesting PBS auction"
         defaultPbsService.sendAuctionRequest(bidRequest)
@@ -92,7 +92,7 @@ class AuctionSpec extends BaseSpec {
                 "Invalid request format: Stored request processing failed: Id is not found in storedRequest"
 
         and: "Metric count is updated"
-        assert getCurrentMetricValue(fullMetricName) == initialMetricCount + 1
+        assert getCurrentMetricValue(defaultPbsService, fullMetricName) == initialMetricCount + 1
 
         where:
         metricName               | updateBidRequestClosure

--- a/src/test/groovy/org/prebid/server/functional/tests/BaseSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/BaseSpec.groovy
@@ -23,7 +23,6 @@ abstract class BaseSpec extends Specification implements ObjectMapperWrapper {
     protected static final PbsServiceFactory pbsServiceFactory = new PbsServiceFactory(networkServiceContainer)
     protected static final Bidder bidder = new Bidder(networkServiceContainer)
     protected static final PrebidCache prebidCache = new PrebidCache(networkServiceContainer)
-    protected static final PrebidServerService defaultPbsService = pbsServiceFactory.getService([:])
 
     protected static final HibernateRepositoryService repository = new HibernateRepositoryService(Dependencies.mysqlContainer)
     protected static final AccountDao accountDao = repository.accountDao
@@ -34,6 +33,8 @@ abstract class BaseSpec extends Specification implements ObjectMapperWrapper {
     protected static final int MAX_TIMEOUT = MIN_TIMEOUT + 1000
     private static final int MIN_TIMEOUT = DEFAULT_TIMEOUT
     private static final int DEFAULT_TARGETING_PRECISION = 1
+
+    protected final PrebidServerService defaultPbsService = pbsServiceFactory.getService([:])
 
     def setupSpec() {
         prebidCache.setResponse()
@@ -50,12 +51,12 @@ abstract class BaseSpec extends Specification implements ObjectMapperWrapper {
         PBSUtils.getRandomNumber(MIN_TIMEOUT, MAX_TIMEOUT)
     }
 
-    protected static Number getCurrentMetricValue(PrebidServerService pbsService = defaultPbsService, String name) {
+    protected static Number getCurrentMetricValue(PrebidServerService pbsService, String name) {
         def response = pbsService.sendCollectedMetricsRequest()
         response[name] ?: 0
     }
 
-    protected static void flushMetrics(PrebidServerService pbsService = defaultPbsService) {
+    protected static void flushMetrics(PrebidServerService pbsService) {
         // flushing PBS metrics by receiving collected metrics so that each new test works with a fresh state
         pbsService.sendCollectedMetricsRequest()
     }

--- a/src/test/groovy/org/prebid/server/functional/tests/BidValidationSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/BidValidationSpec.groovy
@@ -192,7 +192,7 @@ class BidValidationSpec extends BaseSpec {
 
     def "PBS should update 'adapter.generic.requests.bid_validation' metric when bid validation error appears"() {
         given: "Initial 'adapter.generic.requests.bid_validation' metric value"
-        def initialMetricValue = getCurrentMetricValue("adapter.generic.requests.bid_validation")
+        def initialMetricValue = getCurrentMetricValue(defaultPbsService, "adapter.generic.requests.bid_validation")
 
         and: "Bid request"
         def bidRequest = BidRequest.defaultBidRequest

--- a/src/test/groovy/org/prebid/server/functional/tests/CacheSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/CacheSpec.groovy
@@ -13,7 +13,7 @@ class CacheSpec extends BaseSpec {
 
     def "PBS should update prebid_cache.creative_size.xml metric when xml creative is received"() {
         given: "Current value of metric prebid_cache.requests.ok"
-        def initialValue = getCurrentMetricValue("prebid_cache.requests.ok")
+        def initialValue = getCurrentMetricValue(defaultPbsService, "prebid_cache.requests.ok")
 
         and: "Default VtrackRequest"
         def accountId = PBSUtils.randomNumber.toString()
@@ -36,7 +36,7 @@ class CacheSpec extends BaseSpec {
 
     def "PBS should update prebid_cache.creative_size.json metric when json creative is received"() {
         given: "Current value of metric prebid_cache.requests.ok"
-        def initialValue = getCurrentMetricValue("prebid_cache.requests.ok")
+        def initialValue = getCurrentMetricValue(defaultPbsService, "prebid_cache.requests.ok")
 
         and: "Default BidRequest with cache, targeting"
         def bidRequest = BidRequest.defaultBidRequest

--- a/src/test/groovy/org/prebid/server/functional/tests/MetricsSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/MetricsSpec.groovy
@@ -13,7 +13,7 @@ import static org.prebid.server.functional.model.config.AccountMetricsVerbosityL
 class MetricsSpec extends BaseSpec {
 
     def setup() {
-        flushMetrics()
+        flushMetrics(defaultPbsService)
     }
 
     def "PBS should not populate account metric when verbosity level is none"() {

--- a/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
@@ -31,7 +31,11 @@ import static org.prebid.server.functional.util.HttpUtil.UUID_REGEX
 class ReportSpec extends BasePgSpec {
 
     def cleanup() {
+        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
         pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
+        deliveryStatistics.reset()
+        PBSUtils.waitUntil { deliveryStatistics.requestCount == 0 }
+        deliveryStatistics.setResponse()
     }
 
     def "PBS shouldn't send delivery statistics when PBS doesn't have reports to send"() {

--- a/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/pg/ReportSpec.groovy
@@ -31,11 +31,7 @@ import static org.prebid.server.functional.util.HttpUtil.UUID_REGEX
 class ReportSpec extends BasePgSpec {
 
     def cleanup() {
-        pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
         pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.invalidateLineItemsRequest)
-        deliveryStatistics.reset()
-        PBSUtils.waitUntil { deliveryStatistics.requestCount == 0 }
-        deliveryStatistics.setResponse()
     }
 
     def "PBS shouldn't send delivery statistics when PBS doesn't have reports to send"() {
@@ -46,7 +42,7 @@ class ReportSpec extends BasePgSpec {
         pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
 
         then: "Delivery Statistics Service request count is not changed"
-        assert deliveryStatistics.requestCount == initialRequestCount
+        PBSUtils.waitUntil { deliveryStatistics.requestCount == initialRequestCount }
     }
 
     def "PBS shouldn't send delivery statistics when delivery report batch is created but doesn't have reports to send"() {
@@ -60,7 +56,7 @@ class ReportSpec extends BasePgSpec {
         pgPbsService.sendForceDealsUpdateRequest(ForceDealsUpdateRequest.sendReportRequest)
 
         then: "Delivery Statistics Service request count is not changed"
-        assert deliveryStatistics.requestCount == initialRequestCount
+        PBSUtils.waitUntil { deliveryStatistics.requestCount == initialRequestCount }
     }
 
     def "PBS should send a report request with appropriate headers"() {

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprAmpSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprAmpSpec.groovy
@@ -23,7 +23,7 @@ import static org.prebid.server.functional.util.privacy.TcfConsent.PurposeId.BAS
 class GdprAmpSpec extends PrivacyBaseSpec {
 
     def setupSpec() {
-        cacheVendorList()
+        cacheVendorList(privacyPbsService)
     }
 
     @PendingFeature
@@ -42,7 +42,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         storedRequestDao.save(storedRequest)
 
         when: "PBS processes amp request"
-        def response = defaultPbsService.sendAmpRequest(ampRequest)
+        def response = privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Response should contain debug log"
         assert response.ext?.debug?.privacy
@@ -83,7 +83,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         storedRequestDao.save(storedRequest)
 
         when: "PBS processes amp request"
-        def response = defaultPbsService.sendAmpRequest(ampRequest)
+        def response = privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Response should contain debug log with error"
         assert response.ext?.debug?.privacy
@@ -118,7 +118,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         storedRequestDao.save(storedRequest)
 
         when: "PBS processes amp request"
-        def response = defaultPbsService.sendAmpRequest(ampRequest)
+        def response = privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Response should contain error"
         assert response.ext?.warnings[PREBID]*.code == [999]
@@ -145,7 +145,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         storedRequestDao.save(storedRequest)
 
         when: "PBS processes amp request"
-        def response = defaultPbsService.sendAmpRequest(ampRequest)
+        def response = privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Response should contain error"
         assert response.ext?.errors[PREBID]*.code == [999]
@@ -169,7 +169,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         storedRequestDao.save(storedRequest)
 
         when: "PBS processes amp request"
-        def response = defaultPbsService.sendAmpRequest(ampRequest)
+        def response = privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Response should contain error"
         assert response.ext?.errors[PREBID]*.code == [999]
@@ -191,7 +191,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         storedRequestDao.save(storedRequest)
 
         when: "PBS processes amp request"
-        def response = defaultPbsService.sendAmpRequest(ampRequest)
+        def response = privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Response should contain error"
         assert response.ext?.warnings[PREBID]*.code == [999]
@@ -249,7 +249,7 @@ class GdprAmpSpec extends PrivacyBaseSpec {
         accountDao.save(account)
 
         when: "PBS processes amp request"
-        defaultPbsService.sendAmpRequest(ampRequest)
+        privacyPbsService.sendAmpRequest(ampRequest)
 
         then: "Bidder request should contain not masked values"
         def bidderRequests = bidder.getBidderRequest(ampStoredRequest.id)

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprAuctionSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprAuctionSpec.groovy
@@ -20,7 +20,7 @@ import static org.prebid.server.functional.util.privacy.TcfConsent.PurposeId.BAS
 class GdprAuctionSpec extends PrivacyBaseSpec {
 
     def setupSpec() {
-        cacheVendorList()
+        cacheVendorList(defaultPbsService)
     }
 
     @PendingFeature

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprAuctionSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprAuctionSpec.groovy
@@ -20,7 +20,7 @@ import static org.prebid.server.functional.util.privacy.TcfConsent.PurposeId.BAS
 class GdprAuctionSpec extends PrivacyBaseSpec {
 
     def setupSpec() {
-        cacheVendorList(defaultPbsService)
+        cacheVendorList(privacyPbsService)
     }
 
     @PendingFeature
@@ -34,7 +34,7 @@ class GdprAuctionSpec extends PrivacyBaseSpec {
         def bidRequest = getGdprBidRequest(validConsentString)
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Response should contain debug log"
         assert response.ext?.debug?.privacy
@@ -70,7 +70,7 @@ class GdprAuctionSpec extends PrivacyBaseSpec {
         def bidRequest = getGdprBidRequest(invalidConsentString)
 
         when: "PBS processes auction request"
-        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+        def response = privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Response should not contain ext.errors"
         assert !response.ext?.errors
@@ -153,7 +153,7 @@ class GdprAuctionSpec extends PrivacyBaseSpec {
         accountDao.save(getAccountWithGdpr(bidRequest.app.publisher.id, gdprConfig))
 
         when: "PBS processes auction request"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bidder request should contain not masked values"
         def bidderRequests = bidder.getBidderRequest(bidRequest.id)
@@ -177,7 +177,7 @@ class GdprAuctionSpec extends PrivacyBaseSpec {
         accountDao.save(getAccountWithGdpr(bidRequest.site.publisher.id, gdprConfig))
 
         when: "PBS processes auction request"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        privacyPbsService.sendAuctionRequest(bidRequest)
 
         then: "Bidder request should contain not masked values"
         def bidderRequests = bidder.getBidderRequest(bidRequest.id)

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/PrivacyBaseSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/PrivacyBaseSpec.groovy
@@ -93,7 +93,7 @@ abstract class PrivacyBaseSpec extends BaseSpec {
         geo
     }
 
-    protected static void cacheVendorList(PrebidServerService pbsService = defaultPbsService) {
+    protected static void cacheVendorList(PrebidServerService pbsService) {
         def isVendorListCachedClosure = {
             def validConsentString = new TcfConsent.Builder()
                     .setPurposesLITransparency(BASIC_ADS)

--- a/src/test/resources/org/prebid/server/functional/mysql_config_override.cnf
+++ b/src/test/resources/org/prebid/server/functional/mysql_config_override.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_connections=1024


### PR DESCRIPTION
This PR fixes the issue of connections being exhausted during test runs. There is actually 2 issues which this PR tries to solve:
- mySQL container being out of connections due to not closing them after PBS shuts down, which leads to a quite fast exhaustion during runs with high container count;
- MockServer dying mid-run most probably due to bloating with logs