### PR TITLE
add ortb-version to yieldmo.yaml

### DIFF
--- a/src/main/resources/bidder-config/yieldmo.yaml
+++ b/src/main/resources/bidder-config/yieldmo.yaml
@@ -1,6 +1,7 @@
 adapters:
   yieldmo:
     endpoint: https://ads.yieldmo.com/exchange/prebid-server
+    ortb-version: "2.6"
     meta-info:
       maintainer-email: prebid@yieldmo.com
       app-media-types:

--- a/src/test/resources/org/prebid/server/it/openrtb2/yieldmo/test-yieldmo-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yieldmo/test-yieldmo-bid-request.json
@@ -36,9 +36,7 @@
     "USD"
   ],
   "regs": {
-    "ext": {
-      "gdpr": 0
-    }
+    "gdpr": 0
   },
   "ext": {
     "prebid": {


### PR DESCRIPTION
Indicating ortb 2.6 support for yieldmo in the yaml file, and updating the test request json to move the gdpr field out of the regs.ext object, per the ortb 2.6 protocol.