### PR TITLE
RTB House: app support

### DIFF
--- a/src/main/resources/bidder-config/rtbhouse.yaml
+++ b/src/main/resources/bidder-config/rtbhouse.yaml
@@ -5,6 +5,8 @@ adapters:
     meta-info:
       maintainer-email: prebid@rtbhouse.com
       app-media-types:
+        - banner
+        - native
       site-media-types:
         - banner
         - native


### PR DESCRIPTION
## Type of change
[x] Feature

## Description of change
App support is now available at RTB House adapter. 
Mirrors PBS-Go PR: https://github.com/prebid/prebid-server/pull/3422

## Other information
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).