### PR TITLE
Insticator: fix video validation logic

### DIFF
--- a/src/main/java/org/prebid/server/bidder/insticator/InsticatorBidder.java
+++ b/src/main/java/org/prebid/server/bidder/insticator/InsticatorBidder.java
@@ -109,7 +109,7 @@ public class InsticatorBidder implements Bidder<BidRequest> {
 
         if (isInvalidDimension(video.getH())
                 || isInvalidDimension(video.getW())
-                || CollectionUtils.isNotEmpty(video.getMimes())) {
+                || CollectionUtils.isEmpty(video.getMimes())) {
 
             throw new PreBidException("One or more invalid or missing video field(s) w, h, mimes");
         }

--- a/src/test/java/org/prebid/server/bidder/insticator/InsticatorBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/insticator/InsticatorBidderTest.java
@@ -13,9 +13,6 @@ import com.iab.openrtb.request.Video;
 import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
-
-import java.util.Collections;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +33,7 @@ import org.prebid.server.proto.openrtb.ext.request.insticator.ExtImpInsticator;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -45,7 +43,6 @@ import static java.util.Collections.singletonList;
 import static java.util.function.UnaryOperator.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.InstanceOfAssertFactories.COLLECTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/org/prebid/server/bidder/insticator/InsticatorBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/insticator/InsticatorBidderTest.java
@@ -449,11 +449,11 @@ public class InsticatorBidderTest extends VertxTest {
         final BidRequest bidRequest = givenBidRequest(
                 imp -> imp.id("givenImpId1").ext(mapper.valueToTree(ExtPrebid.of(null, mapper.createArrayNode()))),
                 imp -> imp.id("givenImpId2"),
-                imp -> imp.id("givenImpId3").video(Video.builder().mimes(null).build()),
-                imp -> imp.id("givenImpId4").video(Video.builder().h(null).build()),
-                imp -> imp.id("givenImpId5").video(Video.builder().h(0).build()),
-                imp -> imp.id("givenImpId6").video(Video.builder().w(null).build()),
-                imp -> imp.id("givenImpId7").video(Video.builder().w(0).build()));
+                imp -> imp.id("givenImpId3").video(givenVideo(video -> video.mimes(null))),
+                imp -> imp.id("givenImpId4").video(givenVideo(video -> video.h(null))),
+                imp -> imp.id("givenImpId5").video(givenVideo(video -> video.h(0))),
+                imp -> imp.id("givenImpId6").video(givenVideo(video -> video.w(null))),
+                imp -> imp.id("givenImpId7").video(givenVideo(video -> video.w(0))));
 
         //when
         final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
@@ -566,6 +566,14 @@ public class InsticatorBidderTest extends VertxTest {
                         .ext(mapper.valueToTree(ExtPrebid.of(
                                 null,
                                 ExtImpInsticator.of("adUnitId", "publisherId")))))
+                .build();
+    }
+
+    private static Video givenVideo(UnaryOperator<Video.VideoBuilder> videoCustomizer) {
+        return videoCustomizer.apply(Video.builder()
+                        .mimes(List.of("video/mp4"))
+                        .h(100)
+                        .w(100))
                 .build();
     }
 

--- a/src/test/java/org/prebid/server/bidder/insticator/InsticatorBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/insticator/InsticatorBidderTest.java
@@ -13,6 +13,9 @@ import com.iab.openrtb.request.Video;
 import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
+
+import java.util.Collections;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +45,7 @@ import static java.util.Collections.singletonList;
 import static java.util.function.UnaryOperator.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.InstanceOfAssertFactories.COLLECTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -450,6 +454,7 @@ public class InsticatorBidderTest extends VertxTest {
                 imp -> imp.id("givenImpId1").ext(mapper.valueToTree(ExtPrebid.of(null, mapper.createArrayNode()))),
                 imp -> imp.id("givenImpId2"),
                 imp -> imp.id("givenImpId3").video(givenVideo(video -> video.mimes(null))),
+                imp -> imp.id("givenImpId3").video(givenVideo(video -> video.mimes(Collections.emptyList()))),
                 imp -> imp.id("givenImpId4").video(givenVideo(video -> video.h(null))),
                 imp -> imp.id("givenImpId5").video(givenVideo(video -> video.h(0))),
                 imp -> imp.id("givenImpId6").video(givenVideo(video -> video.w(null))),


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Insticator bidder adaptor had an issue in video validation

### 🧠 Rationale behind the change
This is a one-line fix to the video validation logic

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
N/A

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
