### PR TITLE
Tests: Fix fluke when timeout message differs in timeout spec

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/TimeoutSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/TimeoutSpec.groovy
@@ -350,8 +350,10 @@ class TimeoutSpec extends BaseSpec {
 
         and: "Bid response should shutdown by timeout from stored request"
         def errors = bidResponse.ext?.errors
-        assert errors[ErrorType.GENERIC]*.code == [1]
-        assert errors[ErrorType.GENERIC]*.message == ["Timeout has been exceeded"]
+        assert errors[ErrorType.GENERIC].any {
+            it.code == 1
+            it.message ==~ /Timeout .*has been exceeded/
+        }
     }
 
     def "PBS should choose min timeout form config for bidder request when in request value lowest that in auction.biddertmax.min"() {


### PR DESCRIPTION
There is a possibility that PBS will return timeout error with message `"Timeout period of %dms has been exceeded"` [here](https://github.com/Lightwood13/prebid-server-java/blob/a53dcbad135bc0397780c665c338a83ac99f6766/src/main/java/org/prebid/server/vertx/http/BasicHttpClient.java#L89) instead of `"Timeout has been exceeded"` which is returned [here](https://github.com/Lightwood13/prebid-server-java/blob/a53dcbad135bc0397780c665c338a83ac99f6766/src/main/java/org/prebid/server/vertx/http/BasicHttpClient.java#L51). This leads to inconsistent behavior in test runs.

This pr fixes test to address this possibility.