### PR TITLE
Epsilon Bid Adapter: requests have to be made in USD or it will be re…

### DIFF
--- a/src/main/java/org/prebid/server/bidder/epsilon/EpsilonBidder.java
+++ b/src/main/java/org/prebid/server/bidder/epsilon/EpsilonBidder.java
@@ -105,13 +105,11 @@ public class EpsilonBidder implements Bidder<BidRequest> {
         final Site requestSite = bidRequest.getSite();
         final App requestApp = bidRequest.getApp();
         final List<String> cur = bidRequest.getCur();
-        if (cur != null && !cur.isEmpty() && !BIDDER_CURRENCY.equals(cur.get(0))) {
-            bidRequest = bidRequest.toBuilder().cur(Collections.singletonList("USD")).build();
-        }
         return bidRequest.toBuilder()
                 .site(updateSite(requestSite, siteId))
                 .app(requestSite == null ? updateApp(requestApp, siteId) : requestApp)
                 .imp(modifiedImps)
+                .cur(Collections.singletonList(BIDDER_CURRENCY))
                 .build();
     }
 

--- a/src/main/java/org/prebid/server/bidder/epsilon/EpsilonBidder.java
+++ b/src/main/java/org/prebid/server/bidder/epsilon/EpsilonBidder.java
@@ -18,6 +18,7 @@ import org.prebid.server.bidder.model.BidderCall;
 import org.prebid.server.bidder.model.BidderError;
 import org.prebid.server.bidder.model.HttpRequest;
 import org.prebid.server.bidder.model.Result;
+import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.exception.PreBidException;
 import org.prebid.server.json.DecodeException;
 import org.prebid.server.json.JacksonMapper;
@@ -39,6 +40,10 @@ import java.util.stream.IntStream;
 
 public class EpsilonBidder implements Bidder<BidRequest> {
 
+    private static final String BIDDER_CURRENCY = "USD";
+
+    private final CurrencyConversionService currencyConversionService;
+
     private static final TypeReference<ExtPrebid<?, ExtImpEpsilon>> EPSILON_EXT_TYPE_REFERENCE =
             new TypeReference<>() {
             };
@@ -59,10 +64,14 @@ public class EpsilonBidder implements Bidder<BidRequest> {
     private final boolean generateBidId;
     private final JacksonMapper mapper;
 
-    public EpsilonBidder(String endpointUrl, boolean generateBidId, JacksonMapper mapper) {
+    public EpsilonBidder(String endpointUrl,
+                         boolean generateBidId,
+                         JacksonMapper mapper,
+                         CurrencyConversionService currencyConversionService) {
         this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
         this.generateBidId = generateBidId;
         this.mapper = Objects.requireNonNull(mapper);
+        this.currencyConversionService = Objects.requireNonNull(currencyConversionService);
     }
 
     @Override
@@ -84,7 +93,10 @@ public class EpsilonBidder implements Bidder<BidRequest> {
         for (int i = 0; i < requestImps.size(); i++) {
             final Imp imp = requestImps.get(i);
             final ExtImpEpsilon impExt = parseImpExt(imp, i);
-            modifiedImps.add(modifyImp(imp, impExt));
+            final BigDecimal bidFloor = resolveBidFloor(bidRequest,
+                    imp.getBidfloorcur(),
+                    getBidFloor(imp.getBidfloor(), impExt.getBidfloor()));
+            modifiedImps.add(modifyImp(imp, impExt, bidFloor));
         }
 
         final Imp firstImp = requestImps.get(0);
@@ -92,12 +104,24 @@ public class EpsilonBidder implements Bidder<BidRequest> {
         final String siteId = extImp.getSiteId();
         final Site requestSite = bidRequest.getSite();
         final App requestApp = bidRequest.getApp();
-
+        final List<String> cur = bidRequest.getCur();
+        if (cur != null && !cur.isEmpty() && !BIDDER_CURRENCY.equals(cur.get(0))) {
+            bidRequest = bidRequest.toBuilder().cur(Collections.singletonList("USD")).build();
+        }
         return bidRequest.toBuilder()
                 .site(updateSite(requestSite, siteId))
                 .app(requestSite == null ? updateApp(requestApp, siteId) : requestApp)
                 .imp(modifiedImps)
                 .build();
+    }
+
+    private BigDecimal resolveBidFloor(BidRequest bidRequest, String bidfloorcur, BigDecimal bidfloor) {
+        if (BidderUtil.isValidPrice(bidfloor)
+                && !StringUtils.equalsIgnoreCase(bidfloorcur, BIDDER_CURRENCY)
+                && StringUtils.isNotBlank(bidfloorcur)) {
+            return currencyConversionService.convertCurrency(bidfloor, bidRequest, bidfloorcur, BIDDER_CURRENCY);
+        }
+        return bidfloor;
     }
 
     private ExtImpEpsilon parseImpExt(Imp imp, int impIndex) {
@@ -122,14 +146,15 @@ public class EpsilonBidder implements Bidder<BidRequest> {
         return app == null ? null : app.toBuilder().id(siteId).build();
     }
 
-    private static Imp modifyImp(Imp imp, ExtImpEpsilon impExt) {
+    private static Imp modifyImp(Imp imp, ExtImpEpsilon impExt, BigDecimal bidfloor) {
         final Banner banner = imp.getBanner();
         final Video video = imp.getVideo();
 
         return imp.toBuilder()
                 .displaymanager(DISPLAY_MANAGER)
                 .displaymanagerver(DISPLAY_MANAGER_VER)
-                .bidfloor(getBidFloor(imp.getBidfloor(), impExt.getBidfloor()))
+                .bidfloor(bidfloor)
+                .bidfloorcur(BIDDER_CURRENCY)
                 .tagid(getTagId(imp.getTagid(), impExt.getTagId()))
                 .secure(getSecure(imp, impExt))
                 .banner(modifyBanner(banner, impExt.getPosition()))

--- a/src/main/java/org/prebid/server/spring/config/bidder/EpsilonConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/EpsilonConfiguration.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.prebid.server.bidder.BidderDeps;
 import org.prebid.server.bidder.epsilon.EpsilonBidder;
+import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.json.JacksonMapper;
 import org.prebid.server.spring.config.bidder.model.BidderConfigurationProperties;
 import org.prebid.server.spring.config.bidder.util.BidderDepsAssembler;
@@ -34,8 +35,9 @@ public class EpsilonConfiguration {
 
     @Bean
     BidderDeps epsilonBidderDeps(EpsilonConfigurationProperties epsilonConfigurationProperties,
-                                    @NotBlank @Value("${external-url}") String externalUrl,
-                                    JacksonMapper mapper) {
+                                 @NotBlank @Value("${external-url}") String externalUrl,
+                                 JacksonMapper mapper,
+                                 CurrencyConversionService currencyConversionService) {
 
         return BidderDepsAssembler.forBidder(BIDDER_NAME)
                 .withConfig(epsilonConfigurationProperties)
@@ -44,7 +46,8 @@ public class EpsilonConfiguration {
                         new EpsilonBidder(
                                 config.getEndpoint(),
                                 epsilonConfigurationProperties.getGenerateBidId(),
-                                mapper))
+                                mapper,
+                                currencyConversionService))
                 .assemble();
     }
 

--- a/src/main/resources/bidder-config/epsilon.yaml
+++ b/src/main/resources/bidder-config/epsilon.yaml
@@ -1,6 +1,6 @@
 adapters:
   epsilon:
-    endpoint: http://api.hb.ad.cpe.dotomi.com/s2s/header/24
+    endpoint: http://api.hb.ad.cpe.dotomi.com/cvx/server/hb/ortb/25
     aliases:
       conversant:
         usersync:

--- a/src/test/java/org/prebid/server/bidder/epsilon/EpsilonBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/epsilon/EpsilonBidderTest.java
@@ -60,7 +60,9 @@ public class EpsilonBidderTest extends VertxTest {
     private EpsilonBidder target;
 
     @Before
-    public void setUp() { target = new EpsilonBidder(ENDPOINT_URL, false, jacksonMapper, currencyConversionService); }
+    public void setUp() {
+        target = new EpsilonBidder(ENDPOINT_URL, false, jacksonMapper, currencyConversionService);
+    }
 
     @Test
     public void creationShouldFailOnInvalidEndpointUrl() {

--- a/src/test/resources/org/prebid/server/it/openrtb2/epsilon/alias/test-epsilon-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/epsilon/alias/test-epsilon-bid-request.json
@@ -8,6 +8,7 @@
         "w": 300,
         "h": 600
       },
+      "bidfloorcur": "USD",
       "displaymanager": "prebid-s2s",
       "displaymanagerver": "2.0.0",
       "ext": {

--- a/src/test/resources/org/prebid/server/it/openrtb2/epsilon/test-epsilon-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/epsilon/test-epsilon-bid-request.json
@@ -8,6 +8,7 @@
         "w": 300,
         "h": 600
       },
+      "bidfloorcur": "USD",
       "displaymanager": "prebid-s2s",
       "displaymanagerver": "2.0.0",
       "ext": {


### PR DESCRIPTION
The backend server rejects any requests that don't have request.cur set to USD. For now, make the Conversant/Epsilon request, and floors in USD.

These changes are intended to match the changes made here https://github.com/prebid/prebid-server/pull/3611
