### PR TITLE
Add CPM, bidder params, UserAgent, PBS flag in GreenbidsAnalyticsReporter

### DIFF
--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/CommonMessage.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/CommonMessage.java
@@ -17,7 +17,7 @@ public class CommonMessage {
 
     String referrer;
 
-    double sampling;
+    Double sampling;
 
     @JsonProperty("prebidServer")
     String prebidServer;

--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsAdUnit.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsAdUnit.java
@@ -18,5 +18,5 @@ public class GreenbidsAdUnit {
     @JsonProperty("mediaTypes")
     MediaTypes mediaTypes;
 
-    List<GreenbidsBids> bids;
+    List<GreenbidsBid> bids;
 }

--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsAnalyticsProperties.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsAnalyticsProperties.java
@@ -9,6 +9,8 @@ public class GreenbidsAnalyticsProperties {
 
     Double exploratorySamplingSplit;
 
+    Double defaultSamplingRate;
+
     String analyticsServerVersion;
 
     String analyticsServerUrl;

--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBid.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBid.java
@@ -28,18 +28,24 @@ public class GreenbidsBid {
 
     String currency;
 
-    public static GreenbidsBidBuilder ofBidBuilder(String seat, Bid bid) {
+    public static GreenbidsBid ofBid(String seat, Bid bid, JsonNode params, String currency) {
         return GreenbidsBid.builder()
                 .bidder(seat)
                 .isTimeout(false)
                 .hasBid(bid != null)
-                .cpm(bid.getPrice());
+                .params(params)
+                .cpm(bid.getPrice())
+                .currency(currency)
+                .build();
     }
 
-    public static GreenbidsBidBuilder ofNonBidBuilder(String seat, NonBid nonBid) {
+    public static GreenbidsBid ofNonBid(String seat, NonBid nonBid, JsonNode params, String currency) {
         return GreenbidsBid.builder()
                 .bidder(seat)
                 .isTimeout(nonBid.getStatusCode() == BidRejectionReason.TIMED_OUT)
-                .hasBid(false);
+                .hasBid(false)
+                .params(params)
+                .currency(currency)
+                .build();
     }
 }

--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBid.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBid.java
@@ -28,20 +28,18 @@ public class GreenbidsBid {
 
     String currency;
 
-    public static GreenbidsBid ofBid(String seat, Bid bid) {
+    public static GreenbidsBidBuilder ofBidBuilder(String seat, Bid bid) {
         return GreenbidsBid.builder()
                 .bidder(seat)
                 .isTimeout(false)
                 .hasBid(bid != null)
-                .cpm(bid.getPrice())
-                .build();
+                .cpm(bid.getPrice());
     }
 
-    public static GreenbidsBid ofNonBid(String seat, NonBid nonBid) {
+    public static GreenbidsBidBuilder ofNonBidBuilder(String seat, NonBid nonBid) {
         return GreenbidsBid.builder()
                 .bidder(seat)
                 .isTimeout(nonBid.getStatusCode() == BidRejectionReason.TIMED_OUT)
-                .hasBid(false)
-                .build();
+                .hasBid(false);
     }
 }

--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBid.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBid.java
@@ -12,7 +12,7 @@ import java.math.BigDecimal;
 
 @Builder(toBuilder = true)
 @Value
-public class GreenbidsBids {
+public class GreenbidsBid {
 
     String bidder;
 
@@ -28,8 +28,8 @@ public class GreenbidsBids {
 
     String currency;
 
-    public static GreenbidsBids ofBid(String seat, Bid bid) {
-        return GreenbidsBids.builder()
+    public static GreenbidsBid ofBid(String seat, Bid bid) {
+        return GreenbidsBid.builder()
                 .bidder(seat)
                 .isTimeout(false)
                 .hasBid(bid != null)
@@ -37,8 +37,8 @@ public class GreenbidsBids {
                 .build();
     }
 
-    public static GreenbidsBids ofNonBid(String seat, NonBid nonBid) {
-        return GreenbidsBids.builder()
+    public static GreenbidsBid ofNonBid(String seat, NonBid nonBid) {
+        return GreenbidsBid.builder()
                 .bidder(seat)
                 .isTimeout(nonBid.getStatusCode() == BidRejectionReason.TIMED_OUT)
                 .hasBid(false)

--- a/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBids.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/greenbids/model/GreenbidsBids.java
@@ -1,11 +1,14 @@
 package org.prebid.server.analytics.reporter.greenbids.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.iab.openrtb.response.Bid;
 import lombok.Builder;
 import lombok.Value;
 import org.prebid.server.auction.model.BidRejectionReason;
 import org.prebid.server.proto.openrtb.ext.response.seatnonbid.NonBid;
+
+import java.math.BigDecimal;
 
 @Builder(toBuilder = true)
 @Value
@@ -19,11 +22,18 @@ public class GreenbidsBids {
     @JsonProperty("hasBid")
     Boolean hasBid;
 
+    JsonNode params;
+
+    BigDecimal cpm;
+
+    String currency;
+
     public static GreenbidsBids ofBid(String seat, Bid bid) {
         return GreenbidsBids.builder()
                 .bidder(seat)
                 .isTimeout(false)
                 .hasBid(bid != null)
+                .cpm(bid.getPrice())
                 .build();
     }
 

--- a/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
@@ -91,11 +91,14 @@ public class AnalyticsConfiguration {
 
             Double exploratorySamplingSplit;
 
+            Double defaultSamplingRate;
+
             Long timeoutMs;
 
             public GreenbidsAnalyticsProperties toComponentProperties() {
                 return GreenbidsAnalyticsProperties.builder()
                         .exploratorySamplingSplit(getExploratorySamplingSplit())
+                        .defaultSamplingRate(getDefaultSamplingRate())
                         .analyticsServerVersion(getAnalyticsServerVersion())
                         .analyticsServerUrl(getAnalyticsServer())
                         .timeoutMs(getTimeoutMs())

--- a/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
@@ -597,16 +597,6 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
         return prebidNode;
     }
 
-    private static UnaryOperator<ObjectNode> createBidderParams(
-            String bidder, UnaryOperator<ObjectNode> paramsCustomizer) {
-        return bidderNode -> {
-            final ObjectNode paramsNode = mapper.createObjectNode();
-            paramsCustomizer.apply(paramsNode);
-            bidderNode.set(bidder, paramsNode);
-            return bidderNode;
-        };
-    }
-
     private static ExtRequest givenExtRequest() {
         final ObjectNode greenbidsNode = new ObjectMapper().createObjectNode();
         greenbidsNode.put("pbuid", "leparisien");

--- a/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
@@ -29,7 +29,7 @@ import org.prebid.server.analytics.reporter.greenbids.model.CommonMessage;
 import org.prebid.server.analytics.reporter.greenbids.model.ExtBanner;
 import org.prebid.server.analytics.reporter.greenbids.model.GreenbidsAdUnit;
 import org.prebid.server.analytics.reporter.greenbids.model.GreenbidsAnalyticsProperties;
-import org.prebid.server.analytics.reporter.greenbids.model.GreenbidsBids;
+import org.prebid.server.analytics.reporter.greenbids.model.GreenbidsBid;
 import org.prebid.server.analytics.reporter.greenbids.model.GreenbidsUnifiedCode;
 import org.prebid.server.analytics.reporter.greenbids.model.MediaTypes;
 import org.prebid.server.auction.model.AuctionContext;
@@ -610,7 +610,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .build();
     }
 
-    private static List<GreenbidsBids> givenGreenbidsBids() {
+    private static List<GreenbidsBid> givenGreenbidsBids() {
         final ObjectNode paramsSeat1 = mapper.createObjectNode()
                 .put("accountId", 1001)
                 .put("siteId", 267318)
@@ -632,10 +632,10 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                         .currency("USD").params(paramsSeat3));
     }
 
-    private static List<GreenbidsBids> givenGreenbidsBidsWithCustomizer(
-            UnaryOperator<GreenbidsBids.GreenbidsBidsBuilder>... greenbidsBidsCustomizers) {
+    private static List<GreenbidsBid> givenGreenbidsBidsWithCustomizer(
+            UnaryOperator<GreenbidsBid.GreenbidsBidBuilder>... greenbidsBidsCustomizers) {
         return Arrays.stream(greenbidsBidsCustomizers)
-                .map(customizer -> customizer.apply(GreenbidsBids.builder()).build())
+                .map(customizer -> customizer.apply(GreenbidsBid.builder()).build())
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
@@ -57,10 +57,12 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
+import static java.util.function.UnaryOperator.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -132,7 +134,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .banner(banner)
                 .build();
 
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -149,10 +151,10 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                urlCaptor.capture(),
-                headersCaptor.capture(),
+                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                any(MultiMap.class),
                 jsonCaptor.capture(),
-                timeoutCaptor.capture());
+                eq(greenbidsAnalyticsProperties.getTimeoutMs()));
 
         final String capturedJson = jsonCaptor.getValue();
         final CommonMessage capturedCommonMessage = jacksonMapper.mapper()
@@ -179,7 +181,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .video(video)
                 .build();
 
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -196,10 +198,10 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                urlCaptor.capture(),
-                headersCaptor.capture(),
+                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                any(MultiMap.class),
                 jsonCaptor.capture(),
-                timeoutCaptor.capture());
+                eq(greenbidsAnalyticsProperties.getTimeoutMs()));
 
         final String capturedJson = jsonCaptor.getValue();
         final CommonMessage capturedCommonMessage = jacksonMapper.mapper()
@@ -225,7 +227,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .ext(impExtNode)
                 .build();
 
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -247,10 +249,10 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                urlCaptor.capture(),
-                headersCaptor.capture(),
+                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                any(MultiMap.class),
                 jsonCaptor.capture(),
-                timeoutCaptor.capture());
+                eq(greenbidsAnalyticsProperties.getTimeoutMs()));
 
         final String capturedJson = jsonCaptor.getValue();
         final CommonMessage capturedCommonMessage = jacksonMapper.mapper()
@@ -276,7 +278,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .banner(banner)
                 .build();
 
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -292,10 +294,10 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                urlCaptor.capture(),
+                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
                 headersCaptor.capture(),
-                jsonCaptor.capture(),
-                timeoutCaptor.capture());
+                anyString(),
+                eq(greenbidsAnalyticsProperties.getTimeoutMs()));
 
         assertThat(result.succeeded()).isTrue();
         assertThat(headersCaptor.getValue().get(HttpUtil.ACCEPT_HEADER))
@@ -304,14 +306,12 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .isEqualTo(HttpHeaderValues.APPLICATION_JSON.toString());
         assertThat(headersCaptor.getValue().get(HttpUtil.USER_AGENT_HEADER))
                 .isEqualTo(givenUserAgent());
-        assertThat(timeoutCaptor.getValue()).isEqualTo(greenbidsAnalyticsProperties.getTimeoutMs());
-        assertThat(urlCaptor.getValue()).isEqualTo(greenbidsAnalyticsProperties.getAnalyticsServerUrl());
     }
 
     @Test
     public void shouldFailWhenBidResponseIsNull() {
         // given
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, null, false);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), null, false);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -348,7 +348,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
         final Imp imp = Imp.builder()
                 .banner(banner)
                 .build();
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -375,7 +375,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .banner(banner)
                 .ext(impExtNode)
                 .build();
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -414,7 +414,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .banner(banner)
                 .ext(impExtNode)
                 .build();
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -481,7 +481,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
                 .ext(prebidJsonNodes)
                 .banner(givenBanner())
                 .build();
-        final AuctionContext auctionContext = givenAuctionContext(context -> context, List.of(imp), true);
+        final AuctionContext auctionContext = givenAuctionContext(identity(), List.of(imp), true);
         final AuctionEvent event = AuctionEvent.builder()
                 .auctionContext(auctionContext)
                 .bidResponse(auctionContext.getBidResponse())
@@ -580,25 +580,26 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
     }
 
     private static ObjectNode givenPrebidBidderParamsNode() {
-        return givenPrebidObjectNode(
-                createBidderParams("seat1", params -> params
-                        .put("accountId", 1001)
-                        .put("siteId", 267318)
-                        .put("zoneId", 1861698)),
-                createBidderParams("seat2", params -> params
-                        .put("publisherId", 111)
-                        .put("adSlotId", 123456)),
-                createBidderParams("seat3", params -> params
-                        .put("placementId", 222))
-        );
-    }
-
-    private static ObjectNode givenPrebidObjectNode(UnaryOperator<ObjectNode>... bidderCustomizers) {
         final ObjectNode bidderNode = mapper.createObjectNode();
-        Arrays.stream(bidderCustomizers).forEach(customizer -> customizer.apply(bidderNode));
+
+        final ObjectNode seat1Params = mapper.createObjectNode()
+                .put("accountId", 1001)
+                .put("siteId", 267318)
+                .put("zoneId", 1861698);
+        bidderNode.set("seat1", seat1Params);
+
+        final ObjectNode seat2Params = mapper.createObjectNode()
+                .put("publisherId", 111)
+                .put("adSlotId", 123456);
+        bidderNode.set("seat2", seat2Params);
+
+        final ObjectNode seat3Params = mapper.createObjectNode()
+                .put("placementId", 222);
+        bidderNode.set("seat3", seat3Params);
 
         final ObjectNode prebidNode = mapper.createObjectNode();
         prebidNode.set("bidder", bidderNode);
+
         return prebidNode;
     }
 

--- a/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
@@ -61,7 +61,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -78,6 +77,9 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
     @Captor
     private ArgumentCaptor<Long> timeoutCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> urlCaptor;
 
     @Mock
     private HttpClient httpClient;
@@ -147,7 +149,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                urlCaptor.capture(),
                 headersCaptor.capture(),
                 jsonCaptor.capture(),
                 timeoutCaptor.capture());
@@ -194,7 +196,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                urlCaptor.capture(),
                 headersCaptor.capture(),
                 jsonCaptor.capture(),
                 timeoutCaptor.capture());
@@ -245,7 +247,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                urlCaptor.capture(),
                 headersCaptor.capture(),
                 jsonCaptor.capture(),
                 timeoutCaptor.capture());
@@ -261,7 +263,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
     }
 
     @Test
-    public void shouldReturnValidHeadersAndTimeouts() throws IOException {
+    public void shouldReturnValidHeadersAndTimeouts() {
         final Banner banner = givenBanner();
 
         final ObjectNode impExtNode = mapper.createObjectNode();
@@ -290,7 +292,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
 
         // then
         verify(httpClient).post(
-                eq(greenbidsAnalyticsProperties.getAnalyticsServerUrl()),
+                urlCaptor.capture(),
                 headersCaptor.capture(),
                 jsonCaptor.capture(),
                 timeoutCaptor.capture());
@@ -303,6 +305,7 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
         assertThat(headersCaptor.getValue().get(HttpUtil.USER_AGENT_HEADER))
                 .isEqualTo(givenUserAgent());
         assertThat(timeoutCaptor.getValue()).isEqualTo(greenbidsAnalyticsProperties.getTimeoutMs());
+        assertThat(urlCaptor.getValue()).isEqualTo(greenbidsAnalyticsProperties.getAnalyticsServerUrl());
     }
 
     @Test

--- a/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
@@ -77,12 +77,6 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
     @Captor
     private ArgumentCaptor<MultiMap> headersCaptor;
 
-    @Captor
-    private ArgumentCaptor<Long> timeoutCaptor;
-
-    @Captor
-    private ArgumentCaptor<String> urlCaptor;
-
     @Mock
     private HttpClient httpClient;
 

--- a/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/greenbids/GreenbidsAnalyticsReporterTest.java
@@ -470,15 +470,14 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
         return siteCustomizer.apply(Site.builder().domain("www.leparisien.fr")).build();
     }
 
-
     private static Device givenDevice(UnaryOperator<Device.DeviceBuilder> deviceCustomizer) {
         return deviceCustomizer.apply(Device.builder().ua(givenUserAgent()))
                 .build();
     }
 
     private static String givenUserAgent() {
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8)" +
-                "AppleWebKit/537.13 (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2";
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8)"
+                + "AppleWebKit/537.13 (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2";
     }
 
     private static BidResponse givenBidResponse(UnaryOperator<BidResponse.BidResponseBuilder> bidResponseCustomizer) {
@@ -536,18 +535,18 @@ public class GreenbidsAnalyticsReporterTest extends VertxTest {
     }
 
     private static ObjectNode givenPrebidObjectNode(UnaryOperator<ObjectNode>... bidderCustomizers) {
-        ObjectNode bidderNode = mapper.createObjectNode();
+        final ObjectNode bidderNode = mapper.createObjectNode();
         Arrays.stream(bidderCustomizers).forEach(customizer -> customizer.apply(bidderNode));
 
-        ObjectNode prebidNode = mapper.createObjectNode();
+        final ObjectNode prebidNode = mapper.createObjectNode();
         prebidNode.set("bidder", bidderNode);
         return prebidNode;
     }
 
     private static UnaryOperator<ObjectNode> createBidderParams(
-            String bidder,UnaryOperator<ObjectNode> paramsCustomizer) {
+            String bidder, UnaryOperator<ObjectNode> paramsCustomizer) {
         return bidderNode -> {
-            ObjectNode paramsNode = mapper.createObjectNode();
+            final ObjectNode paramsNode = mapper.createObjectNode();
             paramsCustomizer.apply(paramsNode);
             bidderNode.set(bidder, paramsNode);
             return bidderNode;


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] new analytics adapter
- [x] update analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

We want to add the following info into analytics payload

- CPM from Bid, currency from BidResponse for each bidder
- bidder specific params from the BidRequest extension imp[].ext.prebid.bidder
- also we want to add to the HTTP header
  - the custom flag header into HTTP POST call to distinguish between PBJS and PBS traffic on Greenbids Analytics Server side
  - UserAgent header


### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?


### 🧪 Test plan

Have added `givenPrebidNode` with the bidder params and `UserAgent` string into `BidRequest.Device` into `GreenbidsAnalyticsReporterTest` so we can test the new payload.


### 🏎 Quality check

- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
