### PR TITLE
Yieldlab: Fix the default endpoint

### DIFF
--- a/src/main/resources/bidder-config/yieldlab.yaml
+++ b/src/main/resources/bidder-config/yieldlab.yaml
@@ -1,6 +1,6 @@
 adapters:
   yieldlab:
-    endpoint: https://ad.yieldlab.net/yp/
+    endpoint: https://ad.yieldlab.net/yp
     meta-info:
       maintainer-email: solutions@yieldlab.de
       app-media-types:


### PR DESCRIPTION
The trailing slash needs to be removed because we end up with [two consecutive slashes in the final URL](https://github.com/prebid/prebid-server-java/blob/master/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java#L139) otherwise. This could easily lead to issues.