### PR TITLE
Rubicon adapter: adding gzip support

### DIFF
--- a/src/main/resources/bidder-config/rubicon.yaml
+++ b/src/main/resources/bidder-config/rubicon.yaml
@@ -2,6 +2,7 @@ adapters:
   rubicon:
     ortb-version: "2.6"
     endpoint: http://exapi-us-east.rubiconproject.com/a/api/exchange.json
+    endpoint-compression: gzip
     meta-info:
       maintainer-email: header-bidding@rubiconproject.com
       app-media-types:


### PR DESCRIPTION
The Magnite exchange can receive gzip compressed requests