### PR TITLE
Gumgum remove video validations

### DIFF
--- a/src/main/java/org/prebid/server/bidder/gumgum/GumgumBidder.java
+++ b/src/main/java/org/prebid/server/bidder/gumgum/GumgumBidder.java
@@ -135,7 +135,6 @@ public class GumgumBidder implements Bidder<BidRequest> {
 
         final Video video = imp.getVideo();
         if (video != null) {
-            validateVideoParams(video);
             final String irisId = extImp.getIrisId();
             if (StringUtils.isNotEmpty(irisId)) {
                 final Video resolvedVideo = resolveVideo(video, irisId);
@@ -172,18 +171,6 @@ public class GumgumBidder implements Bidder<BidRequest> {
                         .thenComparing(Format::getH))
                 .map(format -> ExtImpGumgumBanner.of(slot, format.getW(), format.getH()))
                 .orElseGet(() -> ExtImpGumgumBanner.of(slot, 0, 0));
-    }
-
-    private void validateVideoParams(Video video) {
-        if (anyOfNull(
-                video.getW(),
-                video.getH(),
-                video.getMinduration(),
-                video.getMaxduration(),
-                video.getPlacement(),
-                video.getLinearity())) {
-            throw new PreBidException("Invalid or missing video field(s)");
-        }
     }
 
     private Video resolveVideo(Video video, String irisId) {

--- a/src/test/java/org/prebid/server/bidder/gumgum/GumgumBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/gumgum/GumgumBidderTest.java
@@ -73,44 +73,6 @@ public class GumgumBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldReturnErrorIfNoValidImpressions() {
-        // given
-        final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(
-                        givenImp(impBuilder -> impBuilder.video(Video.builder().build()))))
-                .build();
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).hasSize(2)
-                .contains(BidderError.badInput("No valid impressions"));
-        assertThat(result.getValue()).isEmpty();
-    }
-
-    @Test
-    public void makeHttpRequestsShouldReturnErrorIfVideoFieldsAreNotValid() {
-        // given
-        final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(Imp.builder()
-                        .video(Video.builder().w(0).build())
-                        .ext(mapper.valueToTree(ExtPrebid.of(null,
-                                ExtImpGumgum.of("zone", BigInteger.TEN, "irisId", null, null))))
-                        .build()))
-                .build();
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors())
-                .containsExactlyInAnyOrder(BidderError.badInput("Invalid or missing video field(s)"),
-                        BidderError.badInput("No valid impressions"));
-        assertThat(result.getValue()).isEmpty();
-    }
-
-    @Test
     public void makeHttpRequestsShouldModifyVideoExtOfIrisIdIsPresent() {
         // given
         final BidRequest bidRequest = BidRequest.builder()


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

What's the context for the changes? 
Currently, Prebid Server conducts validations for certain video parameters before passing inventory requests to the GG ad server. This preliminary validation prevents the GG ad server from receiving complete inventory data, limiting our ability to apply comprehensive validations and record inventory details.


### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?


### 🧪 Test plan

Since this is about removing validations should bot present any risk


### 🏎 Quality check

- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
