### PR TITLE
Optional "bidresponse.ext.prebid.targeting" response block

### DIFF
--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -1423,7 +1423,8 @@ public class BidResponseCreator {
                 && targetingInfo.isTargetingEnabled()
                 && targetingInfo.isBidderWinningBid()
                 && (Objects.equals(targeting.getIncludebidderkeys(), true)
-                || Objects.equals(targeting.getIncludewinners(), true));
+                || Objects.equals(targeting.getIncludewinners(), true)
+                || Objects.equals(targeting.getIncludeformat(), true));
     }
 
     private JsonNode extractPassThrough(Imp imp) {

--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -1374,7 +1374,7 @@ public class BidResponseCreator {
 
         final Map<String, String> targetingKeywords;
         final String bidderCode = targetingInfo.getBidderCode();
-        if (targeting != null && targetingInfo.isTargetingEnabled() && targetingInfo.isBidderWinningBid()) {
+        if (shouldIncludeTargetingInResponse(targeting, bidInfo.getTargetingInfo())) {
             final TargetingKeywordsCreator keywordsCreator = resolveKeywordsCreator(
                     bidType, targeting, isApp, bidRequest, account);
 
@@ -1416,6 +1416,14 @@ public class BidResponseCreator {
                 .ext(updatedBidExt)
                 .exp(ttl)
                 .build();
+    }
+
+    private boolean shouldIncludeTargetingInResponse(ExtRequestTargeting targeting, TargetingInfo targetingInfo) {
+        return targeting != null
+                && targetingInfo.isTargetingEnabled()
+                && targetingInfo.isBidderWinningBid()
+                && (Objects.equals(targeting.getIncludebidderkeys(), true)
+                || Objects.equals(targeting.getIncludewinners(), true));
     }
 
     private JsonNode extractPassThrough(Imp imp) {

--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -404,13 +404,6 @@ public class RequestValidator {
         }
         validateMediaTypePriceGranularity(extRequestTargeting.getMediatypepricegranularity());
 
-        final Boolean includeWinners = extRequestTargeting.getIncludewinners();
-        final Boolean includeBidderKeys = extRequestTargeting.getIncludebidderkeys();
-        if (Objects.equals(includeWinners, false) && Objects.equals(includeBidderKeys, false)) {
-            throw new ValidationException("ext.prebid.targeting: At least one of includewinners or includebidderkeys"
-                    + " must be enabled to enable targeting support");
-        }
-
         validateTargetingPrefix(extRequestTargeting);
     }
 

--- a/src/test/groovy/org/prebid/server/functional/model/request/auction/Targeting.groovy
+++ b/src/test/groovy/org/prebid/server/functional/model/request/auction/Targeting.groovy
@@ -20,7 +20,7 @@ class Targeting {
 
     static Targeting createWithAllValuesSetTo(Boolean value) {
         new Targeting().tap {
-            // At least one of includewinners or includebidderkeys must be enabled
+            // Leave true for populating targeting
             includeWinners = true
             includeBidderKeys = value
             preferDeals = value
@@ -32,7 +32,7 @@ class Targeting {
     static Targeting createWithRandomValues() {
         new Random().with {
             new Targeting().tap {
-                // At least one of includewinners or includebidderkeys must be enabled
+                // Leave true for populating targeting
                 includeWinners = true
                 includeBidderKeys = nextBoolean()
                 preferDeals = nextBoolean()

--- a/src/test/groovy/org/prebid/server/functional/tests/TargetingSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/TargetingSpec.groovy
@@ -15,11 +15,9 @@ import org.prebid.server.functional.model.request.auction.StoredBidResponse
 import org.prebid.server.functional.model.request.auction.Targeting
 import org.prebid.server.functional.model.response.auction.Bid
 import org.prebid.server.functional.model.response.auction.BidResponse
-import org.prebid.server.functional.service.PrebidServerException
 import org.prebid.server.functional.service.PrebidServerService
 import org.prebid.server.functional.util.PBSUtils
 
-import static org.mockserver.model.HttpStatusCode.BAD_REQUEST_400
 import static org.prebid.server.functional.model.bidder.BidderName.GENERIC
 import static org.prebid.server.functional.testcontainers.Dependencies.getNetworkServiceContainer
 
@@ -144,22 +142,45 @@ class TargetingSpec extends BaseSpec {
         null              || null
     }
 
-    def "PBS should throw an exception when targeting includeBidderKeys and includeWinners flags are false"() {
-        given: "Bid request with includeBidderKeys = false and includeWinners = false"
+    def "PBS auction shouldn't throw an exception and don't populate targeting when targeting includeBidderKeys and includeWinners and includeFormat flags are false"() {
+        given: "Default bid request with includeBidderKeys=false and includeWinners=false and includeFormat=false"
         def bidRequest = BidRequest.defaultBidRequest.tap {
-            it.ext.prebid.targeting = new Targeting(includeBidderKeys: false, includeWinners: false)
+            it.ext.prebid.targeting = new Targeting().tap {
+                includeBidderKeys = false
+                includeWinners = false
+                includeFormat = false
+            }
         }
 
         when: "Requesting PBS auction"
-        defaultPbsService.sendAuctionRequest(bidRequest)
+        def bidResponse = defaultPbsService.sendAuctionRequest(bidRequest)
 
-        then: "PBS returns an error"
-        def exception = thrown PrebidServerException
-        verifyAll(exception) {
-            it.statusCode == BAD_REQUEST_400.code()
-            it.responseBody == "Invalid request format: ext.prebid.targeting: At least one of includewinners or " +
-                    "includebidderkeys must be enabled to enable targeting support"
+        then: "PBS response shouldn't contain targeting in response"
+        assert !bidResponse.seatbid?.first()?.bid?.first()?.ext?.prebid?.targeting
+    }
+
+    def "PBS amp shouldn't throw an exception and don't populate targeting when includeBidderKeys and includeWinners and includeFormat flags are false"() {
+        given: "Default AmpRequest"
+        def ampRequest = AmpRequest.defaultAmpRequest
+
+        and: "Default bid request with includeBidderKeys=false and includeWinners=false and includeFormat=false"
+        def ampStoredRequest = BidRequest.defaultBidRequest.tap {
+            it.ext.prebid.targeting = new Targeting().tap {
+                includeBidderKeys = false
+                includeWinners = false
+                includeFormat = false
+            }
         }
+
+        and: "Create and save stored request into DB"
+        def storedRequest = StoredRequest.getStoredRequest(ampRequest, ampStoredRequest)
+        storedRequestDao.save(storedRequest)
+
+        when: "PBS processes amp request"
+        def response = defaultPbsService.sendAmpRequest(ampRequest)
+
+        then: "Amp response shouldn't contain targeting"
+        assert !response.targeting
     }
 
     def "PBS should include only #presentDealKey deal specific targeting key when includeBidderKeys is #includeBidderKeys and includeWinners is #includeWinners"() {

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -1856,30 +1856,6 @@ public class RequestValidatorTest extends VertxTest {
     }
 
     @Test
-    public void validateShouldReturnValidationMessageForInvalidTargeting() {
-        // given
-        final ExtPriceGranularity priceGranularity = ExtPriceGranularity.of(1, singletonList(
-                ExtGranularityRange.of(BigDecimal.valueOf(5), BigDecimal.valueOf(0.01))));
-        final BidRequest bidRequest = validBidRequestBuilder()
-                .ext(ExtRequest.of(ExtRequestPrebid.builder()
-                        .targeting(ExtRequestTargeting.builder()
-                                .pricegranularity(mapper.valueToTree(priceGranularity))
-                                .includebidderkeys(false)
-                                .includewinners(false)
-                                .build())
-                        .build()))
-                .build();
-
-        // when
-        final ValidationResult result = target.validate(bidRequest, null);
-
-        // then
-        assertThat(result.getErrors()).hasSize(1)
-                .containsOnly("ext.prebid.targeting: At least one of includewinners or includebidderkeys"
-                        + " must be enabled to enable targeting support");
-    }
-
-    @Test
     public void validateShouldReturnValidationMessageForInvalidTargetingPrefix() {
         // given
         final ExtPriceGranularity priceGranularity = ExtPriceGranularity.of(1, singletonList(


### PR DESCRIPTION
Simplified targeting validation, added additional check before targeting keywords resolving.

Related to: https://github.com/prebid/prebid-server/issues/2030