### PR TITLE
rxnetwork: adding rxnetwork alias to adkernel

### DIFF
--- a/src/main/resources/bidder-config/adkernel.yaml
+++ b/src/main/resources/bidder-config/adkernel.yaml
@@ -2,6 +2,8 @@ adapters:
   adkernel:
     endpoint: http://pbs.adksrv.com/hb?zone=%s
     endpoint-compression: gzip
+    aliases:
+      rxnetwork: ~
     meta-info:
       maintainer-email: prebid-dev@adkernel.com
       app-media-types:


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [x] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
What's the context for the changes?
Added `rxnetwork` as alias for `adkernel`

