### PR TITLE
GitHub action: release assets build and publish

### DIFF
--- a/.github/workflows/release-asset-publish.yml
+++ b/.github/workflows/release-asset-publish.yml
@@ -39,4 +39,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: extra/bundle/target/prebid-server-bundle.jar
           asset_name: prebid-server-bundle-${{ github.ref_name }}.jar
+          overwrite: true
           tag: ${{ github.ref }}

--- a/.github/workflows/release-asset-publish.yml
+++ b/.github/workflows/release-asset-publish.yml
@@ -1,0 +1,42 @@
+name: Publish release .jar
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Publish release .jar
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 17 ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          cache: 'maven'
+          java-version: ${{ matrix.java }}
+
+      - name: Build base .jar via Maven
+        run: mvn clean package -Dcheckstyle.skip -Dmaven.test.skip=true
+      - name: Upload and attach base .jar to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/prebid-server.jar
+          asset_name: prebid-server-${{ github.ref_name }}.jar
+          tag: ${{ github.ref }}
+
+      - name: Build bundled .jar via Maven
+        run: mvn clean package --file extra/pom.xml -Dcheckstyle.skip -Dmaven.test.skip=true
+      - name: Upload and attach bundled .jar to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: extra/bundle/target/prebid-server-bundle.jar
+          asset_name: prebid-server-bundle-${{ github.ref_name }}.jar
+          tag: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ java -jar target/prebid-server.jar --spring.config.additional-location=sample/pr
 For more options how to start the server, please follow [documentation](docs/run.md).
 
 ## Running prebuilt .jar
-Starting from PBS Java v2.7, you can download prebuilt .jar packages from [Release Notes](https://github.com/prebid/prebid-server-java/releases) page, instead of building them by yourself. 
+Starting from PBS Java v2.9, you can download prebuilt .jar packages from [Release Notes](https://github.com/prebid/prebid-server-java/releases) page, instead of building them by yourself. 
 This prebuilt packages are delivered with or without extra modules.
 
 ## Verifying

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ Run your local server with the command:
 ```bash
 java -jar target/prebid-server.jar --spring.config.additional-location=sample/prebid-config.yaml
 ```
-
 For more options how to start the server, please follow [documentation](docs/run.md).
+
+## Running prebuilt .jar
+Starting from PBS Java v2.7, you can download prebuilt .jar packages from [Release Notes](https://github.com/prebid/prebid-server-java/releases) page, instead of building them by yourself. 
+This prebuilt packages are delivered with or without extra modules.
 
 ## Verifying
 


### PR DESCRIPTION
GitHub action, that triggered by new release tag. Composes two ready-to-go .jar files (with and without PBS modules) and attaches them to release as assets for download.