### PR TITLE
Adnuntius: Use format=prebidServer on adserver requests

### DIFF
--- a/src/main/java/org/prebid/server/bidder/adnuntius/AdnuntiusBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adnuntius/AdnuntiusBidder.java
@@ -213,7 +213,7 @@ public class AdnuntiusBidder implements Bidder<AdnuntiusRequest> {
     private String createUri(BidRequest bidRequest, Boolean noCookies) {
         try {
             final URIBuilder uriBuilder = new URIBuilder(endpointUrl)
-                    .addParameter("format", "prebid")
+                    .addParameter("format", "prebidServer")
                     .addParameter("tzo", getTimeZoneOffset());
 
             final String gdpr = extractGdpr(bidRequest.getRegs());

--- a/src/test/java/org/prebid/server/bidder/adnuntius/AdnuntiusBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/adnuntius/AdnuntiusBidderTest.java
@@ -1004,7 +1004,7 @@ public class AdnuntiusBidderTest extends VertxTest {
     }
 
     private static String buildExpectedUrl(Integer gdpr, String consent, Boolean noCookies) {
-        final StringBuilder expectedUri = new StringBuilder("https://test.domain.dm/uri?format=prebid&tzo=-300");
+        final StringBuilder expectedUri = new StringBuilder("https://test.domain.dm/uri?format=prebidServer&tzo=-300");
         if (gdpr != null) {
             expectedUri.append("&gdpr=").append(HttpUtil.encodeUrl(gdpr.toString()));
         }


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
What's the context for the changes?

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
