### PR TITLE
Add cache-dependency-path

### DIFF
--- a/.github/workflows/pr-java-ci.yml
+++ b/.github/workflows/pr-java-ci.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           distribution: 'temurin'
           cache: 'maven'
+          cache-dependency-path: extra/pom.xml
           java-version: ${{ matrix.java }}
 
       - name: Build with Maven


### PR DESCRIPTION
I noticed that on my  PR no caching is taking place.

### 🔧 Type of changes

- [x] bugfix

### ✨ What's the context?

https://github.com/prebid/prebid-server-java/pull/3613/checks shows

> Creating settings.xml with server-id: github
> Writing to /home/runner/.m2/settings.xml
> maven cache is not found

### 🧠 Rationale behind the change

Make PR tests faster

