### PR TITLE
Remove documentation references to metrics that are no longer available

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -106,8 +106,6 @@ Following metrics are collected and submitted if account is configured with `det
 
 ## /cookie_sync endpoint metrics
 - `cookie_sync_requests` - number of requests received
-- `cookie_sync.<bidder-name>.gen` - number of times cookies was synced per bidder 
-- `cookie_sync.<bidder-name>.matches` - number of times cookie was already matched when synced per bidder 
 - `cookie_sync.<bidder-name>.tcf.blocked` - number of times cookie sync was prevented by TCF per bidder
 
 ## /setuid endpoint metrics


### PR DESCRIPTION
The "`/cookie_sync` endpoint metrics`" section of the [Metrics documentation](https://github.com/prebid/prebid-server-java/blob/master/docs/metrics.md#cookie_sync-endpoint-metrics) seems to be out of date.

It lists `cookie_sync.<bidder-name>.gen` and `cookie_sync.<bidder-name>.matches` as available metrics, but neither seems to be available anymore, and it looks like they were removed:
- https://github.com/prebid/prebid-server-java/issues/2114
- https://github.com/prebid/prebid-server-java/pull/2065
  - In particular, https://github.com/prebid/prebid-server-java/pull/2065/files#diff-fcd88b249295823c1877f78f5e06d5c8119384d522032b15eecca80b7bb24d55L80-L81

Issue: https://github.com/prebid/prebid-server-java/issues/3017