### PR TITLE
GitHub action: Docker image build and publish

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -1,0 +1,59 @@
+name: Publish Docker image for new tag/release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Publish Docker image for new tag/release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        java: [ 17 ]
+        dockerfile-path: [Dockerfile, extra/Dockerfile]
+        include:
+          - dockerfile-path: Dockerfile
+            build-cmd: mvn clean package -Dcheckstyle.skip -Dmaven.test.skip=true
+            package-name: ghcr.io/${{ github.repository }}
+          - dockerfile-path: extra/Dockerfile
+            build-cmd: mvn clean package --file extra/pom.xml -Dcheckstyle.skip -Dmaven.test.skip=true
+            package-name: ghcr.io/${{ github.repository }}-bundle
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          cache: 'maven'
+          java-version: ${{ matrix.java }}
+      - name: Build .jar via Maven
+        run: ${{ matrix.build-cmd }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker Image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.package-name }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile-path }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ and verify response status is `200 OK`.
 
 There are a couple of 'hello world' test requests described in sample/requests/README.txt
 
+## Running Docker image
+
+Starting from PBS Java v2.7, you can download prebuilt Docker images from [GitHub Packages](https://github.com/orgs/prebid/packages?repo_name=prebid-server-java) page,
+and use them instead of plain .jar files. This prebuilt images are delivered with or without extra modules.
+
+In order to run such image correctly, you should attach PBS config file. Easiest way is to mount config file into container,
+using [--mount or --volume (-v) Docker CLI arguments](https://docs.docker.com/engine/reference/commandline/run/).
+Keep in mind, that config file should be mounted into specific location: ```/app/prebid-server/``` or ```/app/prebid-server/conf/```.
+
 # Documentation
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are a couple of 'hello world' test requests described in sample/requests/R
 
 ## Running Docker image
 
-Starting from PBS Java v2.7, you can download prebuilt Docker images from [GitHub Packages](https://github.com/orgs/prebid/packages?repo_name=prebid-server-java) page,
+Starting from PBS Java v2.9, you can download prebuilt Docker images from [GitHub Packages](https://github.com/orgs/prebid/packages?repo_name=prebid-server-java) page,
 and use them instead of plain .jar files. This prebuilt images are delivered with or without extra modules.
 
 In order to run such image correctly, you should attach PBS config file. Easiest way is to mount config file into container,


### PR DESCRIPTION
Docker images build and publish for bare and bundled PBJ versions.

Action is triggered by new tag that usually corresponds to the new release.