### PR TITLE
agma: bugfixes

### DIFF
--- a/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
@@ -97,7 +97,12 @@ public class AgmaAnalyticsReporter implements AnalyticsReporter, Initializable {
 
     @Override
     public void initialize(Promise<Void> initializePromise) {
-        vertx.setPeriodic(bufferTimeoutMs, ignored -> sendEvents(buffer.pollAll()));
+        vertx.setPeriodic(bufferTimeoutMs, ignored -> {
+            final List<String> toFlush = buffer.pollAll();
+            if (!toFlush.isEmpty()) {
+                sendEvents(toFlush);
+            }
+        });
         initializePromise.complete();
     }
 

--- a/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
@@ -206,8 +206,8 @@ public class AgmaAnalyticsReporter implements AnalyticsReporter, Initializable {
             return null;
         }
 
-        return appSiteId != null
-                ? String.format("%s_%s", StringUtils.defaultString(publisherId, ""), appSiteId)
+        return StringUtils.isNotBlank(appSiteId)
+                ? String.format("%s_%s", StringUtils.defaultString(publisherId), appSiteId)
                 : publisherId;
     }
 

--- a/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
@@ -195,17 +195,17 @@ public class AgmaAnalyticsReporter implements AnalyticsReporter, Initializable {
 
         final String publisherId = Optional.ofNullable(site).map(Site::getPublisher).map(Publisher::getId)
                 .or(() -> Optional.ofNullable(app).map(App::getPublisher).map(Publisher::getId))
-                .orElse(null);
+                .orElse("");
         final String appSiteId = Optional.ofNullable(site).map(Site::getId)
                 .or(() -> Optional.ofNullable(app).map(App::getId))
                 .or(() -> Optional.ofNullable(app).map(App::getBundle))
                 .orElse(null);
 
-        if (publisherId == null && appSiteId == null) {
+        if (publisherId.equals("") && appSiteId == null) {
             return null;
         }
 
-        return publisherId;
+        return appSiteId != null ? publisherId + "_" + appSiteId : publisherId;
     }
 
     private void sendEvents(List<String> events) {

--- a/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
@@ -16,6 +16,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.prebid.server.analytics.AnalyticsReporter;
 import org.prebid.server.analytics.model.AmpEvent;
@@ -195,17 +196,19 @@ public class AgmaAnalyticsReporter implements AnalyticsReporter, Initializable {
 
         final String publisherId = Optional.ofNullable(site).map(Site::getPublisher).map(Publisher::getId)
                 .or(() -> Optional.ofNullable(app).map(App::getPublisher).map(Publisher::getId))
-                .orElse("");
+                .orElse(null);
         final String appSiteId = Optional.ofNullable(site).map(Site::getId)
                 .or(() -> Optional.ofNullable(app).map(App::getId))
                 .or(() -> Optional.ofNullable(app).map(App::getBundle))
                 .orElse(null);
 
-        if (publisherId.equals("") && appSiteId == null) {
+        if (publisherId == null && appSiteId == null) {
             return null;
         }
 
-        return appSiteId != null ? publisherId + "_" + appSiteId : publisherId;
+        return appSiteId != null
+                ? String.format("%s_%s", StringUtils.defaultString(publisherId, ""), appSiteId)
+                : publisherId;
     }
 
     private void sendEvents(List<String> events) {

--- a/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.analytics.AnalyticsReporter;
 import org.prebid.server.analytics.reporter.AnalyticsReporterDelegator;
 import org.prebid.server.analytics.reporter.agma.AgmaAnalyticsReporter;
@@ -114,8 +115,8 @@ public class AnalyticsConfiguration {
                                 account -> {
                                     final String publisherId = account.getPublisherId();
                                     final String siteAppId = account.getSiteAppId();
-                                    return (siteAppId != null && !siteAppId.isEmpty())
-                                            ? publisherId + "_" + siteAppId
+                                    return StringUtils.isNotBlank(siteAppId)
+                                            ? String.format("%s_%s", publisherId, siteAppId)
                                             : publisherId;
                                 },
                                 AgmaAnalyticsAccountProperties::getCode

--- a/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
@@ -112,13 +112,7 @@ public class AnalyticsConfiguration {
             public AgmaAnalyticsProperties toComponentProperties() {
                 final Map<String, String> accountsByPublisherId = accounts.stream()
                         .collect(Collectors.toMap(
-                                account -> {
-                                    final String publisherId = account.getPublisherId();
-                                    final String siteAppId = account.getSiteAppId();
-                                    return StringUtils.isNotBlank(siteAppId)
-                                            ? String.format("%s_%s", publisherId, siteAppId)
-                                            : publisherId;
-                                },
+                                this::buildPublisherSiteAppIdKey,
                                 AgmaAnalyticsAccountProperties::getCode
                         ));
 
@@ -131,6 +125,14 @@ public class AnalyticsConfiguration {
                         .httpTimeoutMs(endpoint.getTimeoutMs())
                         .accounts(accountsByPublisherId)
                         .build();
+            }
+
+            private String buildPublisherSiteAppIdKey(AgmaAnalyticsAccountProperties account) {
+                final String publisherId = account.getPublisherId();
+                final String siteAppId = account.getSiteAppId();
+                return StringUtils.isNotBlank(siteAppId)
+                        ? String.format("%s_%s", publisherId, siteAppId)
+                        : publisherId;
             }
 
             @Validated

--- a/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/AnalyticsConfiguration.java
@@ -111,8 +111,15 @@ public class AnalyticsConfiguration {
             public AgmaAnalyticsProperties toComponentProperties() {
                 final Map<String, String> accountsByPublisherId = accounts.stream()
                         .collect(Collectors.toMap(
-                                AgmaAnalyticsAccountProperties::getPublisherId,
-                                AgmaAnalyticsAccountProperties::getCode));
+                                account -> {
+                                    final String publisherId = account.getPublisherId();
+                                    final String siteAppId = account.getSiteAppId();
+                                    return (siteAppId != null && !siteAppId.isEmpty())
+                                            ? publisherId + "_" + siteAppId
+                                            : publisherId;
+                                },
+                                AgmaAnalyticsAccountProperties::getCode
+                        ));
 
                 return AgmaAnalyticsProperties.builder()
                         .url(endpoint.getUrl())

--- a/src/test/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporterTest.java
@@ -409,6 +409,124 @@ public class AgmaAnalyticsReporterTest extends VertxTest {
     }
 
     @Test
+    public void processEventShouldSendWhenAccountsHasConfiguredAppsOrSites() {
+        // given
+        final AgmaAnalyticsProperties properties = AgmaAnalyticsProperties.builder()
+                .url("http://endpoint.com")
+                .gzip(false)
+                .bufferSize(100000)
+                .bufferTimeoutMs(10000L)
+                .maxEventsCount(0)
+                .httpTimeoutMs(1000L)
+                .accounts(Map.of("publisherId_bundleId", "accountCode"))
+                .build();
+
+        target = new AgmaAnalyticsReporter(properties, versionProvider, jacksonMapper, clock, httpClient, vertx);
+
+        // given
+        final App givenApp = App.builder().bundle("bundleId")
+                .publisher(Publisher.builder().id("publisherId").build()).build();
+        final Device givenDevice = Device.builder().build();
+        final User givenUser = User.builder().build();
+
+        final AuctionEvent auctionEvent = AuctionEvent.builder()
+                .auctionContext(AuctionContext.builder()
+                        .privacyContext(PrivacyContext.of(
+                                null, TcfContext.builder().consent(PARSED_VALID_CONSENT).build()))
+                        .timeoutContext(TimeoutContext.of(clock.millis(), null, 1))
+                        .bidRequest(BidRequest.builder()
+                                .id("requestId")
+                                .app(givenApp)
+                                .app(givenApp)
+                                .device(givenDevice)
+                                .user(givenUser)
+                                .build())
+                        .build())
+                .build();
+
+        // when
+        final Future<Void> result = target.processEvent(auctionEvent);
+
+        // then
+        final AgmaEvent expectedEvent = AgmaEvent.builder()
+                .eventType("auction")
+                .accountCode("accountCode")
+                .requestId("requestId")
+                .app(givenApp)
+                .device(givenDevice)
+                .user(givenUser)
+                .startTime(ZonedDateTime.parse("2024-09-03T15:00:00+05:00"))
+                .build();
+
+        final String expectedEventPayload = "[" + jacksonMapper.encodeToString(expectedEvent) + "]";
+
+        verify(httpClient).request(
+                eq(POST),
+                eq("http://endpoint.com"),
+                any(),
+                eq(expectedEventPayload),
+                eq(1000L));
+    }
+
+    @Test
+    public void processEventShouldSendWhenAccountsHasConfiguredAppsOrSitesOnly() {
+        // given
+        final AgmaAnalyticsProperties properties = AgmaAnalyticsProperties.builder()
+                .url("http://endpoint.com")
+                .gzip(false)
+                .bufferSize(100000)
+                .bufferTimeoutMs(10000L)
+                .maxEventsCount(0)
+                .httpTimeoutMs(1000L)
+                .accounts(Map.of("_mySite", "accountCode"))
+                .build();
+
+        target = new AgmaAnalyticsReporter(properties, versionProvider, jacksonMapper, clock, httpClient, vertx);
+
+        // given
+        final Site givenSite = Site.builder().id("mySite").build();
+        final Device givenDevice = Device.builder().build();
+        final User givenUser = User.builder().build();
+
+        final AuctionEvent auctionEvent = AuctionEvent.builder()
+                .auctionContext(AuctionContext.builder()
+                        .privacyContext(PrivacyContext.of(
+                                null, TcfContext.builder().consent(PARSED_VALID_CONSENT).build()))
+                        .timeoutContext(TimeoutContext.of(clock.millis(), null, 1))
+                        .bidRequest(BidRequest.builder()
+                                .id("requestId")
+                                .site(givenSite)
+                                .device(givenDevice)
+                                .user(givenUser)
+                                .build())
+                        .build())
+                .build();
+
+        // when
+        final Future<Void> result = target.processEvent(auctionEvent);
+
+        // then
+        final AgmaEvent expectedEvent = AgmaEvent.builder()
+                .eventType("auction")
+                .accountCode("accountCode")
+                .requestId("requestId")
+                .site(givenSite)
+                .device(givenDevice)
+                .user(givenUser)
+                .startTime(ZonedDateTime.parse("2024-09-03T15:00:00+05:00"))
+                .build();
+
+        final String expectedEventPayload = "[" + jacksonMapper.encodeToString(expectedEvent) + "]";
+
+        verify(httpClient).request(
+                eq(POST),
+                eq("http://endpoint.com"),
+                any(),
+                eq(expectedEventPayload),
+                eq(1000L));
+    }
+
+    @Test
     public void processEventShouldSendEncodingGzipHeaderAndCompressedPayload() {
         // given
         final AgmaAnalyticsProperties properties = AgmaAnalyticsProperties.builder()


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bugfix

### ✨ What's the context?

Thanks @AntoxaAntoxic for the port of our adapter! During testing we found 2 minor bugs in the implementation-

- 9da4ca89af35efcf07b1e670563425da7b1dc3d4: prevents triggering a POST request when the buffer is empty. [original](https://github.com/prebid/prebid-server/blob/master/analytics/agma/agma_module.go#L128-L131)
- 2271af3b6490ca1613cdbdd04d4cd32054e32730: respect the sitesApp config and allow empty strings as publisherId, when the sitesApp is set. This also allows a publisher to set multiple codes for multiple sites/apps for the same `publisherId`. [original test](https://github.com/prebid/prebid-server/blob/master/analytics/agma/agma_module_test.go#L293-L305)

Thanks again for the port!
