### PR TITLE
Rise adapter allowing modified VAST

### DIFF
--- a/src/main/resources/bidder-config/rise.yaml
+++ b/src/main/resources/bidder-config/rise.yaml
@@ -1,7 +1,7 @@
 adapters:
   rise:
     endpoint: https://pbs.yellowblue.io/pbs
-    modifying-vast-xml-allowed: false
+    modifying-vast-xml-allowed: true
     meta-info:
       maintainer-email: rise-prog-dev@risecodes.com
       app-media-types:


### PR DESCRIPTION
Spoke with Erez @ Rise who expressed a willingness to change their adapter config to allow modifying VAST.

Heads up @misha93m who authored the PBS-Go version of this file.