### PR TITLE
Yieldmo Adapter: add currency conversion for bid floors

### DIFF
--- a/src/main/java/org/prebid/server/bidder/yieldmo/YieldmoBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldmo/YieldmoBidder.java
@@ -108,8 +108,8 @@ public class YieldmoBidder implements Bidder<BidRequest> {
 
             return Price.of(USD_CURRENCY, convertedPrice);
         } catch (PreBidException e) {
-            throw new PreBidException("Unable to convert provided bid floor currency from %s to %s for imp `%s`"
-                    .formatted(bidFloorCur, USD_CURRENCY, impId));
+            //If currency conversion fails, we still want to recieve the bid request.
+            return bidFloorPrice;
         }
     }
 

--- a/src/main/java/org/prebid/server/bidder/yieldmo/YieldmoBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldmo/YieldmoBidder.java
@@ -108,7 +108,7 @@ public class YieldmoBidder implements Bidder<BidRequest> {
 
             return Price.of(USD_CURRENCY, convertedPrice);
         } catch (PreBidException e) {
-            //If currency conversion fails, we still want to recieve the bid request.
+            // If currency conversion fails, we still want to receive the bid request.
             return bidFloorPrice;
         }
     }

--- a/src/main/java/org/prebid/server/bidder/yieldmo/YieldmoBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldmo/YieldmoBidder.java
@@ -15,7 +15,9 @@ import org.prebid.server.bidder.model.BidderBid;
 import org.prebid.server.bidder.model.BidderCall;
 import org.prebid.server.bidder.model.BidderError;
 import org.prebid.server.bidder.model.HttpRequest;
+import org.prebid.server.bidder.model.Price;
 import org.prebid.server.bidder.model.Result;
+import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.bidder.yieldmo.proto.YieldmoBidExt;
 import org.prebid.server.bidder.yieldmo.proto.YieldmoImpExt;
 import org.prebid.server.exception.PreBidException;
@@ -27,6 +29,7 @@ import org.prebid.server.proto.openrtb.ext.response.BidType;
 import org.prebid.server.util.BidderUtil;
 import org.prebid.server.util.HttpUtil;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,12 +42,17 @@ public class YieldmoBidder implements Bidder<BidRequest> {
     private static final TypeReference<ExtPrebid<?, ExtImpYieldmo>> YIELDMO_EXT_TYPE_REFERENCE =
             new TypeReference<>() {
             };
+    private static final String USD_CURRENCY = "USD";
 
     private final String endpointUrl;
+    private final CurrencyConversionService currencyConversionService;
     private final JacksonMapper mapper;
 
-    public YieldmoBidder(String endpointUrl, JacksonMapper mapper) {
+    public YieldmoBidder(String endpointUrl,
+            CurrencyConversionService currencyConversionService,
+            JacksonMapper mapper) {
         this.endpointUrl = HttpUtil.validateUrl(Objects.requireNonNull(endpointUrl));
+        this.currencyConversionService = Objects.requireNonNull(currencyConversionService);
         this.mapper = Objects.requireNonNull(mapper);
     }
 
@@ -56,7 +64,7 @@ public class YieldmoBidder implements Bidder<BidRequest> {
         for (Imp imp : bidRequest.getImp()) {
             try {
                 final ExtImpYieldmo impExt = parseImpExt(imp);
-                modifiedImps.add(modifyImp(imp, impExt));
+                modifiedImps.add(modifyImp(imp, bidRequest, impExt));
             } catch (PreBidException e) {
                 errors.add(BidderError.badInput(e.getMessage()));
             }
@@ -78,9 +86,31 @@ public class YieldmoBidder implements Bidder<BidRequest> {
         }
     }
 
-    private Imp modifyImp(Imp imp, ExtImpYieldmo ext) {
+    private Imp modifyImp(Imp imp, BidRequest bidRequest, ExtImpYieldmo ext) {
         final YieldmoImpExt modifiedExt = YieldmoImpExt.of(ext.getPlacementId(), extractGpid(imp));
-        return imp.toBuilder().ext(mapper.mapper().valueToTree(modifiedExt)).build();
+
+        Price bidFloorPrice = Price.of(imp.getBidfloorcur(), imp.getBidfloor());
+        bidFloorPrice = BidderUtil.isValidPrice(bidFloorPrice)
+                ? convertBidFloor(bidFloorPrice, imp.getId(), bidRequest) : bidFloorPrice;
+
+        return imp.toBuilder()
+            .bidfloor(bidFloorPrice.getValue())
+            .bidfloorcur(bidFloorPrice.getCurrency())
+            .ext(mapper.mapper().valueToTree(modifiedExt))
+            .build();
+    }
+
+    private Price convertBidFloor(Price bidFloorPrice, String impId, BidRequest bidRequest) {
+        final String bidFloorCur = bidFloorPrice.getCurrency();
+        try {
+            final BigDecimal convertedPrice = currencyConversionService
+                    .convertCurrency(bidFloorPrice.getValue(), bidRequest, bidFloorCur, USD_CURRENCY);
+
+            return Price.of(USD_CURRENCY, convertedPrice);
+        } catch (PreBidException e) {
+            throw new PreBidException("Unable to convert provided bid floor currency from %s to %s for imp `%s`"
+                    .formatted(bidFloorCur, USD_CURRENCY, impId));
+        }
     }
 
     private static String extractGpid(Imp imp) {

--- a/src/main/java/org/prebid/server/spring/config/bidder/YieldmoConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/YieldmoConfiguration.java
@@ -2,6 +2,7 @@ package org.prebid.server.spring.config.bidder;
 
 import org.prebid.server.bidder.BidderDeps;
 import org.prebid.server.bidder.yieldmo.YieldmoBidder;
+import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.json.JacksonMapper;
 import org.prebid.server.spring.config.bidder.model.BidderConfigurationProperties;
 import org.prebid.server.spring.config.bidder.util.BidderDepsAssembler;
@@ -30,12 +31,13 @@ public class YieldmoConfiguration {
     @Bean
     BidderDeps yieldmoBidderDeps(BidderConfigurationProperties yieldmoConfigurationProperties,
                                  @NotBlank @Value("${external-url}") String externalUrl,
-                                 JacksonMapper mapper) {
+                                 JacksonMapper mapper,
+                                 CurrencyConversionService currencyConversionService) {
 
         return BidderDepsAssembler.forBidder(BIDDER_NAME)
                 .withConfig(yieldmoConfigurationProperties)
                 .usersyncerCreator(UsersyncerCreator.create(externalUrl))
-                .bidderCreator(config -> new YieldmoBidder(config.getEndpoint(), mapper))
+                .bidderCreator(config -> new YieldmoBidder(config.getEndpoint(), currencyConversionService, mapper))
                 .assemble();
     }
 }

--- a/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
@@ -13,7 +13,12 @@ import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.prebid.server.VertxTest;
 import org.prebid.server.bidder.model.BidderBid;
 import org.prebid.server.bidder.model.BidderCall;
@@ -21,6 +26,7 @@ import org.prebid.server.bidder.model.BidderError;
 import org.prebid.server.bidder.model.HttpRequest;
 import org.prebid.server.bidder.model.HttpResponse;
 import org.prebid.server.bidder.model.Result;
+import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.bidder.yieldmo.proto.YieldmoImpExt;
 import org.prebid.server.proto.openrtb.ext.ExtPrebid;
 import org.prebid.server.proto.openrtb.ext.request.yieldmo.ExtImpYieldmo;
@@ -43,11 +49,23 @@ public class YieldmoBidderTest extends VertxTest {
     private static final String ENDPOINT_URL = "https://test.endpoint.com";
     private static final String PLACEMENT_VALUE = "placementId";
 
-    private final YieldmoBidder target = new YieldmoBidder(ENDPOINT_URL, jacksonMapper);
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private CurrencyConversionService currencyConversionService;
+
+    private YieldmoBidder target;
+
+    @Before
+    public void setUp() {
+        target = new YieldmoBidder(ENDPOINT_URL, currencyConversionService, jacksonMapper);
+    }
 
     @Test
     public void creationShouldFailOnInvalidEndpointUrl() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new YieldmoBidder("invalid_url", jacksonMapper));
+        assertThatIllegalArgumentException().isThrownBy(() -> new YieldmoBidder("invalid_url",
+                currencyConversionService, jacksonMapper));
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
@@ -28,10 +28,12 @@ import org.prebid.server.bidder.model.HttpResponse;
 import org.prebid.server.bidder.model.Result;
 import org.prebid.server.currency.CurrencyConversionService;
 import org.prebid.server.bidder.yieldmo.proto.YieldmoImpExt;
+import org.prebid.server.exception.PreBidException;
 import org.prebid.server.proto.openrtb.ext.ExtPrebid;
 import org.prebid.server.proto.openrtb.ext.request.yieldmo.ExtImpYieldmo;
 import org.prebid.server.util.HttpUtil;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -43,6 +45,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.tuple;
 import static org.prebid.server.proto.openrtb.ext.response.BidType.banner;
 import static org.prebid.server.proto.openrtb.ext.response.BidType.video;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class YieldmoBidderTest extends VertxTest {
 
@@ -173,6 +179,53 @@ public class YieldmoBidderTest extends VertxTest {
                 .containsExactly(
                         tuple(HttpUtil.CONTENT_TYPE_HEADER.toString(), HttpUtil.APPLICATION_JSON_CONTENT_TYPE),
                         tuple(HttpUtil.ACCEPT_HEADER.toString(), HttpHeaderValues.APPLICATION_JSON.toString()));
+    }
+
+    @Test
+    public void makeHttpRequestConvertsCurrencyToUsdWhenAble() {
+        //given
+        final BidRequest bidRequest = givenBidRequest(impBuilder ->
+                impBuilder.bidfloor(BigDecimal.ONE).bidfloorcur("EUR"));
+
+        final var convertedBidFloor = new BigDecimal("1.5");
+
+        when(currencyConversionService.convertCurrency(any(), any(), any(), any())).thenReturn(convertedBidFloor);
+
+        //when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        //then
+        verify(currencyConversionService).convertCurrency(eq(BigDecimal.ONE), any(), eq("EUR"), eq("USD"));
+        assertThat(result.getValue()).hasSize(1).doesNotContainNull()
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp).doesNotContainNull()
+                .extracting(Imp::getBidfloor, Imp::getBidfloorcur)
+                .containsOnly(tuple(convertedBidFloor, "USD"));
+
+    }
+
+    @Test
+    public void makeHttpRequestShouldUseOriginalBidFloorsIfCurrencyCanNotBeConverted() {
+        //given
+        final BidRequest bidRequest = givenBidRequest(impBuilder ->
+                impBuilder.bidfloor(BigDecimal.ONE).bidfloorcur("EUR"));
+
+        final var convertedBidFloor = new BigDecimal("1.5");
+
+        when(currencyConversionService.convertCurrency(any(), any(), any(), any())).thenThrow(
+                new PreBidException("currency could not be converted"));
+
+        //when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        //then
+        verify(currencyConversionService).convertCurrency(eq(BigDecimal.ONE), any(), eq("EUR"), eq("USD"));
+        assertThat(result.getValue()).hasSize(1).doesNotContainNull()
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp).doesNotContainNull()
+                .extracting(Imp::getBidfloor, Imp::getBidfloorcur)
+                .containsOnly(tuple(BigDecimal.ONE, "EUR"));
+
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/yieldmo/YieldmoBidderTest.java
@@ -187,7 +187,7 @@ public class YieldmoBidderTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(impBuilder ->
                 impBuilder.bidfloor(BigDecimal.ONE).bidfloorcur("EUR"));
 
-        final var convertedBidFloor = new BigDecimal("1.5");
+        final BigDecimal convertedBidFloor = new BigDecimal("1.5");
 
         when(currencyConversionService.convertCurrency(any(), any(), any(), any())).thenReturn(convertedBidFloor);
 
@@ -201,7 +201,6 @@ public class YieldmoBidderTest extends VertxTest {
                 .flatExtracting(BidRequest::getImp).doesNotContainNull()
                 .extracting(Imp::getBidfloor, Imp::getBidfloorcur)
                 .containsOnly(tuple(convertedBidFloor, "USD"));
-
     }
 
     @Test
@@ -225,7 +224,6 @@ public class YieldmoBidderTest extends VertxTest {
                 .flatExtracting(BidRequest::getImp).doesNotContainNull()
                 .extracting(Imp::getBidfloor, Imp::getBidfloorcur)
                 .containsOnly(tuple(BigDecimal.ONE, "EUR"));
-
     }
 
     @Test


### PR DESCRIPTION
This branch adds currency conversion for bid floors to the yieldmo adapter. I wasn't able to find any documentation around this feature, so this is largely based off of the implementations found in other adapters.