### PR TITLE
Fix #3592. Bad Input Error if pbjs s2s config contains alias configuration for a disabled adapter

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -302,6 +302,10 @@ Preconfigured application settings can be obtained from multiple data sources co
 
 Warning! Application will not start in case of no one data source is defined and you'll get an exception in logs.
 
+For requests validation mode available next options:
+- `settings.fail-on-unknown-bidders` - fail with validation error or just make warning for unknown bidders.
+- `settings.fail-on-disabled-bidders` - fail with validation error or just make warning for disabled bidders.
+
 For filesystem data source available next options:
 - `settings.filesystem.settings-filename` - location of file settings.
 - `settings.filesystem.stored-requests-dir` - directory with stored requests.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -45,6 +45,8 @@ where `[DATASOURCE]` is a data source name, `DEFAULT_DS` by defaul.
 - `imps_video` - number of video impressions
 - `imps_native` - number of native impressions
 - `imps_audio` - number of audio impressions
+- `disabled_bidder` - number of disabled bidders received within requests
+- `unknown_bidder` - number of unknown bidders received within requests
 - `requests.(ok|badinput|err|networkerr|blocklisted_account|blocklisted_app).(openrtb2-web|openrtb-app|amp|legacy)` - number of requests broken down by status and type
 - `bidder-cardinality.<cardinality>.requests` - number of requests targeting `<cardinality>` of bidders
 - `connection_accept_errors` - number of errors occurred while establishing HTTP connection
@@ -92,6 +94,8 @@ Following metrics are collected and submitted if account is configured with `det
 - `account.<account-id>.requests.type.(openrtb2-web,openrtb-app,amp,legacy)` - number of requests received from account with `<account-id>` broken down by type of incoming request
 - `account.<account-id>.debug_requests` - number of requests received from account with `<account-id>` broken down by type of incoming request (when debug mode is enabled)
 - `account.<account-id>.requests.rejected` - number of rejected requests caused by incorrect `accountId`
+- `account.<account-id>.requests.disabled_bidder` - number of disabled bidders received within requests from account with `<account-id>`
+- `account.<account-id>.requests.unknown_bidder` - number of unknown bidder names received within requests from account with `<account-id>`
 - `account.<account-id>.adapter.<bidder-name>.request_time` - timer tracking how long did it take to make a request to `<bidder-name>` when incoming request was from `<account-id>` 
 - `account.<account-id>.adapter.<bidder-name>.bids_received` - number of bids received from `<bidder-name>` when incoming request was from `<account-id>`
 - `account.<account-id>.adapter.<bidder-name>.requests.(gotbids|nobid)` - number of requests made to `<bidder-name>` broken down by result status  when incoming request was from `<account-id>`

--- a/src/main/java/org/prebid/server/auction/requestfactory/AmpRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/AmpRequestFactory.java
@@ -415,6 +415,7 @@ public class AmpRequestFactory {
                 .map(bidRequest -> paramsResolver.resolve(bidRequest, auctionContext, ENDPOINT, true))
                 .map(bidRequest -> ortb2RequestFactory.removeEmptyEids(bidRequest, auctionContext.getDebugWarnings()))
                 .compose(resolvedBidRequest -> ortb2RequestFactory.validateRequest(
+                        account,
                         resolvedBidRequest,
                         auctionContext.getHttpRequest(),
                         auctionContext.getDebugContext(),

--- a/src/main/java/org/prebid/server/auction/requestfactory/AuctionRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/AuctionRequestFactory.java
@@ -242,7 +242,7 @@ public class AuctionRequestFactory {
         return storedRequestProcessor.processAuctionRequest(account.getId(), auctionContext.getBidRequest())
                 .compose(auctionStoredResult -> updateBidRequest(auctionStoredResult, auctionContext))
                 .compose(bidRequest -> ortb2RequestFactory.validateRequest(
-                        bidRequest, httpRequest, auctionContext.getDebugContext(), debugWarnings))
+                        account, bidRequest, httpRequest, auctionContext.getDebugContext(), debugWarnings))
                 .map(interstitialProcessor::process);
     }
 

--- a/src/main/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactory.java
@@ -192,7 +192,8 @@ public class Ortb2RequestFactory {
                 auctionContext.getDebugContext().getTraceLevel()));
     }
 
-    public Future<BidRequest> validateRequest(Account account, BidRequest bidRequest,
+    public Future<BidRequest> validateRequest(Account account,
+                                              BidRequest bidRequest,
                                               HttpRequestContext httpRequestContext,
                                               DebugContext debugContext,
                                               List<String> warnings) {

--- a/src/main/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactory.java
@@ -192,13 +192,13 @@ public class Ortb2RequestFactory {
                 auctionContext.getDebugContext().getTraceLevel()));
     }
 
-    public Future<BidRequest> validateRequest(BidRequest bidRequest,
+    public Future<BidRequest> validateRequest(Account account, BidRequest bidRequest,
                                               HttpRequestContext httpRequestContext,
                                               DebugContext debugContext,
                                               List<String> warnings) {
 
         final ValidationResult validationResult = requestValidator.validate(
-                bidRequest, httpRequestContext, debugContext);
+                account, bidRequest, httpRequestContext, debugContext);
 
         if (validationResult.hasWarnings()) {
             warnings.addAll(validationResult.getWarnings());

--- a/src/main/java/org/prebid/server/auction/requestfactory/VideoRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/VideoRequestFactory.java
@@ -33,7 +33,6 @@ import org.prebid.server.model.Endpoint;
 import org.prebid.server.model.HttpRequestContext;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisher;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisherPrebid;
-import org.prebid.server.settings.model.Account;
 import org.prebid.server.util.HttpUtil;
 import org.prebid.server.util.ObjectUtil;
 

--- a/src/main/java/org/prebid/server/auction/requestfactory/VideoRequestFactory.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/VideoRequestFactory.java
@@ -33,6 +33,7 @@ import org.prebid.server.model.Endpoint;
 import org.prebid.server.model.HttpRequestContext;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisher;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisherPrebid;
+import org.prebid.server.settings.model.Account;
 import org.prebid.server.util.HttpUtil;
 import org.prebid.server.util.ObjectUtil;
 
@@ -120,6 +121,7 @@ public class VideoRequestFactory {
                 .map(auctionContext -> auctionContext.with(debugResolver.debugContextFrom(auctionContext)))
 
                 .compose(auctionContext -> ortb2RequestFactory.validateRequest(
+                                auctionContext.getAccount(),
                                 auctionContext.getBidRequest(),
                                 auctionContext.getHttpRequest(),
                                 auctionContext.getDebugContext(),

--- a/src/main/java/org/prebid/server/metric/MetricName.java
+++ b/src/main/java/org/prebid/server/metric/MetricName.java
@@ -63,6 +63,8 @@ public enum MetricName {
     nobid,
     gotbids,
     badinput,
+    disabled_bidder,
+    unknown_bidder,
     blocklisted_account,
     blocklisted_app,
     badserverresponse,

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -336,19 +336,19 @@ public class Metrics extends UpdatableMetrics {
         forAdapter(bidder).request().incCounter(errorMetric);
     }
 
-    public void updateAdapterRequestDisabledBidderMetric(String bidder, Account account) {
-        forAdapter(bidder).request().incCounter(MetricName.disabled_bidder);
+    public void updateDisabledBidderMetric(Account account) {
+        incCounter(MetricName.disabled_bidder);
         if (accountMetricsVerbosityResolver.forAccount(account)
                 .isAtLeast(AccountMetricsVerbosityLevel.detailed)) {
-            forAccount(account.getId()).adapter().forAdapter(bidder).request().incCounter(MetricName.disabled_bidder);
+            forAccount(account.getId()).requests().incCounter(MetricName.disabled_bidder);
         }
     }
 
-    public void updateAdapterRequestUnknownBidderMetric(String bidder, Account account) {
-        forAdapter(bidder).request().incCounter(MetricName.unknown_bidder);
+    public void updateUnknownBidderMetric(Account account) {
+        incCounter(MetricName.unknown_bidder);
         if (accountMetricsVerbosityResolver.forAccount(account)
                 .isAtLeast(AccountMetricsVerbosityLevel.detailed)) {
-            forAccount(account.getId()).adapter().forAdapter(bidder).request().incCounter(MetricName.unknown_bidder);
+            forAccount(account.getId()).requests().incCounter(MetricName.unknown_bidder);
         }
     }
 

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -336,6 +336,22 @@ public class Metrics extends UpdatableMetrics {
         forAdapter(bidder).request().incCounter(errorMetric);
     }
 
+    public void updateAdapterRequestDisabledBidderMetric(String bidder, Account account) {
+        forAdapter(bidder).request().incCounter(MetricName.disabled_bidder);
+        if (accountMetricsVerbosityResolver.forAccount(account)
+                .isAtLeast(AccountMetricsVerbosityLevel.detailed)) {
+            forAccount(account.getId()).adapter().forAdapter(bidder).request().incCounter(MetricName.disabled_bidder);
+        }
+    }
+
+    public void updateAdapterRequestUnknownBidderMetric(String bidder, Account account) {
+        forAdapter(bidder).request().incCounter(MetricName.unknown_bidder);
+        if (accountMetricsVerbosityResolver.forAccount(account)
+                .isAtLeast(AccountMetricsVerbosityLevel.detailed)) {
+            forAccount(account.getId()).adapter().forAdapter(bidder).request().incCounter(MetricName.unknown_bidder);
+        }
+    }
+
     public void updateAnalyticEventMetric(String analyticCode, MetricName eventType, MetricName result) {
         forAnalyticReporter(analyticCode).forEventType(eventType).incCounter(result);
     }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -1033,7 +1033,9 @@ public class ServiceConfiguration {
             Metrics metrics,
             JacksonMapper mapper,
             @Value("${logging.sampling-rate:0.01}") double logSamplingRate,
-            @Value("${auction.strict-app-site-dooh:false}") boolean enabledStrictAppSiteDoohValidation) {
+            @Value("${auction.strict-app-site-dooh:false}") boolean enabledStrictAppSiteDoohValidation,
+            @Value("${settings.fail-on-disabled-bidders}") boolean failOnDisabledBidders,
+            @Value("${settings.fail-on-unknown-bidders}") boolean failOnUnknownBidders) {
 
         return new RequestValidator(
                 bidderCatalog,
@@ -1041,7 +1043,9 @@ public class ServiceConfiguration {
                 metrics,
                 mapper,
                 logSamplingRate,
-                enabledStrictAppSiteDoohValidation);
+                enabledStrictAppSiteDoohValidation,
+                failOnDisabledBidders,
+                failOnUnknownBidders);
     }
 
     @Bean

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -1034,8 +1034,8 @@ public class ServiceConfiguration {
             JacksonMapper mapper,
             @Value("${logging.sampling-rate:0.01}") double logSamplingRate,
             @Value("${auction.strict-app-site-dooh:false}") boolean enabledStrictAppSiteDoohValidation,
-            @Value("${settings.fail-on-disabled-bidders}") boolean failOnDisabledBidders,
-            @Value("${settings.fail-on-unknown-bidders}") boolean failOnUnknownBidders) {
+            @Value("${settings.fail-on-disabled-bidders:true}") boolean failOnDisabledBidders,
+            @Value("${settings.fail-on-unknown-bidders:true}") boolean failOnUnknownBidders) {
 
         return new RequestValidator(
                 bidderCatalog,

--- a/src/main/java/org/prebid/server/validation/RequestValidator.java
+++ b/src/main/java/org/prebid/server/validation/RequestValidator.java
@@ -134,7 +134,7 @@ public class RequestValidator {
                     validateTargeting(targeting);
                 }
                 aliases = ObjectUtils.defaultIfNull(extRequestPrebid.getAliases(), Collections.emptyMap());
-                validateAliases(aliases, warnings, metrics, account);
+                validateAliases(aliases, warnings, account);
                 validateAliasesGvlIds(extRequestPrebid, aliases);
                 validateBidAdjustmentFactors(extRequestPrebid.getBidadjustmentfactors(), aliases);
                 validateExtBidPrebidData(extRequestPrebid.getData(), aliases, isDebugEnabled, warnings);
@@ -514,7 +514,7 @@ public class RequestValidator {
      * is equals to itself.
      */
     private void validateAliases(Map<String, String> aliases, List<String> warnings,
-                                 Metrics metrics, Account account) throws ValidationException {
+                                 Account account) throws ValidationException {
 
         for (final Map.Entry<String, String> aliasToBidder : aliases.entrySet()) {
             final String alias = aliasToBidder.getKey();
@@ -522,8 +522,8 @@ public class RequestValidator {
             if (!bidderCatalog.isValidName(coreBidder)) {
                 metrics.updateUnknownBidderMetric(account);
 
-                final String message = String.format("request.ext.prebid.aliases.%s refers to unknown bidder: %s",
-                        alias, coreBidder);
+                final String message = "request.ext.prebid.aliases.%s refers to unknown bidder: %s".formatted(alias,
+                        coreBidder);
                 if (failOnUnknownBidders) {
                     throw new ValidationException(message);
                 } else {
@@ -532,8 +532,8 @@ public class RequestValidator {
             } else if (!bidderCatalog.isActive(coreBidder)) {
                 metrics.updateDisabledBidderMetric(account);
 
-                final String message = String.format("request.ext.prebid.aliases.%s refers to disabled bidder: %s",
-                        alias, coreBidder);
+                final String message = "request.ext.prebid.aliases.%s refers to disabled bidder: %s".formatted(alias,
+                        coreBidder);
                 if (failOnDisabledBidders) {
                     throw new ValidationException(message);
                 } else {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -158,6 +158,8 @@ currency-converter:
 settings:
   generate-storedrequest-bidrequest-id: false
   enforce-valid-account: false
+  fail-on-unknown-bidders: true
+  fail-on-disabled-bidders: true
   database:
     pool-size: 20
     idle-connection-timeout: 300

--- a/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
@@ -1753,7 +1753,7 @@ public class AmpRequestFactoryTest extends VertxTest {
 
         given(ortb2ImplicitParametersResolver.resolve(any(), any(), any(), anyBoolean())).willAnswer(
                 answerWithFirstArgument());
-        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any()))
+        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
                 .willAnswer(invocation -> Future.succeededFuture((BidRequest) invocation.getArgument(0)));
 
         given(ortb2RequestFactory.enrichBidRequestWithAccountAndPrivacyData(any()))

--- a/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AmpRequestFactoryTest.java
@@ -1754,7 +1754,7 @@ public class AmpRequestFactoryTest extends VertxTest {
         given(ortb2ImplicitParametersResolver.resolve(any(), any(), any(), anyBoolean())).willAnswer(
                 answerWithFirstArgument());
         given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
-                .willAnswer(invocation -> Future.succeededFuture((BidRequest) invocation.getArgument(0)));
+                .willAnswer(invocation -> Future.succeededFuture((BidRequest) invocation.getArgument(1)));
 
         given(ortb2RequestFactory.enrichBidRequestWithAccountAndPrivacyData(any()))
                 .willAnswer(invocation -> Future.succeededFuture(((AuctionContext) invocation.getArgument(0))

--- a/src/test/java/org/prebid/server/auction/requestfactory/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AuctionRequestFactoryTest.java
@@ -165,7 +165,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
         given(ortb2RequestFactory.executeRawAuctionRequestHooks(any()))
                 .willAnswer(invocation -> Future.succeededFuture(
                         ((AuctionContext) invocation.getArgument(0)).getBidRequest()));
-        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any()))
+        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
                 .willAnswer(invocationOnMock -> Future.succeededFuture((BidRequest) invocationOnMock.getArgument(0)));
         given(ortb2RequestFactory.removeEmptyEids(any(), any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -662,7 +662,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
         // given
         givenValidBidRequest();
 
-        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any()))
+        given(ortb2RequestFactory.validateRequest(any(), any(), any()))
                 .willReturn(Future.failedFuture(new InvalidRequestException("errors")));
 
         // when

--- a/src/test/java/org/prebid/server/auction/requestfactory/AuctionRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/AuctionRequestFactoryTest.java
@@ -166,7 +166,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
                 .willAnswer(invocation -> Future.succeededFuture(
                         ((AuctionContext) invocation.getArgument(0)).getBidRequest()));
         given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
-                .willAnswer(invocationOnMock -> Future.succeededFuture((BidRequest) invocationOnMock.getArgument(0)));
+                .willAnswer(invocationOnMock -> Future.succeededFuture((BidRequest) invocationOnMock.getArgument(1)));
         given(ortb2RequestFactory.removeEmptyEids(any(), any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         given(ortb2RequestFactory.updateTimeout(any())).willAnswer(invocation -> invocation.getArgument(0));
@@ -662,7 +662,7 @@ public class AuctionRequestFactoryTest extends VertxTest {
         // given
         givenValidBidRequest();
 
-        given(ortb2RequestFactory.validateRequest(any(), any(), any()))
+        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
                 .willReturn(Future.failedFuture(new InvalidRequestException("errors")));
 
         // when

--- a/src/test/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/Ortb2RequestFactoryTest.java
@@ -104,6 +104,7 @@ import static org.prebid.server.assertion.FutureAssertion.assertThat;
 public class Ortb2RequestFactoryTest extends VertxTest {
 
     private static final List<String> BLOCKLISTED_ACCOUNTS = singletonList("bad_acc");
+    private static final String ACCOUNT_ID = "accountId";
 
     @Mock
     private UidsCookieService uidsCookieService;
@@ -658,12 +659,13 @@ public class Ortb2RequestFactoryTest extends VertxTest {
     @Test
     public void validateRequestShouldThrowInvalidRequestExceptionIfRequestIsInvalid() {
         // given
-        given(requestValidator.validate(any(), any(), any())).willReturn(ValidationResult.error("error"));
+        given(requestValidator.validate(any(), any(), any(), any())).willReturn(ValidationResult.error("error"));
 
         final BidRequest bidRequest = givenBidRequest(identity());
 
         // when
         final Future<BidRequest> result = target.validateRequest(
+                Account.empty(ACCOUNT_ID),
                 bidRequest,
                 HttpRequestContext.builder().build(),
                 DebugContext.empty(),
@@ -675,25 +677,26 @@ public class Ortb2RequestFactoryTest extends VertxTest {
                 .isInstanceOf(InvalidRequestException.class)
                 .hasMessage("error");
 
-        verify(requestValidator).validate(eq(bidRequest), any(), any());
+        verify(requestValidator).validate(any(), eq(bidRequest), any(), any());
     }
 
     @Test
     public void validateRequestShouldReturnSameBidRequest() {
         // given
-        given(requestValidator.validate(any(), any(), any())).willReturn(ValidationResult.success());
+        given(requestValidator.validate(any(), any(), any(), any())).willReturn(ValidationResult.success());
 
         final BidRequest bidRequest = givenBidRequest(identity());
 
         // when
         final BidRequest result = target.validateRequest(
+                Account.empty(ACCOUNT_ID),
                 bidRequest,
                 HttpRequestContext.builder().build(),
                 DebugContext.empty(),
                 new ArrayList<>()).result();
 
         // then
-        verify(requestValidator).validate(eq(bidRequest), any(), any());
+        verify(requestValidator).validate(any(), eq(bidRequest), any(), any());
 
         assertThat(result).isSameAs(bidRequest);
     }

--- a/src/test/java/org/prebid/server/auction/requestfactory/VideoRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/VideoRequestFactoryTest.java
@@ -345,7 +345,7 @@ public class VideoRequestFactoryTest extends VertxTest {
         verify(ortb2RequestFactory).createAuctionContext(any(), eq(MetricName.video));
         verify(ortb2RequestFactory).enrichAuctionContext(any(), any(), eq(bidRequest), eq(0L));
         verify(ortb2RequestFactory).fetchAccountWithoutStoredRequestLookup(any());
-        verify(ortb2RequestFactory).validateRequest(eq(bidRequest), any(), any(), any());
+        verify(ortb2RequestFactory).validateRequest(any(), eq(bidRequest), any(), any(), any());
         verify(paramsResolver)
                 .resolve(eq(bidRequest), any(), eq(Endpoint.openrtb2_video.value()), eq(false));
         verify(ortb2RequestFactory).enrichBidRequestWithAccountAndPrivacyData(
@@ -404,7 +404,7 @@ public class VideoRequestFactoryTest extends VertxTest {
                         .build());
         given(ortb2RequestFactory.fetchAccountWithoutStoredRequestLookup(any())).willReturn(Future.succeededFuture());
 
-        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any()))
+        given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
                 .willAnswer(invocation -> Future.succeededFuture((BidRequest) invocation.getArgument(0)));
 
         given(paramsResolver.resolve(any(), any(), any(), anyBoolean()))

--- a/src/test/java/org/prebid/server/auction/requestfactory/VideoRequestFactoryTest.java
+++ b/src/test/java/org/prebid/server/auction/requestfactory/VideoRequestFactoryTest.java
@@ -405,7 +405,7 @@ public class VideoRequestFactoryTest extends VertxTest {
         given(ortb2RequestFactory.fetchAccountWithoutStoredRequestLookup(any())).willReturn(Future.succeededFuture());
 
         given(ortb2RequestFactory.validateRequest(any(), any(), any(), any(), any()))
-                .willAnswer(invocation -> Future.succeededFuture((BidRequest) invocation.getArgument(0)));
+                .willAnswer(invocation -> Future.succeededFuture((BidRequest) invocation.getArgument(1)));
 
         given(paramsResolver.resolve(any(), any(), any(), anyBoolean()))
                 .willAnswer(answerWithFirstArgument());

--- a/src/test/java/org/prebid/server/metric/MetricsTest.java
+++ b/src/test/java/org/prebid/server/metric/MetricsTest.java
@@ -615,6 +615,40 @@ public class MetricsTest {
     }
 
     @Test
+    public void updateAdapterRequestUnknownBidderMetricsShouldIncrementMetrics() {
+        // when
+        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestUnknownBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestUnknownBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
+
+        // then
+        assertThat(metricRegistry.counter("adapter.rubicon.requests.unknown_bidder").getCount()).isOne();
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.unknown_bidder").getCount()).isOne();
+        assertThat(metricRegistry.counter(
+                "adapter.conversant.requests.unknown_bidder").getCount()).isEqualTo(2);
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.conversant.requests.unknown_bidder").getCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void updateAdapterRequestDisabledBidderMetricsShouldIncrementMetrics() {
+        // when
+        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestDisabledBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestDisabledBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
+
+        // then
+        assertThat(metricRegistry.counter("adapter.rubicon.requests.disabled_bidder").getCount()).isOne();
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.disabled_bidder").getCount()).isOne();
+        assertThat(metricRegistry.counter(
+                "adapter.conversant.requests.disabled_bidder").getCount()).isEqualTo(2);
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.conversant.requests.disabled_bidder").getCount()).isEqualTo(2);
+    }
+
+    @Test
     public void updateAdapterRequestErrorMetricShouldIncrementMetrics() {
         // when
         metrics.updateAdapterRequestErrorMetric(RUBICON, MetricName.badinput);
@@ -965,16 +999,22 @@ public class MetricsTest {
         metrics.updateAdapterRequestNobidMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterRequestGotbidsMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterBidMetrics(RUBICON, Account.empty(ACCOUNT_ID), 1234L, true, "banner");
+        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
 
         // then
         assertThat(metricRegistry.counter("account.accountId.requests").getCount()).isZero();
         assertThat(metricRegistry.counter("account.accountId.debug_requests").getCount()).isZero();
         assertThat(metricRegistry.counter("account.accountId.requests.type.openrtb2-web").getCount()).isZero();
-        assertThat(metricRegistry.timer("account.accountId.rubicon.request_time").getCount()).isZero();
-        assertThat(metricRegistry.counter("account.accountId.rubicon.requests.nobid").getCount()).isZero();
-        assertThat(metricRegistry.counter("account.accountId.rubicon.requests.gotbids").getCount()).isZero();
-        assertThat(metricRegistry.histogram("account.accountId.rubicon.prices").getCount()).isZero();
-        assertThat(metricRegistry.counter("account.accountId.rubicon.bids_received").getCount()).isZero();
+        assertThat(metricRegistry.timer("account.accountId.adapter.rubicon.request_time").getCount()).isZero();
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.requests.nobid").getCount()).isZero();
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.requests.gotbids").getCount()).isZero();
+        assertThat(metricRegistry.histogram("account.accountId.adapter.rubicon.prices").getCount()).isZero();
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.bids_received").getCount()).isZero();
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.unknown_bidder").getCount()).isZero();
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.disabled_bidder").getCount()).isZero();
     }
 
     @Test
@@ -990,16 +1030,58 @@ public class MetricsTest {
         metrics.updateAdapterRequestNobidMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterRequestGotbidsMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterBidMetrics(RUBICON, Account.empty(ACCOUNT_ID), 1234L, true, "banner");
+        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
 
         // then
         assertThat(metricRegistry.counter("account.accountId.requests").getCount()).isOne();
         assertThat(metricRegistry.counter("account.accountId.debug_requests").getCount()).isZero();
         assertThat(metricRegistry.counter("account.accountId.requests.type.openrtb2-web").getCount()).isZero();
         assertThat(metricRegistry.timer("account.accountId.rubicon.request_time").getCount()).isZero();
-        assertThat(metricRegistry.counter("account.accountId.rubicon.requests.nobid").getCount()).isZero();
-        assertThat(metricRegistry.counter("account.accountId.rubicon.requests.gotbids").getCount()).isZero();
-        assertThat(metricRegistry.histogram("account.accountId.rubicon.prices").getCount()).isZero();
-        assertThat(metricRegistry.counter("account.accountId.rubicon.bids_received").getCount()).isZero();
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.requests.nobid").getCount()).isZero();
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.requests.gotbids").getCount()).isZero();
+        assertThat(metricRegistry.histogram("account.accountId.adapter.rubicon.prices").getCount()).isZero();
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.bids_received").getCount()).isZero();
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.unknown_bidder").getCount()).isZero();
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.disabled_bidder").getCount()).isZero();
+    }
+
+    @Test
+    public void shouldUpdateAccountRequestsMetricOnlyIfVerbosityIsDetailed() {
+        // given
+        given(accountMetricsVerbosityResolver.forAccount(any())).willReturn(AccountMetricsVerbosityLevel.detailed);
+
+        // when
+        metrics.updateAccountRequestMetrics(Account.empty(ACCOUNT_ID), MetricName.openrtb2web);
+        metrics.updateAccountDebugRequestMetrics(Account.empty(ACCOUNT_ID), false);
+        metrics.updateAccountDebugRequestMetrics(Account.empty(ACCOUNT_ID), true);
+        metrics.updateAdapterResponseTime(RUBICON, Account.empty(ACCOUNT_ID), 500);
+        metrics.updateAdapterRequestNobidMetrics(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestGotbidsMetrics(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterBidMetrics(RUBICON, Account.empty(ACCOUNT_ID), 1234L, true, "banner");
+        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+
+        // then
+        assertThat(metricRegistry.counter("account.accountId.requests").getCount()).isOne();
+        assertThat(metricRegistry.counter("account.accountId.debug_requests").getCount())
+                .isEqualTo(1);
+        assertThat(metricRegistry.counter("account.accountId.requests.type.openrtb2-web").getCount())
+                .isEqualTo(1);
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.requests.nobid").getCount())
+                .isEqualTo(1);
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.requests.gotbids").getCount())
+                .isEqualTo(1);
+        assertThat(metricRegistry.histogram("account.accountId.adapter.rubicon.prices").getCount())
+                .isEqualTo(1);
+        assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.bids_received").getCount())
+                .isEqualTo(1);
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.unknown_bidder").getCount()).isEqualTo(1);
+        assertThat(metricRegistry.counter(
+                "account.accountId.adapter.rubicon.requests.disabled_bidder").getCount()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/metric/MetricsTest.java
+++ b/src/test/java/org/prebid/server/metric/MetricsTest.java
@@ -48,6 +48,7 @@ public class MetricsTest {
     private static final String RUBICON = "rubicon";
     private static final String CONVERSANT = "conversant";
     private static final String ACCOUNT_ID = "accountId";
+    private static final String ACCOUNT_ID_1 = "accountId1";
     private static final String ANALYTIC_CODE = "analyticCode";
 
     private MetricRegistry metricRegistry;
@@ -615,37 +616,34 @@ public class MetricsTest {
     }
 
     @Test
-    public void updateAdapterRequestUnknownBidderMetricsShouldIncrementMetrics() {
+    public void updateUnknownBidderMetricsShouldIncrementMetrics() {
         // when
-        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestUnknownBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestUnknownBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
+        metrics.updateUnknownBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateUnknownBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateUnknownBidderMetric(Account.empty(ACCOUNT_ID_1));
 
         // then
-        assertThat(metricRegistry.counter("adapter.rubicon.requests.unknown_bidder").getCount()).isOne();
+        assertThat(metricRegistry.counter("unknown_bidder").getCount()).isEqualTo(3);
         assertThat(metricRegistry.counter(
-                "account.accountId.adapter.rubicon.requests.unknown_bidder").getCount()).isOne();
+                "account.accountId.requests.unknown_bidder").getCount()).isEqualTo(2);
         assertThat(metricRegistry.counter(
-                "adapter.conversant.requests.unknown_bidder").getCount()).isEqualTo(2);
-        assertThat(metricRegistry.counter(
-                "account.accountId.adapter.conversant.requests.unknown_bidder").getCount()).isEqualTo(2);
+                "account.accountId1.requests.unknown_bidder").getCount()).isEqualTo(1);
     }
 
     @Test
-    public void updateAdapterRequestDisabledBidderMetricsShouldIncrementMetrics() {
+    public void updateDisabledBidderMetricsShouldIncrementMetrics() {
         // when
-        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestDisabledBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestDisabledBidderMetric(CONVERSANT, Account.empty(ACCOUNT_ID));
+        metrics.updateDisabledBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateDisabledBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateDisabledBidderMetric(Account.empty(ACCOUNT_ID_1));
 
         // then
-        assertThat(metricRegistry.counter("adapter.rubicon.requests.disabled_bidder").getCount()).isOne();
         assertThat(metricRegistry.counter(
-                "account.accountId.adapter.rubicon.requests.disabled_bidder").getCount()).isOne();
+                "disabled_bidder").getCount()).isEqualTo(3);
         assertThat(metricRegistry.counter(
-                "adapter.conversant.requests.disabled_bidder").getCount()).isEqualTo(2);
+                "account.accountId.requests.disabled_bidder").getCount()).isEqualTo(2);
         assertThat(metricRegistry.counter(
-                "account.accountId.adapter.conversant.requests.disabled_bidder").getCount()).isEqualTo(2);
+                "account.accountId1.requests.disabled_bidder").getCount()).isEqualTo(1);
     }
 
     @Test
@@ -999,8 +997,8 @@ public class MetricsTest {
         metrics.updateAdapterRequestNobidMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterRequestGotbidsMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterBidMetrics(RUBICON, Account.empty(ACCOUNT_ID), 1234L, true, "banner");
-        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateDisabledBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateUnknownBidderMetric(Account.empty(ACCOUNT_ID));
 
         // then
         assertThat(metricRegistry.counter("account.accountId.requests").getCount()).isZero();
@@ -1030,8 +1028,8 @@ public class MetricsTest {
         metrics.updateAdapterRequestNobidMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterRequestGotbidsMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterBidMetrics(RUBICON, Account.empty(ACCOUNT_ID), 1234L, true, "banner");
-        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateDisabledBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateUnknownBidderMetric(Account.empty(ACCOUNT_ID));
 
         // then
         assertThat(metricRegistry.counter("account.accountId.requests").getCount()).isOne();
@@ -1061,8 +1059,8 @@ public class MetricsTest {
         metrics.updateAdapterRequestNobidMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterRequestGotbidsMetrics(RUBICON, Account.empty(ACCOUNT_ID));
         metrics.updateAdapterBidMetrics(RUBICON, Account.empty(ACCOUNT_ID), 1234L, true, "banner");
-        metrics.updateAdapterRequestDisabledBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
-        metrics.updateAdapterRequestUnknownBidderMetric(RUBICON, Account.empty(ACCOUNT_ID));
+        metrics.updateDisabledBidderMetric(Account.empty(ACCOUNT_ID));
+        metrics.updateUnknownBidderMetric(Account.empty(ACCOUNT_ID));
 
         // then
         assertThat(metricRegistry.counter("account.accountId.requests").getCount()).isOne();
@@ -1079,9 +1077,9 @@ public class MetricsTest {
         assertThat(metricRegistry.counter("account.accountId.adapter.rubicon.bids_received").getCount())
                 .isEqualTo(1);
         assertThat(metricRegistry.counter(
-                "account.accountId.adapter.rubicon.requests.unknown_bidder").getCount()).isEqualTo(1);
+                "unknown_bidder").getCount()).isEqualTo(1);
         assertThat(metricRegistry.counter(
-                "account.accountId.adapter.rubicon.requests.disabled_bidder").getCount()).isEqualTo(1);
+                "account.accountId.requests.disabled_bidder").getCount()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -42,6 +42,7 @@ import org.prebid.server.proto.openrtb.ext.request.ExtSite;
 import org.prebid.server.proto.openrtb.ext.request.ExtUser;
 import org.prebid.server.proto.openrtb.ext.request.ExtUserPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ImpMediaType;
+import org.prebid.server.settings.model.Account;
 import org.prebid.server.validation.model.ValidationResult;
 
 import java.math.BigDecimal;
@@ -67,6 +68,7 @@ import static org.mockito.Mockito.verify;
 public class RequestValidatorTest extends VertxTest {
 
     private static final String RUBICON = "rubicon";
+    private static final String ACCOUNT_ID = "accountId";
 
     @Mock(strictness = LENIENT)
     private BidderCatalog bidderCatalog;
@@ -91,7 +93,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = BidRequest.builder().build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result).isNotNull();
@@ -104,7 +106,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().id("").build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -117,7 +119,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().id(null).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -130,7 +132,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().id("1").tmax(-100L).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -143,7 +145,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().tmax(null).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -155,7 +157,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().cur(null).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -169,7 +171,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().imp(null).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -187,7 +189,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors())
@@ -205,7 +207,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors())
@@ -219,7 +221,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(Site.builder().id(null).build()).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -232,7 +234,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(Site.builder().id("").build()).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -245,7 +247,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(Site.builder().id("1").page(null).build()).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.hasErrors()).isFalse();
@@ -257,7 +259,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(Site.builder().id("1").page("").build()).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.hasErrors()).isFalse();
@@ -269,7 +271,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(Site.builder().id("").page("").build()).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -284,7 +286,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -299,7 +301,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -313,7 +315,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(null).dooh(invalidDooh).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -327,7 +329,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().site(null).dooh(invalidDooh).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -344,7 +346,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -360,7 +362,7 @@ public class RequestValidatorTest extends VertxTest {
                 .app(App.builder().build())
                 .site(Site.builder().build())
                 .build();
-        final ValidationResult result = target.validate(invalidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), invalidRequest, null, null);
 
         // then
         verify(metrics).updateAlertsMetrics(MetricName.general);
@@ -377,7 +379,7 @@ public class RequestValidatorTest extends VertxTest {
                 .app(App.builder().build())
                 .site(Site.builder().build())
                 .build();
-        final ValidationResult result = target.validate(invalidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), invalidRequest, null, null);
 
         // then
         verify(metrics).updateAlertsMetrics(MetricName.general);
@@ -394,7 +396,7 @@ public class RequestValidatorTest extends VertxTest {
                 .dooh(Dooh.builder().build())
                 .site(Site.builder().build())
                 .build();
-        final ValidationResult result = target.validate(invalidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), invalidRequest, null, null);
 
         // then
         verify(metrics).updateAlertsMetrics(MetricName.general);
@@ -411,7 +413,7 @@ public class RequestValidatorTest extends VertxTest {
                 .dooh(Dooh.builder().build())
                 .app(App.builder().build())
                 .build();
-        final ValidationResult result = target.validate(invalidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), invalidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -429,7 +431,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -446,7 +448,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -463,7 +465,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -480,7 +482,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -498,7 +500,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -516,7 +518,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -530,7 +532,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -549,7 +551,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -566,7 +568,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -580,7 +582,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -598,7 +600,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -616,7 +618,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -634,7 +636,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -653,7 +655,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -675,7 +677,7 @@ public class RequestValidatorTest extends VertxTest {
 
         // when
         final ValidationResult result = target.validate(
-                bidRequest, null, DebugContext.of(true, false, null));
+                Account.empty(ACCOUNT_ID), bidRequest, null, DebugContext.of(true, false, null));
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -698,7 +700,7 @@ public class RequestValidatorTest extends VertxTest {
 
         // when
         final ValidationResult result = target.validate(
-                bidRequest, null, DebugContext.of(false, false, null));
+                Account.empty(ACCOUNT_ID), bidRequest, null, DebugContext.of(false, false, null));
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -718,7 +720,7 @@ public class RequestValidatorTest extends VertxTest {
 
         // when
         final ValidationResult result = target.validate(
-                bidRequest, null, DebugContext.of(true, false, null));
+                Account.empty(ACCOUNT_ID), bidRequest, null, DebugContext.of(true, false, null));
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -743,7 +745,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -761,7 +763,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -779,7 +781,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -798,7 +800,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -817,7 +819,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -838,7 +840,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -858,7 +860,7 @@ public class RequestValidatorTest extends VertxTest {
                         .build()))
                 .build();
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -879,7 +881,7 @@ public class RequestValidatorTest extends VertxTest {
                         .build()))
                 .build();
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -898,7 +900,7 @@ public class RequestValidatorTest extends VertxTest {
                         .build()))
                 .build();
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -921,7 +923,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -949,7 +951,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -976,7 +978,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -998,7 +1000,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1019,7 +1021,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1042,7 +1044,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1064,7 +1066,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1083,7 +1085,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1106,7 +1108,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -1124,7 +1126,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -1140,7 +1142,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -1156,7 +1158,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1172,7 +1174,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().ext(ext).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1190,7 +1192,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().ext(ext).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1208,7 +1210,7 @@ public class RequestValidatorTest extends VertxTest {
         given(bidderCatalog.isActive("appnexus")).willReturn(false);
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1224,7 +1226,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().ext(ext).build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -1238,7 +1240,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1257,7 +1259,7 @@ public class RequestValidatorTest extends VertxTest {
                                 .build()))
                 .build();
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1279,7 +1281,7 @@ public class RequestValidatorTest extends VertxTest {
                                 .build()))
                 .build();
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1301,7 +1303,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1322,7 +1324,7 @@ public class RequestValidatorTest extends VertxTest {
                                 .build()))
                 .build();
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).hasSize(1)
@@ -1346,7 +1348,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -1370,7 +1372,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).isEmpty();
@@ -1391,7 +1393,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         verify(bidderCatalog).isValidName(rubiconAlias);
@@ -1412,7 +1414,7 @@ public class RequestValidatorTest extends VertxTest {
                 .build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors())
@@ -1429,7 +1431,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getErrors()).containsOnly("imp[0] validation failed");
@@ -1444,7 +1446,7 @@ public class RequestValidatorTest extends VertxTest {
         final BidRequest bidRequest = validBidRequestBuilder().build();
 
         // when
-        final ValidationResult result = target.validate(bidRequest, null, null);
+        final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
         assertThat(result.getWarnings()).containsOnly("imp[0] validation warning");

--- a/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
+++ b/src/test/java/org/prebid/server/validation/RequestValidatorTest.java
@@ -1195,7 +1195,7 @@ public class RequestValidatorTest extends VertxTest {
         final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
-        assertThat(result.getErrors()).hasSize(1)
+        assertThat(result.getWarnings()).hasSize(1)
                 .containsOnly("request.ext.prebid.aliases.alias refers to unknown bidder: fake");
     }
 
@@ -1213,7 +1213,7 @@ public class RequestValidatorTest extends VertxTest {
         final ValidationResult result = target.validate(Account.empty(ACCOUNT_ID), bidRequest, null, null);
 
         // then
-        assertThat(result.getErrors()).hasSize(1)
+        assertThat(result.getWarnings()).hasSize(1)
                 .containsOnly("request.ext.prebid.aliases.alias refers to disabled bidder: appnexus");
     }
 


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Fix [issue #3592](https://github.com/prebid/prebid-server-java/issues/3592). Bad Input Error if pbjs s2s config contains alias configuration for a disabled adapter.
Move unknown bidder and bidder is deactivated errors to warnings level.
Add unknown_bidder and deactivated_bidder metrics
 

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Changes are covered by unit tests.

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
