### PR TITLE
Github actions: fix github container registry workflow

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -1,10 +1,9 @@
 name: Publish Docker image for new tag/release
 
 on:
-  workflow_run:
-    workflows: [Publish release]
-    types:
-      - completed
+  push:
+    tags:
+      - '*'
 
 env:
   REGISTRY: ghcr.io
@@ -20,36 +19,42 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        dockerfile-path: [Dockerfile, extra/Dockerfile]
+        dockerfile-path: [Dockerfile, Dockerfile-modules]
         include:
           - dockerfile-path: Dockerfile
             build-cmd: mvn clean package -Dcheckstyle.skip -Dmaven.test.skip=true
             package-name: ghcr.io/${{ github.repository }}
-          - dockerfile-path: extra/Dockerfile
+
+          - dockerfile-path: Dockerfile-modules
             build-cmd: mvn clean package --file extra/pom.xml -Dcheckstyle.skip -Dmaven.test.skip=true
             package-name: ghcr.io/${{ github.repository }}-bundle
     steps:
+      - name: Check out Repository
+        uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           cache: 'maven'
           java-version: ${{ matrix.java }}
+
       - name: Build .jar via Maven
         run: ${{ matrix.build-cmd }}
-      - name: Checkout repository
-        uses: actions/checkout@v4
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker Image
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.package-name }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

We have a disabled github actions workflow to build and publish docker image of prebid server to github container registry. This workflow is disabled because its broken. This pr will fix it.


### 🏎 Quality check

- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
