### PR TITLE
Smaato: update user sync URL to add GDPR macros

### DIFF
--- a/src/main/resources/bidder-config/smaato.yaml
+++ b/src/main/resources/bidder-config/smaato.yaml
@@ -15,6 +15,6 @@ adapters:
     usersync:
       cookie-family-name: smaato
       redirect:
-        url: https://s.ad.smaato.net/c/?adExInit=p&redir={{redirect_url}}
+        url: https://s.ad.smaato.net/c/?adExInit=p&redir={{redirect_url}}&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}
         support-cors: false
         uid-macro: '$UID'


### PR DESCRIPTION
Related to: [Port PR from PBS-Go: Smaato: Update userSync url to add GDPR macros](https://github.com/prebid/prebid-server-java/issues/2582)