### PR TITLE
YahooAds: Update maintainer email address

### DIFF
--- a/src/main/resources/bidder-config/yahooAds.yaml
+++ b/src/main/resources/bidder-config/yahooAds.yaml
@@ -7,7 +7,7 @@ adapters:
       yahoossp: ~
       yahooAdvertising: ~
     meta-info:
-      maintainer-email: hb-fe-tech@yahooinc.com
+      maintainer-email: prebid-tech-team@yahooinc.com
       app-media-types:
         - banner
         - video


### PR DESCRIPTION
This pull request updates the maintainer email address to [prebid-tech-team@yahooinc.com](mailto:prebid-tech-team@yahooinc.com).

Details:

Maintainer Email Address: [prebid-tech-team@yahooinc.com](mailto:prebid-tech-team@yahooinc.com)
