### PR TITLE
fix: prevent ExchangeService from emptying Source object

### DIFF
--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -1137,8 +1137,15 @@ public class ExchangeService {
         final Source receivedSource = bidRequest.getSource();
         final SupplyChain bidderSchain = supplyChainResolver.resolveForBidder(bidder, bidRequest);
 
-        if (bidderSchain == null && transmitTid) {
-            return receivedSource;
+        if (bidderSchain == null) {
+
+            if (receivedSource == null) {
+                return null;
+            }
+
+            return receivedSource.toBuilder()
+                    .tid(transmitTid ? receivedSource.getTid() : null)
+                    .build();
         }
 
         return receivedSource == null


### PR DESCRIPTION
fix: prevent ExchangeService from emptying Source object when TRANSMIT_TID is false, and supplyChainResolver can't resolve a schain for bidder