### PR TITLE
CPMStar: Updated vendor-id for TCF/GVL

### DIFF
--- a/src/main/resources/bidder-config/cpmstar.yaml
+++ b/src/main/resources/bidder-config/cpmstar.yaml
@@ -10,7 +10,7 @@ adapters:
         - banner
         - video
       supported-vendors:
-      vendor-id: 0
+      vendor-id: 1317
     usersync:
       cookie-family-name: cpmstar
       iframe:


### PR DESCRIPTION
### 🔧 Type of changes
- [X] update bid adapter
- [X] configuration

### ✨ What's the context?
- Updated vendor-id for TCF/GVL in bidder-config

### 🧠 Rationale behind the change
- CPMStar now is on the GVL

### 🧪 Test plan
- Tested on production already 
- Config changes only, no code changes

### 🏎 Quality check
- Config changes only, no code changes

