### PR TITLE
Fix IX bidder crash

### DIFF
--- a/src/main/java/org/prebid/server/bidder/ix/IxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/ix/IxBidder.java
@@ -386,12 +386,15 @@ public class IxBidder implements Bidder<BidRequest> {
     }
 
     private static Response mergeNativeImpTrackers(Response response, List<EventTracker> eventTrackers) {
+        final Stream<String> impTrackers = Optional.of(response)
+                .map(Response::getImptrackers).stream().flatMap(Collection::stream);
+
         return response.toBuilder()
                 .imptrackers(Stream.concat(
                                 eventTrackers.stream()
                                         .filter(IxBidder::isImpTracker)
                                         .map(EventTracker::getUrl),
-                                response.getImptrackers().stream())
+                                impTrackers)
                         .distinct()
                         .toList())
                 .build();


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Fix IX bidder's crash with Nullpointer at merging NativeImpTrackers for adm when Imptrackers are absent. 

### 🧠 Rationale behind the change
It makes auction fail. 
Stacktrace:
```2025-02-18T22:22:42.529Z ERROR 1 --- [ntloop-thread-7] o.p.s.handler.openrtb2.AuctionHandler    : Critical error while running the auction
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "com.iab.openrtb.response.Response.getImptrackers()" is null
	at org.prebid.server.bidder.ix.IxBidder.mergeNativeImpTrackers(IxBidder.java:392)
	at org.prebid.server.bidder.ix.IxBidder.mergeNativeImpTrackers(IxBidder.java:382)
	at org.prebid.server.bidder.ix.IxBidder.updateBidAdmWithNativeAttributes(IxBidder.java:364)
	at org.prebid.server.bidder.ix.IxBidder.toBidderBid(IxBidder.java:281)
	at org.prebid.server.bidder.ix.IxBidder.lambda$extractBids$2(IxBidder.java:261)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at org.prebid.server.bidder.ix.IxBidder.extractBids(IxBidder.java:263)
	at org.prebid.server.bidder.ix.IxBidder.makeBidderResponse(IxBidder.java:238)
	at org.prebid.server.bidder.HttpBidderRequester.makeBids(HttpBidderRequester.java:318)
	at org.prebid.server.bidder.HttpBidderRequester.processHttpCall(HttpBidderRequester.java:295)
	at org.prebid.server.bidder.HttpBidderRequester.lambda$requestBids$2(HttpBidderRequester.java:130)...```

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Covered by unit tests.

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
