### PR TITLE
Update TappxBidder.java

### DIFF
--- a/src/main/java/org/prebid/server/bidder/tappx/TappxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/tappx/TappxBidder.java
@@ -42,7 +42,7 @@ public class TappxBidder implements Bidder<BidRequest> {
     private static final TypeReference<ExtPrebid<?, ExtImpTappx>> TAPX_EXT_TYPE_REFERENCE =
             new TypeReference<>() {
             };
-    private static final Pattern NEW_ENDPOINT_PATTERN = Pattern.compile("^(zz|vz)[0-9]{3,}([a-z]{2}|test)$");
+    private static final Pattern NEW_ENDPOINT_PATTERN = Pattern.compile("^(zz|vz)[0-9]{3,}([a-z]{2,3}|test)$");
     private static final String SUBDOMAIN_MACRO = "{{subdomain}}";
 
     private final String endpointUrl;


### PR DESCRIPTION
This change is made to reflect the PBS GO regex pattern defined [here](https://github.com/prebid/prebid-server/blob/d82c99733d7f0a41e5f15af95c8a5e45ab60177c/adapters/tappx/tappx.go#L135C2-L135C15)

