### PR TITLE
Amp: update consented providers settings support

### DIFF
--- a/src/main/java/org/prebid/server/auction/requestfactory/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/AmpRequestFactory.java
@@ -274,6 +274,7 @@ public class AmpRequestFactory {
 
         final ExtUser extUser = consentedProvidersSettings != null
                 ? ExtUser.builder()
+                .deprecatedConsentedProvidersSettings(consentedProvidersSettings)
                 .consentedProvidersSettings(consentedProvidersSettings)
                 .build()
                 : null;

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtUser.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtUser.java
@@ -55,8 +55,13 @@ public class ExtUser extends FlexibleExtension {
 
     /**
      * Defines the contract for bidrequest.user.ext.ConsentedProvidersSettings
+     * <p>
+     * TODO: Remove after PBS 4.0
      */
+    @Deprecated(forRemoval = true)
     @JsonProperty("ConsentedProvidersSettings")
+    ConsentedProvidersSettings deprecatedConsentedProvidersSettings;
+
     ConsentedProvidersSettings consentedProvidersSettings;
 
     @JsonIgnore

--- a/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
@@ -1280,7 +1280,7 @@ public class AmpRequestFactoryTest extends VertxTest {
         assertThat(result.getUser())
                 .isEqualTo(User.builder()
                         .ext(ExtUser.builder()
-                                .consentedProvidersSettings(ConsentedProvidersSettings.of("someConsent"))
+                                .deprecatedConsentedProvidersSettings(ConsentedProvidersSettings.of("someConsent"))
                                 .build())
                         .build());
     }

--- a/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
@@ -1277,10 +1277,12 @@ public class AmpRequestFactoryTest extends VertxTest {
         final BidRequest result = target.fromRequest(routingContext, 0L).result().getBidRequest();
 
         // then
+        final ConsentedProvidersSettings settings = ConsentedProvidersSettings.of("someConsent");
         assertThat(result.getUser())
                 .isEqualTo(User.builder()
                         .ext(ExtUser.builder()
-                                .deprecatedConsentedProvidersSettings(ConsentedProvidersSettings.of("someConsent"))
+                                .deprecatedConsentedProvidersSettings(settings)
+                                .consentedProvidersSettings(settings)
                                 .build())
                         .build());
     }

--- a/src/test/java/org/prebid/server/bidder/improvedigital/ImprovedigitalBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/improvedigital/ImprovedigitalBidderTest.java
@@ -116,7 +116,7 @@ public class ImprovedigitalBidderTest extends VertxTest {
     public void makeHttpRequestsShouldProperProcessConsentedProvidersSetting() {
         // given
         final ExtUser extUser = ExtUser.builder()
-                .consentedProvidersSettings(ConsentedProvidersSettings.of("1~10.20.90"))
+                .deprecatedConsentedProvidersSettings(ConsentedProvidersSettings.of("1~10.20.90"))
                 .build();
 
         final BidRequest bidRequest = givenBidRequest(bidRequestBuilder -> bidRequestBuilder
@@ -145,7 +145,7 @@ public class ImprovedigitalBidderTest extends VertxTest {
     public void makeHttpRequestsShouldProperProcessConsentedProvidersSettingWithMultipleTilda() {
         // given
         final ExtUser extUser = ExtUser.builder()
-                .consentedProvidersSettings(ConsentedProvidersSettings.of("1~10.20.90~anything"))
+                .deprecatedConsentedProvidersSettings(ConsentedProvidersSettings.of("1~10.20.90~anything"))
                 .build();
 
         final BidRequest bidRequest = givenBidRequest(bidRequestBuilder -> bidRequestBuilder
@@ -174,7 +174,7 @@ public class ImprovedigitalBidderTest extends VertxTest {
     public void makeHttpRequestsShouldReturnUserExtIfConsentedProvidersIsNotProvided() {
         // given
         final ExtUser extUser = ExtUser.builder()
-                .consentedProvidersSettings(ConsentedProvidersSettings.of(null))
+                .deprecatedConsentedProvidersSettings(ConsentedProvidersSettings.of(null))
                 .build();
 
         final BidRequest bidRequest = givenBidRequest(bidRequestBuilder ->

--- a/src/test/resources/org/prebid/server/it/amp/test-generic-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/amp/test-generic-bid-request.json
@@ -51,6 +51,9 @@
     "ext": {
       "ConsentedProvidersSettings": {
         "consented_providers": "someConsent"
+      },
+      "consented_providers_settings": {
+        "consented_providers": "someConsent"
       }
     }
   },

--- a/src/test/resources/org/prebid/server/it/amp/test-genericAlias-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/amp/test-genericAlias-bid-request.json
@@ -49,6 +49,9 @@
     "ext": {
       "ConsentedProvidersSettings": {
         "consented_providers": "someConsent"
+      },
+      "consented_providers_settings": {
+        "consented_providers": "someConsent"
       }
     }
   },


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [x] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Apparently Google documentation had an error. To avoid breaking changes we now support both `ConsentedProvidersSettings` and `consented_providers_settings` fields.

### 🧪 Test plan
Unit tests + functional tests.

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
