### PR TITLE
Add Logback support for metrics

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -217,6 +217,12 @@ Also, each bidder could have its own bidder-specific options.
 So far metrics cannot be submitted simultaneously to many backends. Currently we support `graphite` and `influxdb`. 
 Also, for debug purposes you can use `console` as metrics backend.
 
+For `logback` backend type available next options:
+- `metrics.logback.enabled` - if equals to `true` then logback reporter will be started.
+- `metrics.logback.name` - name of logger element in the logback configuration file.
+- `metrics.logback.interval` - interval in seconds between successive sending metrics.
+
+
 For `graphite` backend type available next options:
 - `metrics.graphite.enabled` - if equals to `true` then `graphite` will be used to submit metrics.
 - `metrics.graphite.prefix` - the prefix of all metric names.

--- a/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
@@ -94,7 +94,7 @@ public class MetricsConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "metrics.log", name = "enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "metrics.logback", name = "enabled", havingValue = "true")
     ScheduledReporter logReporter(MetricsLogProperties metricsLogProperties, MetricRegistry metricRegistry) {
         final ScheduledReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
                 .outputTo(LoggerFactory.getLogger(metricsLogProperties.getName()))

--- a/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
@@ -197,8 +197,8 @@ public class MetricsConfiguration {
     }
 
     @Component
-    @ConfigurationProperties(prefix = "metrics.log")
-    @ConditionalOnProperty(prefix = "metrics.log", name = "enabled", havingValue = "true")
+    @ConfigurationProperties(prefix = "metrics.logback")
+    @ConditionalOnProperty(prefix = "metrics.logback", name = "enabled", havingValue = "true")
     @Validated
     @Data
     @NoArgsConstructor

--- a/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/metrics/MetricsConfiguration.java
@@ -104,7 +104,7 @@ public class MetricsConfiguration {
 
         return reporter;
     }
-    
+
     @Bean
     Metrics metrics(@Value("${metrics.metricType}") CounterType counterType, MetricRegistry metricRegistry,
                     AccountMetricsVerbosityResolver accountMetricsVerbosityResolver) {
@@ -210,7 +210,7 @@ public class MetricsConfiguration {
         @NotBlank
         private String name;
     }
-    
+
     @Component
     @ConfigurationProperties(prefix = "metrics.accounts")
     @Validated


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [ x ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

This PR activates Logback reporters for metrics. 

### 🧠 Rationale behind the change

PBS-Java currently supports Influx, Graphite, Prometheus, and Console for metrics (see https://docs.prebid.org/prebid-server/hosting/pbs-hosting.html). This PR extends that list by adding support for Logback so that metrics can be configured with the same patterns and configuration files used for configuring runtime logs.

### 🧪 Test plan

These Logback capabilities already exist in PBS-Java, they just aren't enabled. No new dependencies or business logic have been added.

### 🏎 Quality check

- [ x ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ n/a ] Are there any breaking changes in your code?
- [ n/a ] Does your test coverage exceed 90%?
- [ n/a ] Are there any erroneous console logs, debuggers or leftover code in your changes?
