### PR TITLE
RTB House: video ads support

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidder.java
@@ -157,6 +157,8 @@ public class RtbhouseBidder implements Bidder<BidRequest> {
                     return BidType.banner;
                 } else if (imp.getXNative() != null) {
                     return BidType.xNative;
+                } else if (imp.getVideo() != null) {
+                    return BidType.video;
                 }
             }
         }

--- a/src/main/resources/bidder-config/rtbhouse.yaml
+++ b/src/main/resources/bidder-config/rtbhouse.yaml
@@ -18,9 +18,11 @@ adapters:
       app-media-types:
         - banner
         - native
+        - video
       site-media-types:
         - banner
         - native
+        - video
       supported-vendors:
       vendor-id: 16
     usersync:

--- a/src/test/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidderTest.java
@@ -6,6 +6,7 @@ import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.Native;
+import com.iab.openrtb.request.Video;
 import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
@@ -40,6 +41,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.prebid.server.proto.openrtb.ext.response.BidType.banner;
+import static org.prebid.server.proto.openrtb.ext.response.BidType.video;
 
 public class RtbhouseBidderTest extends VertxTest {
 
@@ -130,6 +132,30 @@ public class RtbhouseBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue())
                 .containsOnly(BidderBid.of(Bid.builder().impid("123").build(), banner, "USD"));
+    }
+
+    @Test
+    public void makeBidsShouldReturnVideoBidIfVideoIsPresent() throws JsonProcessingException {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder()
+                        .id("123")
+                        .video(Video.builder().build())
+                        .build()))
+                .build();
+
+        final BidderCall<BidRequest> httpCall = givenHttpCall(
+                bidRequest,
+                mapper.writeValueAsString(
+                        givenBidResponse(bidBuilder -> bidBuilder.impid("123"))));
+
+        // when
+        final Result<List<BidderBid>> result = target.makeBids(httpCall, bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue())
+                .containsExactly(BidderBid.of(Bid.builder().impid("123").build(), video, "USD"));
     }
 
     @Test


### PR DESCRIPTION
## Type of change
[x] Feature

## Description of change
Video ads are now available to be processed and accessed by RTB House adapter.

## Other information
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).