### PR TITLE
OpenX: populate BidderBid.videoInfo for targeting

### DIFF
--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -29,6 +29,7 @@ import org.prebid.server.proto.openrtb.ext.request.ExtImpPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
 import org.prebid.server.proto.openrtb.ext.request.openx.ExtImpOpenx;
 import org.prebid.server.proto.openrtb.ext.response.BidType;
+import org.prebid.server.proto.openrtb.ext.response.ExtBidPrebidVideo;
 import org.prebid.server.proto.openrtb.ext.response.FledgeAuctionConfig;
 import org.prebid.server.util.BidderUtil;
 import org.prebid.server.util.HttpUtil;
@@ -253,8 +254,24 @@ public class OpenxBidder implements Bidder<BidRequest> {
                 .map(SeatBid::getBid)
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
-                .map(bid -> BidderBid.of(bid, getBidType(bid, impIdToBidType), bidCurrency))
+                .map(bid -> toBidderBid(bid, impIdToBidType, bidCurrency))
                 .toList();
+    }
+
+    private static BidderBid toBidderBid(Bid bid, Map<String, BidType> impIdToBidType, String bidCurrency) {
+        final BidType bidType = getBidType(bid, impIdToBidType);
+        final ExtBidPrebidVideo videoInfo = bidType == BidType.video ? getVideoInfo(bid) : null;
+        return BidderBid.builder()
+                .bid(bid)
+                .type(bidType)
+                .bidCurrency(bidCurrency)
+                .videoInfo(videoInfo)
+                .build();
+    }
+
+    private static ExtBidPrebidVideo getVideoInfo(Bid bid) {
+        final String primaryCategory = CollectionUtils.isEmpty(bid.getCat()) ? null : bid.getCat().getFirst();
+        return ExtBidPrebidVideo.of(bid.getDur(), primaryCategory);
     }
 
     private static Map<String, BidType> impIdToBidType(BidRequest bidRequest) {


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Populate BidderBid.videoInfo object for generation of `hb_pb_cat_dur` targeting

### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?
Closes #3353 for 
PBS-Go counterpart PR: https://github.com/prebid/prebid-server/pull/3834

### 🧪 Test plan

How do you know the changes are safe to ship to production?


### 🏎 Quality check

- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
