### PR TITLE
RTB House: resolve oRTB `AUCTION_PRICE` macro

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidder.java
@@ -41,6 +41,7 @@ public class RtbhouseBidder implements Bidder<BidRequest> {
             new TypeReference<>() {
             };
     private static final String BIDDER_CURRENCY = "USD";
+    private static final String PRICE_MACRO = "${AUCTION_PRICE}";
 
     private final String endpointUrl;
     private final JacksonMapper mapper;
@@ -127,7 +128,7 @@ public class RtbhouseBidder implements Bidder<BidRequest> {
                 .build();
 
         return BidderBid.builder()
-                .bid(updatedBid)
+                .bid(resolveMacros(updatedBid))
                 .type(bidType)
                 .bidCurrency(currency)
                 .build();
@@ -210,6 +211,16 @@ public class RtbhouseBidder implements Bidder<BidRequest> {
                     "Unable to convert provided bid floor currency from %s to %s for imp `%s`",
                     bidFloorCur, BIDDER_CURRENCY, impId));
         }
+    }
+
+    private static Bid resolveMacros(Bid bid) {
+        final BigDecimal price = bid.getPrice();
+        final String priceAsString = price != null ? price.toPlainString() : "0";
+
+        return bid.toBuilder()
+                .nurl(StringUtils.replace(bid.getNurl(), PRICE_MACRO, priceAsString))
+                .adm(StringUtils.replace(bid.getAdm(), PRICE_MACRO, priceAsString))
+                .build();
     }
 
 }

--- a/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-auction-rtbhouse-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-auction-rtbhouse-response.json
@@ -7,7 +7,7 @@
           "id": "bid_id",
           "impid": "imp_id",
           "price": 0.5,
-          "adm": "some-test-ad ${AUCTION_PRICE}",
+          "adm": "some-test-ad_0.5",
           "adid": "12345678",
           "cid": "987",
           "crid": "12345678",

--- a/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-auction-rtbhouse-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-auction-rtbhouse-response.json
@@ -7,7 +7,7 @@
           "id": "bid_id",
           "impid": "imp_id",
           "price": 0.5,
-          "adm": "some-test-ad",
+          "adm": "some-test-ad ${AUCTION_PRICE}",
           "adid": "12345678",
           "cid": "987",
           "crid": "12345678",

--- a/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-rtbhouse-bid-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-rtbhouse-bid-response.json
@@ -9,7 +9,7 @@
           "impid": "imp_id",
           "price": 0.500000,
           "adid": "12345678",
-          "adm": "some-test-ad 0.5",
+          "adm": "some-test-ad_${AUCTION_PRICE}",
           "cid": "987",
           "crid": "12345678",
           "h": 250,

--- a/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-rtbhouse-bid-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-rtbhouse-bid-response.json
@@ -9,7 +9,7 @@
           "impid": "imp_id",
           "price": 0.500000,
           "adid": "12345678",
-          "adm": "some-test-ad",
+          "adm": "some-test-ad 0.5",
           "cid": "987",
           "crid": "12345678",
           "h": 250,


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] update bid adapter
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

The adapter is now able to resolve `${AUCTION_PRICE}` macro in win notify URLs.


### 🧠 Rationale behind the change
Win notify URLs contain the macro. It has to be resolved with the default bidder's currency.
PBS-Go counterpart PR: https://github.com/prebid/prebid-server/pull/3901

### 🧪 Test plan

Tests passed. Expected behavior tested locally.


### 🏎 Quality check

- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?

### Other information
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).