### PR TITLE
Vert.X refreshable timers with random jitter

### DIFF
--- a/src/main/java/org/prebid/server/health/DatabaseHealthChecker.java
+++ b/src/main/java/org/prebid/server/health/DatabaseHealthChecker.java
@@ -19,8 +19,8 @@ public class DatabaseHealthChecker extends PeriodicHealthChecker {
 
     private StatusResponse status;
 
-    public DatabaseHealthChecker(Vertx vertx, JDBCClient jdbcClient, long refreshPeriod) {
-        super(vertx, refreshPeriod);
+    public DatabaseHealthChecker(Vertx vertx, JDBCClient jdbcClient, long refreshPeriod, long jitter) {
+        super(vertx, refreshPeriod, jitter);
         this.jdbcClient = Objects.requireNonNull(jdbcClient);
     }
 

--- a/src/main/java/org/prebid/server/health/GeoLocationHealthChecker.java
+++ b/src/main/java/org/prebid/server/health/GeoLocationHealthChecker.java
@@ -24,11 +24,12 @@ public class GeoLocationHealthChecker extends PeriodicHealthChecker {
 
     public GeoLocationHealthChecker(Vertx vertx,
                                     long refreshPeriod,
+                                    long jitter,
                                     GeoLocationService geoLocationService,
                                     TimeoutFactory timeoutFactory,
                                     Clock clock) {
 
-        super(vertx, refreshPeriod);
+        super(vertx, refreshPeriod, jitter);
         this.geoLocationService = Objects.requireNonNull(geoLocationService);
         this.timeoutFactory = Objects.requireNonNull(timeoutFactory);
         this.clock = Objects.requireNonNull(clock);

--- a/src/main/java/org/prebid/server/health/PeriodicHealthChecker.java
+++ b/src/main/java/org/prebid/server/health/PeriodicHealthChecker.java
@@ -3,20 +3,27 @@ package org.prebid.server.health;
 import io.vertx.core.Vertx;
 
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class PeriodicHealthChecker implements HealthChecker {
 
     private final Vertx vertx;
     private final long refreshPeriod;
+    private final long jitter;
 
-    PeriodicHealthChecker(Vertx vertx, long refreshPeriod) {
+    PeriodicHealthChecker(Vertx vertx, long refreshPeriod, long jitter) {
         this.vertx = Objects.requireNonNull(vertx);
         this.refreshPeriod = verifyRefreshPeriod(refreshPeriod);
+        this.jitter = verifyRefreshPeriodJitter(refreshPeriod, jitter);
     }
 
     public void initialize() {
         updateStatus();
-        vertx.setPeriodic(refreshPeriod, aLong -> updateStatus());
+        if (jitter == 0) {
+            vertx.setPeriodic(refreshPeriod, aLong -> updateStatus());
+        } else {
+            setTimerWithJitter(vertx, refreshPeriod, jitter);
+        }
     }
 
     abstract void updateStatus();
@@ -26,5 +33,21 @@ public abstract class PeriodicHealthChecker implements HealthChecker {
             throw new IllegalArgumentException("Refresh period for updating status be positive value");
         }
         return refreshPeriod;
+    }
+
+    private static long verifyRefreshPeriodJitter(long refreshPeriod, long jitter) {
+        if (jitter < 0 || jitter > refreshPeriod) {
+            throw new IllegalArgumentException(
+                    "Refresh period jitter for updating status be positive value and less than refresh period");
+        }
+        return jitter;
+    }
+
+    private void setTimerWithJitter(Vertx vertx, long delay, long jitter) {
+        final long nextDelay = delay + ThreadLocalRandom.current().nextLong(jitter * -1, jitter);
+        vertx.setTimer(delay, parameter -> {
+            updateStatus();
+            setTimerWithJitter(vertx, nextDelay, jitter);
+        });
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/HealthCheckerConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/HealthCheckerConfiguration.java
@@ -25,20 +25,22 @@ public class HealthCheckerConfiguration {
     @ConditionalOnProperty(prefix = "health-check.database", name = "enabled", havingValue = "true")
     HealthChecker databaseChecker(Vertx vertx,
                                   JDBCClient jdbcClient,
-                                  @Value("${health-check.database.refresh-period-ms}") long refreshPeriod) {
+                                  @Value("${health-check.database.refresh-period-ms}") long refreshPeriod,
+                                  @Value("${health-check.database.refresh-period-jitter-ms:0}") long jitter) {
 
-        return new DatabaseHealthChecker(vertx, jdbcClient, refreshPeriod);
+        return new DatabaseHealthChecker(vertx, jdbcClient, refreshPeriod, jitter);
     }
 
     @Bean
     @ConditionalOnExpression("${health-check.geolocation.enabled} == true and ${geolocation.enabled} == true")
     HealthChecker geoLocationChecker(Vertx vertx,
                                      @Value("${health-check.geolocation.refresh-period-ms}") long refreshPeriod,
+                                     @Value("${health-check.geolocation.refresh-period-jitter-ms:0}") long jitter,
                                      GeoLocationService geoLocationService,
                                      TimeoutFactory timeoutFactory,
                                      Clock clock) {
 
-        return new GeoLocationHealthChecker(vertx, refreshPeriod, geoLocationService, timeoutFactory, clock);
+        return new GeoLocationHealthChecker(vertx, refreshPeriod, jitter, geoLocationService, timeoutFactory, clock);
     }
 
     @Bean

--- a/src/test/java/org/prebid/server/health/DatabaseHealthCheckerTest.java
+++ b/src/test/java/org/prebid/server/health/DatabaseHealthCheckerTest.java
@@ -30,6 +30,7 @@ public class DatabaseHealthCheckerTest {
 
     private static final String DATABASE_CHECK_NAME = "database";
     private static final long TEST_REFRESH_PERIOD = 1000;
+    private static final long TEST_REFRESH_PERIOD_JITTER = 0;
     private static final String TEST_TIME_STRING = ZonedDateTime.now(Clock.systemUTC()).toString();
 
     @Rule
@@ -46,19 +47,24 @@ public class DatabaseHealthCheckerTest {
 
     @Before
     public void setUp() {
-        databaseHealthCheck = new DatabaseHealthChecker(vertx, jdbcClient, TEST_REFRESH_PERIOD);
+        databaseHealthCheck = new DatabaseHealthChecker(
+                vertx, jdbcClient, TEST_REFRESH_PERIOD, TEST_REFRESH_PERIOD_JITTER);
     }
 
     @Test
     public void creationShouldFailWithNullArguments() {
-        assertThatNullPointerException().isThrownBy(() -> new DatabaseHealthChecker(null, jdbcClient, 0));
-        assertThatNullPointerException().isThrownBy(() -> new DatabaseHealthChecker(vertx, null, TEST_REFRESH_PERIOD));
+        assertThatNullPointerException().isThrownBy(() -> new DatabaseHealthChecker(
+                null, jdbcClient, 0, 0));
+        assertThatNullPointerException().isThrownBy(() -> new DatabaseHealthChecker(
+                vertx, null, TEST_REFRESH_PERIOD, TEST_REFRESH_PERIOD_JITTER));
     }
 
     @Test
     public void creationShouldFailWhenRefreshPeriodIsZeroOrNegative() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new DatabaseHealthChecker(vertx, jdbcClient, 0));
-        assertThatIllegalArgumentException().isThrownBy(() -> new DatabaseHealthChecker(vertx, jdbcClient, -1));
+        assertThatIllegalArgumentException().isThrownBy(() -> new DatabaseHealthChecker(
+                vertx, jdbcClient, 0, 0));
+        assertThatIllegalArgumentException().isThrownBy(() -> new DatabaseHealthChecker(
+                vertx, jdbcClient, -1, 0));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/health/GeoLocationHealthCheckerTest.java
+++ b/src/test/java/org/prebid/server/health/GeoLocationHealthCheckerTest.java
@@ -47,7 +47,8 @@ public class GeoLocationHealthCheckerTest {
     public void setUp() {
         clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
         final TimeoutFactory timeoutFactory = new TimeoutFactory(clock);
-        geoLocationHealthChecker = new GeoLocationHealthChecker(vertx, 1L, geoLocationService, timeoutFactory, clock);
+        geoLocationHealthChecker = new GeoLocationHealthChecker(
+                vertx, 1L, 0L, geoLocationService, timeoutFactory, clock);
     }
 
     @Test


### PR DESCRIPTION
In order to smooth out the load curve to downstream services during several PBS nodes start, next properties may be used:
```
health-check:
    database:
        refresh-period-jitter-ms: 0
    geolocation:
        refresh-period-jitter-ms: 0
```
Where 0 - is default value and will switch off this feature. Use positive integer value that less than related _refresh-period-ms_, in order to enable some kind of jitter for timed events. For example: with value 1000, timed event will start with random deviation in range from -1000 to +1000 milliseconds from _refresh-period-ms_ value.