### PR TITLE
Medianet/fledge support

### DIFF
--- a/src/main/java/org/prebid/server/bidder/medianet/MedianetBidder.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/MedianetBidder.java
@@ -152,9 +152,10 @@ public class MedianetBidder implements Bidder<BidRequest> {
         return Optional.ofNullable(bidResponse)
                 .map(MedianetBidResponse::getExt)
                 .map(MedianetBidResponseExt::getIgi)
-                .map(InterestGroupAuctionIntent::getIgs)
                 .orElse(Collections.emptyList())
                 .stream()
+                .map(InterestGroupAuctionIntent::getIgs)
+                .flatMap(Collection::stream)
                 .map(e -> FledgeAuctionConfig.builder().impId(e.getImpId()).config(e.getConfig()).build())
                 .toList();
     }

--- a/src/main/java/org/prebid/server/bidder/medianet/MedianetBidder.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/MedianetBidder.java
@@ -50,18 +50,8 @@ public class MedianetBidder implements Bidder<BidRequest> {
      */
     @Override
     @Deprecated(forRemoval = true)
-    public final Result<List<BidderBid>> makeBids(BidderCall<BidRequest> httpCall, BidRequest bidRequest) {
-        final MedianetBidResponse bidResponse;
-        try {
-            bidResponse = mapper.decodeValue(httpCall.getResponse().getBody(), MedianetBidResponse.class);
-        } catch (DecodeException e) {
-            return Result.withError(BidderError.badServerResponse(e.getMessage()));
-        }
-
-        final List<BidderError> errors = new ArrayList<>();
-        final List<BidderBid> bids = extractBids(httpCall.getRequest().getPayload(), bidResponse, errors);
-
-        return Result.of(bids, errors);
+    public Result<List<BidderBid>> makeBids(BidderCall<BidRequest> httpCall, BidRequest bidRequest) {
+        return Result.withError(BidderError.generic("Deprecated adapter method invoked"));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/medianet/model/response/InterestGroupAuctionBuyer.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/model/response/InterestGroupAuctionBuyer.java
@@ -1,0 +1,23 @@
+package org.prebid.server.bidder.medianet.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.Value;
+
+@Value
+public class InterestGroupAuctionBuyer {
+
+    String origin;
+
+    @JsonProperty("maxbid")
+    Double maxBid;
+
+    @JsonProperty("cur")
+    String currency;
+
+    @JsonProperty("pbs")
+    String buyerSignals;
+
+    @JsonProperty("ps")
+    ObjectNode prioritySignals;
+}

--- a/src/main/java/org/prebid/server/bidder/medianet/model/response/InterestGroupAuctionIntent.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/model/response/InterestGroupAuctionIntent.java
@@ -1,0 +1,15 @@
+package org.prebid.server.bidder.medianet.model.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Builder
+@Value
+public class InterestGroupAuctionIntent {
+
+    List<InterestGroupAuctionBuyer> igb;
+
+    List<InterestGroupAuctionSeller> igs;
+}

--- a/src/main/java/org/prebid/server/bidder/medianet/model/response/InterestGroupAuctionSeller.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/model/response/InterestGroupAuctionSeller.java
@@ -1,0 +1,16 @@
+package org.prebid.server.bidder.medianet.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.Builder;
+import lombok.Value;
+
+@Builder
+@Value
+public class InterestGroupAuctionSeller {
+
+    @JsonProperty(value = "impid")
+    String impId;
+
+    ObjectNode config;
+}

--- a/src/main/java/org/prebid/server/bidder/medianet/model/response/MedianetBidResponse.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/model/response/MedianetBidResponse.java
@@ -1,0 +1,26 @@
+package org.prebid.server.bidder.medianet.model.response;
+
+import com.iab.openrtb.response.SeatBid;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class MedianetBidResponse {
+
+    String id;
+
+    List<SeatBid> seatbid;
+
+    String bidid;
+
+    String cur;
+
+    String customdata;
+
+    Integer nbr;
+
+    MedianetBidResponseExt ext;
+}

--- a/src/main/java/org/prebid/server/bidder/medianet/model/response/MedianetBidResponseExt.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/model/response/MedianetBidResponseExt.java
@@ -1,0 +1,9 @@
+package org.prebid.server.bidder.medianet.model.response;
+
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class MedianetBidResponseExt {
+
+    InterestGroupAuctionIntent igi;
+}

--- a/src/main/java/org/prebid/server/bidder/medianet/model/response/MedianetBidResponseExt.java
+++ b/src/main/java/org/prebid/server/bidder/medianet/model/response/MedianetBidResponseExt.java
@@ -2,8 +2,10 @@ package org.prebid.server.bidder.medianet.model.response;
 
 import lombok.Value;
 
+import java.util.List;
+
 @Value(staticConstructor = "of")
 public class MedianetBidResponseExt {
 
-    InterestGroupAuctionIntent igi;
+    List<InterestGroupAuctionIntent> igi;
 }

--- a/src/test/java/org/prebid/server/bidder/medianet/MedianetBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/medianet/MedianetBidderTest.java
@@ -262,12 +262,12 @@ public class MedianetBidderTest extends VertxTest {
                 .seatbid(singletonList(SeatBid.builder()
                         .bid(singletonList(bid))
                         .build()))
-                .ext(MedianetBidResponseExt.of(InterestGroupAuctionIntent.builder()
+                .ext(MedianetBidResponseExt.of(List.of(InterestGroupAuctionIntent.builder()
                         .igs(List.of(InterestGroupAuctionSeller.builder()
                                 .impId(bid.getImpid())
                                 .config(mapper.createObjectNode().put("someKey", "someValue"))
                                 .build()))
-                        .build()))
+                        .build())))
                 .build();
     }
 
@@ -275,12 +275,12 @@ public class MedianetBidderTest extends VertxTest {
         return MedianetBidResponse.builder()
                 .cur("USD")
                 .seatbid(emptyList())
-                .ext(MedianetBidResponseExt.of(InterestGroupAuctionIntent.builder()
+                .ext(MedianetBidResponseExt.of(List.of(InterestGroupAuctionIntent.builder()
                         .igs(List.of(InterestGroupAuctionSeller.builder()
                                 .impId(impId)
                                 .config(mapper.createObjectNode().put("someKey", "someValue"))
                                 .build()))
-                        .build()))
+                        .build())))
                 .build();
     }
 


### PR DESCRIPTION
Add Fledge support for Medianet adapter. The response from bidder for fledge auction config support the ortb format mentioned in the below link.
https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/Protected%20Audience%20Support.md