### PR TITLE
Unruly: Remove GZIP compression as this breaks the bidder

### DIFF
--- a/src/main/resources/bidder-config/unruly.yaml
+++ b/src/main/resources/bidder-config/unruly.yaml
@@ -2,7 +2,6 @@ adapters:
   unruly:
     endpoint: https://targeting.unrulymedia.com/unruly_prebid_server
     ortb-version: "2.6"
-    endpoint-compression: gzip
     meta-info:
       maintainer-email: prebidsupport@unrulygroup.com
       app-media-types:


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] update bid adapter
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] tech debt (test coverage, refactorings, etc.)


### ✨ What's the context?
https://github.com/prebid/prebid-server/pull/4028

### 🧠 Rationale behind the change
GZIP breaks Unruly bidder


### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hosts
- [ ] geographic host parameters are NOT required
- [ ] NO direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test


### 🧪 Test plan

How do you know the changes are safe to ship to production?


### 🏎 Quality check

- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
