### PR TITLE
Make pr-richmedia-filter global properties optional

### DIFF
--- a/extra/modules/pb-richmedia-filter/src/main/java/org/prebid/server/hooks/modules/pb/richmedia/filter/config/PbRichmediaFilterModuleConfiguration.java
+++ b/extra/modules/pb-richmedia-filter/src/main/java/org/prebid/server/hooks/modules/pb/richmedia/filter/config/PbRichmediaFilterModuleConfiguration.java
@@ -20,7 +20,7 @@ public class PbRichmediaFilterModuleConfiguration {
 
     @Bean
     PbRichmediaFilterModule pbRichmediaFilterModule(
-            @Value("${hooks.modules.pb-richmedia-filter.filter-mraid:#{null}") Boolean filterMraid,
+            @Value("${hooks.modules.pb-richmedia-filter.filter-mraid:false}") boolean filterMraid,
             @Value("${hooks.modules.pb-richmedia-filter.mraid-script-pattern:#{null}}") String mraidScriptPattern) {
 
         final ObjectMapper mapper = ObjectMapperProvider.mapper();

--- a/extra/modules/pb-richmedia-filter/src/main/java/org/prebid/server/hooks/modules/pb/richmedia/filter/config/PbRichmediaFilterModuleConfiguration.java
+++ b/extra/modules/pb-richmedia-filter/src/main/java/org/prebid/server/hooks/modules/pb/richmedia/filter/config/PbRichmediaFilterModuleConfiguration.java
@@ -20,8 +20,8 @@ public class PbRichmediaFilterModuleConfiguration {
 
     @Bean
     PbRichmediaFilterModule pbRichmediaFilterModule(
-            @Value("${hooks.modules.pb-richmedia-filter.filter-mraid}") Boolean filterMraid,
-            @Value("${hooks.modules.pb-richmedia-filter.mraid-script-pattern}") String mraidScriptPattern) {
+            @Value("${hooks.modules.pb-richmedia-filter.filter-mraid:#{null}") Boolean filterMraid,
+            @Value("${hooks.modules.pb-richmedia-filter.mraid-script-pattern:#{null}}") String mraidScriptPattern) {
 
         final ObjectMapper mapper = ObjectMapperProvider.mapper();
         final PbRichMediaFilterProperties globalProperties = PbRichMediaFilterProperties.of(

--- a/src/test/groovy/org/prebid/server/functional/tests/module/ModuleBaseSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/module/ModuleBaseSpec.groovy
@@ -33,13 +33,14 @@ class ModuleBaseSpec extends BaseSpec {
     }
 
     protected static Map<String, String> getRichMediaFilterSettings(String scriptPattern,
-                                                                    boolean filterMraidEnabled = true,
+                                                                    Boolean filterMraidEnabled = true,
                                                                     Endpoint endpoint = OPENRTB2_AUCTION) {
 
         ["hooks.${PB_RICHMEDIA_FILTER.code}.enabled"                     : true,
          "hooks.modules.${PB_RICHMEDIA_FILTER.code}.mraid-script-pattern": scriptPattern,
          "hooks.modules.${PB_RICHMEDIA_FILTER.code}.filter-mraid"        : filterMraidEnabled,
          "hooks.host-execution-plan"                                     : encode(ExecutionPlan.getSingleEndpointExecutionPlan(endpoint, [(ALL_PROCESSED_BID_RESPONSES): [PB_RICHMEDIA_FILTER]]))]
+                .findAll { it.value != null }
                 .collectEntries { key, value -> [(key.toString()): value.toString()] }
     }
 

--- a/src/test/groovy/org/prebid/server/functional/tests/module/richmedia/RichMediaFilterSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/module/richmedia/RichMediaFilterSpec.groovy
@@ -35,6 +35,51 @@ class RichMediaFilterSpec extends ModuleBaseSpec {
                     .collectEntries { key, value -> [(key.toString()): value.toString()] })
     private final PrebidServerService pbsServiceWithDisabledMediaFilter = pbsServiceFactory.getService(getRichMediaFilterSettings(PATTERN_NAME, false))
 
+    def "PBS should process request without rich media module when host config have empty settings"() {
+        given: "Prebid server with empty settings for module"
+        def prebidServerService = pbsServiceFactory.getService(pbsConfig)
+
+        and: "BidRequest with stored response"
+        def storedResponseId = PBSUtils.randomNumber
+        def bidRequest = BidRequest.defaultBidRequest.tap {
+            ext.prebid.returnAllBidStatus = true
+            it.ext.prebid.trace = VERBOSE
+            it.imp.first().ext.prebid.storedBidResponse = [new StoredBidResponse(id: storedResponseId, bidder: GENERIC)]
+        }
+
+        and: "Stored bid response in DB"
+        def storedBidResponse = BidResponse.getDefaultBidResponse(bidRequest).tap {
+            it.seatbid[0].bid[0].adm = PBSUtils.randomString
+        }
+        def storedResponse = new StoredResponse(responseId: storedResponseId, storedBidResponse: storedBidResponse)
+        storedResponseDao.save(storedResponse)
+
+        and: "Account in the DB"
+        def account = new Account(uuid: bidRequest.getAccountId())
+        accountDao.save(account)
+
+        when: "PBS processes auction request"
+        def response = prebidServerService.sendAuctionRequest(bidRequest)
+
+        then: "Response header should contain seatbid"
+        assert response.seatbid.size() == 1
+
+        and: "Response shouldn't contain errors of invalid creation"
+        assert !response.ext.errors
+
+        and: "Response shouldn't contain analytics"
+        assert !getAnalyticResults(response)
+
+        cleanup: "Stop and remove pbs container"
+        pbsServiceFactory.removeContainer(pbsConfig)
+
+        where:
+        pbsConfig << [getRichMediaFilterSettings(PBSUtils.randomString, null),
+                      getRichMediaFilterSettings(null, true),
+                      getRichMediaFilterSettings(null, false),
+                      getRichMediaFilterSettings(null, null)]
+    }
+
     def "PBS should process request without analytics when adm matches with pattern name and filter set to disabled in host config"() {
         given: "BidRequest with stored response"
         def storedResponseId = PBSUtils.randomNumber


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [x] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
The pb-richmedia-filter module was requiring `filter-mraid` and `mraid-script-pattern` to be set globally. This is sometimes pointless.

### 🧠 Rationale behind the change
This change makes those properties optional so that module can be enabled globally, but configured per-account.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
