### PR TITLE
ORBIDDER: BidType detection, web-sites new types

### DIFF
--- a/src/main/java/org/prebid/server/bidder/orbidder/OrbidderBidder.java
+++ b/src/main/java/org/prebid/server/bidder/orbidder/OrbidderBidder.java
@@ -3,6 +3,7 @@ package org.prebid.server.bidder.orbidder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
+import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
 import org.apache.commons.lang3.StringUtils;
@@ -103,14 +104,16 @@ public class OrbidderBidder implements Bidder<BidRequest> {
             return Result.withError(BidderError.badServerResponse(e.getMessage()));
         }
 
+        final List<BidderError> errors = new ArrayList<>();
         final List<BidderBid> bidderBids = bidResponse.getSeatbid().stream()
                 .filter(Objects::nonNull)
                 .map(SeatBid::getBid)
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
-                .map(bid -> BidderBid.of(bid, BidType.banner, bidResponse.getCur()))
+                .map(bid -> toBidderBid(bid, bidResponse.getCur(), errors))
+                .filter(Objects::nonNull)
                 .toList();
-        return Result.of(bidderBids, Collections.emptyList());
+        return Result.of(bidderBids, errors);
     }
 
     private BidResponse decodeBodyToBidResponse(BidderCall<BidRequest> httpCall) {
@@ -118,6 +121,36 @@ public class OrbidderBidder implements Bidder<BidRequest> {
             return mapper.decodeValue(httpCall.getResponse().getBody(), BidResponse.class);
         } catch (DecodeException e) {
             throw new PreBidException(e.getMessage(), e);
+        }
+    }
+
+    private BidderBid toBidderBid(Bid bid, String cur, List<BidderError> errors) {
+        final BidType bidType;
+        try {
+            bidType = getBidTypeFromMtype(bid.getMtype());
+        } catch (PreBidException e) {
+            errors.add(BidderError.badServerResponse(e.getMessage()));
+            return null;
+        }
+
+        return BidderBid.of(bid, bidType, cur);
+    }
+
+    private static BidType getBidTypeFromMtype(Integer mType) {
+        switch (mType) {
+            case 1 -> {
+                return BidType.banner;
+            }
+            case 2 -> {
+                return BidType.video;
+            }
+            case 3 -> {
+                return BidType.audio;
+            }
+            case 4 -> {
+                return BidType.xNative;
+            }
+            default -> throw new PreBidException("Unsupported mType " + mType);
         }
     }
 }

--- a/src/main/java/org/prebid/server/bidder/orbidder/OrbidderBidder.java
+++ b/src/main/java/org/prebid/server/bidder/orbidder/OrbidderBidder.java
@@ -137,7 +137,7 @@ public class OrbidderBidder implements Bidder<BidRequest> {
     }
 
     private static BidType getBidType(Integer mType) {
-        return switch(mType) {
+        return switch (mType) {
             case 1 -> BidType.banner;
             case 2 -> BidType.video;
             case 3 -> BidType.audio;

--- a/src/main/java/org/prebid/server/bidder/orbidder/OrbidderBidder.java
+++ b/src/main/java/org/prebid/server/bidder/orbidder/OrbidderBidder.java
@@ -127,7 +127,7 @@ public class OrbidderBidder implements Bidder<BidRequest> {
     private BidderBid toBidderBid(Bid bid, String cur, List<BidderError> errors) {
         final BidType bidType;
         try {
-            bidType = getBidTypeFromMtype(bid.getMtype());
+            bidType = getBidType(bid.getMtype());
         } catch (PreBidException e) {
             errors.add(BidderError.badServerResponse(e.getMessage()));
             return null;
@@ -136,21 +136,14 @@ public class OrbidderBidder implements Bidder<BidRequest> {
         return BidderBid.of(bid, bidType, cur);
     }
 
-    private static BidType getBidTypeFromMtype(Integer mType) {
-        switch (mType) {
-            case 1 -> {
-                return BidType.banner;
-            }
-            case 2 -> {
-                return BidType.video;
-            }
-            case 3 -> {
-                return BidType.audio;
-            }
-            case 4 -> {
-                return BidType.xNative;
-            }
+    private static BidType getBidType(Integer mType) {
+        return switch(mType) {
+            case 1 -> BidType.banner;
+            case 2 -> BidType.video;
+            case 3 -> BidType.audio;
+            case 4 -> BidType.xNative;
+
             default -> throw new PreBidException("Unsupported mType " + mType);
-        }
+        };
     }
 }

--- a/src/main/resources/bidder-config/orbidder.yaml
+++ b/src/main/resources/bidder-config/orbidder.yaml
@@ -6,5 +6,7 @@ adapters:
       app-media-types:
         - banner
       site-media-types:
+        - banner
+        - native
       supported-vendors:
       vendor-id: 559

--- a/src/test/resources/org/prebid/server/it/openrtb2/orbidder/test-auction-orbidder-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/orbidder/test-auction-orbidder-response.json
@@ -16,7 +16,8 @@
           },
           "id": "bid_id",
           "impid": "imp_id",
-          "price": 0.01
+          "price": 0.01,
+          "mtype": 1
         }
       ],
       "group": 0,

--- a/src/test/resources/org/prebid/server/it/openrtb2/orbidder/test-orbidder-bid-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/orbidder/test-orbidder-bid-response.json
@@ -12,7 +12,8 @@
           "price": 0.01,
           "ext": {
             "format": "BANNER"
-          }
+          },
+          "mtype": 1
         }
       ]
     }


### PR DESCRIPTION
This PR implements / fixes the "Port PR from PBS-Go: ORBIDDER: enable capability site with media type banner and native" Issue (https://github.com/prebid/prebid-server-java/issues/2515).

We (my team and myself) as developer normally only adjust our GoLang adapter code, but we need as soon as possible the Java Version updated as well. Hopefully it is fine that i did this PR.

Have a nice day
Arne