### PR TITLE
Tests: Add fix for `multibidspec` flaky tests

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/tests/MultibidSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/MultibidSpec.groovy
@@ -9,8 +9,6 @@ import org.prebid.server.functional.model.request.auction.Targeting
 import org.prebid.server.functional.model.response.auction.Bid
 import org.prebid.server.functional.model.response.auction.BidResponse
 import org.prebid.server.functional.util.PBSUtils
-import spock.lang.IgnoreRest
-import spock.lang.RepeatUntilFailure
 
 import static org.prebid.server.functional.model.bidder.BidderName.GENERIC
 

--- a/src/test/groovy/org/prebid/server/functional/tests/MultibidSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/MultibidSpec.groovy
@@ -9,6 +9,8 @@ import org.prebid.server.functional.model.request.auction.Targeting
 import org.prebid.server.functional.model.response.auction.Bid
 import org.prebid.server.functional.model.response.auction.BidResponse
 import org.prebid.server.functional.util.PBSUtils
+import spock.lang.IgnoreRest
+import spock.lang.RepeatUntilFailure
 
 import static org.prebid.server.functional.model.bidder.BidderName.GENERIC
 
@@ -93,7 +95,6 @@ class MultibidSpec extends BaseSpec {
         requestTargeting                          | accountTargeting
         Targeting.createWithAllValuesSetTo(true)  | Targeting.createWithAllValuesSetTo(false)
         Targeting.createWithAllValuesSetTo(false) | Targeting.createWithAllValuesSetTo(true)
-        Targeting.createWithRandomValues()        | Targeting.createWithRandomValues()
     }
 
     def "PBS should use account level config when bidRequest does not have targeting settings"() {
@@ -115,6 +116,8 @@ class MultibidSpec extends BaseSpec {
         assert bidderRequest.ext.prebid.targeting == account.config.auction.targeting
 
         where:
-        accountTargeting << [Targeting.createWithAllValuesSetTo(false), Targeting.createWithAllValuesSetTo(true), Targeting.createWithRandomValues()]
+        accountTargeting << [Targeting.createWithAllValuesSetTo(false),
+                             Targeting.createWithAllValuesSetTo(true),
+                             Targeting.createWithRandomValues()]
     }
 }


### PR DESCRIPTION
This PR aim to resolve this one flaky test
```
Error:  Tests run: 10, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.455 s <<< FAILURE! - in MultibidSpec
Error:  PBS should prefer bidRequest over account level config [requestTargeting: org.prebid.server.functional.model.request.auction.Targeting{includeWinners:true, includeBidderKeys:false, preferDeals:true, alwaysIncludeDeals:false, includeFormat:false}, accountTargeting: org.prebid.server.functional.model.request.auction.Targeting{includeWinners:true, includeBidderKeys:false, preferDeals:true, alwaysIncludeDeals:false, includeFormat:false}, #2]  Time elapsed: 0.67 s  <<< FAILURE!
org.spockframework.runtime.ConditionNotSatisfiedError: 
Condition not satisfied:

bidderRequest.ext.prebid.targeting != accountTargeting
|             |   |      |         |  |
|             |   |      |         |  org.prebid.server.functional.model.request.auction.Targeting(includeWinners:true, includeBidderKeys:false, preferDeals:true, alwaysIncludeDeals:false, includeFormat:false)
|             |   |      |         false
```