### PR TITLE
Fixed NPE for bidder aliases empty config (syntax example added)

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/bidder/util/BidderDepsAssembler.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/util/BidderDepsAssembler.java
@@ -184,7 +184,7 @@ public class BidderDepsAssembler<CFG extends BidderConfigurationProperties> {
                 new InputStreamResource(new ByteArrayInputStream(configAsYamlString.getBytes())));
         final Binder configurationBinder = new Binder(new MapConfigurationPropertySource(configAsProperties));
 
-        return (CFG) configurationBinder.bind(StringUtils.EMPTY, (Class) targetClass).get();
+        return (CFG) configurationBinder.bindOrCreate(StringUtils.EMPTY, (Class) targetClass);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/main/resources/bidder-config/yahooAds.yaml
+++ b/src/main/resources/bidder-config/yahooAds.yaml
@@ -3,12 +3,9 @@ adapters:
     endpoint: https://s2shb.ssp.yahoo.com/admax/bid/partners/PBS
     ortb-version: "2.6"
     aliases:
-      yssp:
-        endpoint: https://s2shb.ssp.yahoo.com/admax/bid/partners/PBS
-      yahoossp:
-        endpoint: https://s2shb.ssp.yahoo.com/admax/bid/partners/PBS
-      yahooAdvertising:
-        endpoint: https://s2shb.ssp.yahoo.com/admax/bid/partners/PBS
+      yssp: ~
+      yahoossp: ~
+      yahooAdvertising: ~
     meta-info:
       maintainer-email: hb-fe-tech@yahooinc.com
       app-media-types:


### PR DESCRIPTION
In order to create alias without specific config (e.g. config is the same as for origin), just use such syntax:
```
adapters:
  adapterName:
    ...
    ...
    aliases:
      aliasName: ~
```