### PR TITLE
Confiant AdQuality: Skip scanning for bidders with empty bids

### DIFF
--- a/extra/modules/confiant-ad-quality/src/main/java/org/prebid/server/hooks/modules/com/confiant/adquality/core/RedisParser.java
+++ b/extra/modules/confiant-ad-quality/src/main/java/org/prebid/server/hooks/modules/com/confiant/adquality/core/RedisParser.java
@@ -41,7 +41,7 @@ public class RedisParser {
             } catch (JsonProcessingException errorParse) {
                 message = String.format("Error during parse redis response: %s", redisResponse);
             }
-            logger.info(message);
+            logger.warn(message);
             return BidsScanResult.builder()
                     .bidScanResults(Collections.emptyList())
                     .debugMessages(List.of(message))

--- a/extra/modules/confiant-ad-quality/src/main/java/org/prebid/server/hooks/modules/com/confiant/adquality/v1/ConfiantAdQualityBidResponsesScanHook.java
+++ b/extra/modules/confiant-ad-quality/src/main/java/org/prebid/server/hooks/modules/com/confiant/adquality/v1/ConfiantAdQualityBidResponsesScanHook.java
@@ -60,7 +60,8 @@ public class ConfiantAdQualityBidResponsesScanHook implements AllProcessedBidRes
         final BidRequest bidRequest = getBidRequest(auctionInvocationContext);
         final List<BidderResponse> responses = allProcessedBidResponsesPayload.bidResponses();
         final Map<Boolean, List<BidderResponse>> needScanMap = responses.stream()
-                .collect(Collectors.groupingBy(bidderResponse -> !biddersToExcludeFromScan.contains(bidderResponse.getBidder())));
+                .collect(Collectors.groupingBy(bidderResponse -> !biddersToExcludeFromScan.contains(bidderResponse.getBidder())
+                        && !bidderResponse.getSeatBid().getBids().isEmpty()));
 
         final List<BidderResponse> toScan = needScanMap.getOrDefault(true, Collections.emptyList());
         final List<BidderResponse> avoidScan = needScanMap.getOrDefault(false, Collections.emptyList());

--- a/extra/modules/confiant-ad-quality/src/test/java/org/prebid/server/hooks/modules/com/confiant/adquality/util/AdQualityModuleTestUtils.java
+++ b/extra/modules/confiant-ad-quality/src/test/java/org/prebid/server/hooks/modules/com/confiant/adquality/util/AdQualityModuleTestUtils.java
@@ -26,4 +26,10 @@ public class AdQualityModuleTestUtils {
                         .build()))
                 .build(), 11);
     }
+
+    public static BidderResponse getEmptyBidderResponse(String bidderName) {
+        return BidderResponse.of(bidderName, BidderSeatBid.builder()
+                .bids(Collections.emptyList())
+                .build(), 5);
+    }
 }

--- a/extra/modules/confiant-ad-quality/src/test/java/org/prebid/server/hooks/modules/com/confiant/adquality/util/AdQualityModuleTestUtils.java
+++ b/extra/modules/confiant-ad-quality/src/test/java/org/prebid/server/hooks/modules/com/confiant/adquality/util/AdQualityModuleTestUtils.java
@@ -26,10 +26,4 @@ public class AdQualityModuleTestUtils {
                         .build()))
                 .build(), 11);
     }
-
-    public static BidderResponse getEmptyBidderResponse(String bidderName) {
-        return BidderResponse.of(bidderName, BidderSeatBid.builder()
-                .bids(Collections.emptyList())
-                .build(), 5);
-    }
 }


### PR DESCRIPTION
Currently Hook for Auctions receives information from all bidders. Some of them can contain empty bids.
Confiant module should not scan them because it has a wrong data format and makes no sense actually.

@AntoxaAntoxic would appreciate for a review. Not 100% sure about your flow how I can ping any required reviewer.

fyi @bretg