### PR TITLE
Sharethrough: declare support for oRTB 2.6

### DIFF
--- a/src/main/resources/bidder-config/sharethrough.yaml
+++ b/src/main/resources/bidder-config/sharethrough.yaml
@@ -1,6 +1,7 @@
 adapters:
   sharethrough:
     endpoint: https://btlr.sharethrough.com/universal/v1?supply_id=FGMrCMMc
+    ortb-version: '2.6'
     meta-info:
       maintainer-email: pubgrowth.engineering@sharethrough.com
       app-media-types:

--- a/src/test/resources/org/prebid/server/it/openrtb2/sharethrough/test-sharethrough-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/sharethrough/test-sharethrough-bid-request.json
@@ -33,9 +33,7 @@
   },
   "at": 1,
   "tmax": "${json-unit.any-number}",
-  "cur": [
-    "USD"
-  ],
+  "cur": ["USD"],
   "source": {
     "tid": "${json-unit.any-string}",
     "ext": {
@@ -44,9 +42,7 @@
     }
   },
   "regs": {
-    "ext": {
-      "gdpr": 0
-    }
+    "gdpr": 0
   },
   "ext": {
     "prebid": {


### PR DESCRIPTION
### 🔧 Type of changes
- [x] documentation
- [x] configuration

### ✨ What's the context?
Updating the bid adapter's configuration file (`sharethrough.yaml`).

### 🧠 Rationale behind the change
Making these changes so that publishers and other partners are aware that Sharethrough's exchange supports oRTB 2.6-compliant bid requests.
