### PR TITLE
Update code-path-changes.yml

### DIFF
--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -1,7 +1,7 @@
 name: Notify Code Path Changes
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     paths:
       - '**'

--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -14,7 +14,8 @@ env:
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   notify:

--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -14,6 +14,8 @@ env:
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions: read-all
+
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out in order for this to work for forked repos the trigger needs to be 'pull_request_target' rather than 'pull_request'

### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [X] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Code path notifications are not working for PRs from forked repos
