### PR TITLE
Rise: Fix JSON schema (publisher_id not required)

### DIFF
--- a/src/main/resources/static/bidder-params/rise.json
+++ b/src/main/resources/static/bidder-params/rise.json
@@ -13,9 +13,6 @@
       "description": "Deprecated, use org instead."
     }
   },
-  "required": [
-    "publisher_id"
-  ],
   "oneOf": [
     {
       "required": [


### PR DESCRIPTION
#2599 changed the name of the mandatory field for Rise, but JSON schema still requires old `publisher_id` field.
