### PR TITLE
Change size prediction logic

### DIFF
--- a/src/main/java/org/prebid/server/cookie/CookieSize.java
+++ b/src/main/java/org/prebid/server/cookie/CookieSize.java
@@ -1,0 +1,57 @@
+package org.prebid.server.cookie;
+
+import io.vertx.core.http.Cookie;
+import org.apache.commons.lang3.StringUtils;
+
+public class CookieSize {
+
+    // {"tempUIDs":{},"optout":false}
+    private static final int TEMP_UIDS_BASE64_BYTES = "eyJ0ZW1wVUlEcyI6e30sIm9wdG91dCI6ZmFsc2V9".length();
+    private static final int UID_TEMPLATE_BYTES =
+            "\"\":{\"uid\":\"\",\"expires\":\"1970-01-01T00:00:00.000000Z\"},".length();
+
+    private final int cookieSchemaSize;
+    private final int maxSize;
+    private int encodedUidsSize;
+
+    public CookieSize(int cookieSchemaSize, int maxSize) {
+        this.cookieSchemaSize = cookieSchemaSize;
+        this.maxSize = maxSize;
+
+        encodedUidsSize = 0;
+    }
+
+    public static int schemaSize(Cookie cookieSchema) {
+        return cookieSchema.setValue(StringUtils.EMPTY).encode().length();
+    }
+
+    public boolean isValid() {
+        return maxSize <= 0 || totalSize() <= maxSize;
+    }
+
+    public int totalSize() {
+        return cookieSchemaSize
+                + TEMP_UIDS_BASE64_BYTES
+                + Base64Size.base64Size(encodedUidsSize);
+    }
+
+    public void addUid(String cookieFamily, String uid) {
+        final int uidSize = UID_TEMPLATE_BYTES + cookieFamily.length() + uid.length();
+        encodedUidsSize = Base64Size.encodeSize(Base64Size.decodeSize(encodedUidsSize) + uidSize);
+    }
+
+    private static class Base64Size {
+
+        public static int encodeSize(int size) {
+            return size / 3 * 4 + size % 3;
+        }
+
+        public static int decodeSize(int encodedSize) {
+            return encodedSize / 4 * 3 + encodedSize % 4;
+        }
+
+        private static int base64Size(int encodedSize) {
+            return (encodedSize & -4) + 4 * Integer.signum(encodedSize % 4);
+        }
+    }
+}

--- a/src/main/java/org/prebid/server/cookie/UidsCookieService.java
+++ b/src/main/java/org/prebid/server/cookie/UidsCookieService.java
@@ -281,19 +281,19 @@ public class UidsCookieService {
         final Iterator<String> cookieFamilies = cookieFamilyNamesByDescPriorityAndExpiration(uidsCookie);
         final List<Cookie> splitCookies = new ArrayList<>();
 
-        final int cookieSchemaSize = CookieSize.schemaSize(makeCookie(COOKIE_NAME, StringUtils.EMPTY, ttlSeconds));
+        final int cookieSchemaSize = UidsCookieSize.schemaSize(makeCookie(COOKIE_NAME, StringUtils.EMPTY, ttlSeconds));
         String nextCookieFamily = null;
         for (int i = 0; i < numberOfUidCookies; i++) {
             final int digits = i < 10 ? Integer.signum(i) : 2;
-            final CookieSize cookieSize = new CookieSize(cookieSchemaSize + digits, maxCookieSizeBytes);
+            final UidsCookieSize uidsCookieSize = new UidsCookieSize(cookieSchemaSize + digits, maxCookieSizeBytes);
 
             final Map<String, UidWithExpiry> tempUids = new HashMap<>();
             while (nextCookieFamily != null || cookieFamilies.hasNext()) {
                 nextCookieFamily = nextCookieFamily == null ? cookieFamilies.next() : nextCookieFamily;
                 final UidWithExpiry uidWithExpiry = uids.get(nextCookieFamily);
 
-                cookieSize.addUid(nextCookieFamily, uidWithExpiry.getUid());
-                if (!cookieSize.isValid()) {
+                uidsCookieSize.addUid(nextCookieFamily, uidWithExpiry.getUid());
+                if (!uidsCookieSize.isValid()) {
                     break;
                 }
 

--- a/src/main/java/org/prebid/server/cookie/UidsCookieSize.java
+++ b/src/main/java/org/prebid/server/cookie/UidsCookieSize.java
@@ -1,20 +1,36 @@
 package org.prebid.server.cookie;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.vertx.core.http.Cookie;
 import org.apache.commons.lang3.StringUtils;
+import org.prebid.server.json.ObjectMapperProvider;
 
-public class CookieSize {
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class UidsCookieSize {
 
     // {"tempUIDs":{},"optout":false}
     private static final int TEMP_UIDS_BASE64_BYTES = "eyJ0ZW1wVUlEcyI6e30sIm9wdG91dCI6ZmFsc2V9".length();
-    private static final int UID_TEMPLATE_BYTES =
-            "\"\":{\"uid\":\"\",\"expires\":\"1970-01-01T00:00:00.000000Z\"},".length();
+    private static final int UID_TEMPLATE_BYTES;
+
+    static {
+        try {
+            UID_TEMPLATE_BYTES = "\"\":{\"uid\":\"\",\"expires\":\"%s\"},"
+                    .formatted(ObjectMapperProvider.mapper().writeValueAsString(
+                            ZonedDateTime.ofInstant(Instant.ofEpochSecond(0, 1), ZoneId.of("UTC"))))
+                    .length();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private final int cookieSchemaSize;
     private final int maxSize;
     private int encodedUidsSize;
 
-    public CookieSize(int cookieSchemaSize, int maxSize) {
+    public UidsCookieSize(int cookieSchemaSize, int maxSize) {
         this.cookieSchemaSize = cookieSchemaSize;
         this.maxSize = maxSize;
 


### PR DESCRIPTION
- `.000000000Z` -> `.000000Z`
- fixed bug when we adding `cookieName id` size for each `uid` instead once for whole `cookie`
- changed logic so we can add as many uids as possible without any risks
- refactoring