### PR TITLE
Adding other SSPs to codepath-notification

### DIFF
--- a/.github/workflows/scripts/codepath-notification
+++ b/.github/workflows/scripts/codepath-notification
@@ -19,4 +19,5 @@
 /ix|Ix|ix.json|ix.yaml: pdu-supply-prebid@indexexchange.com
 appnexus|Appnexus: prebid@microsoft.com
 pubmatic|Pubmatic: header-bidding@pubmatic.com
-openx|OpenX: : prebid@openx.com
+openx|OpenX: prebid@openx.com
+medianet|Medianet: prebid@media.net

--- a/.github/workflows/scripts/codepath-notification
+++ b/.github/workflows/scripts/codepath-notification
@@ -17,3 +17,6 @@
 # The aim is to find a minimal set of regex patterns that matches any file in these paths
 
 /ix|Ix|ix.json|ix.yaml: pdu-supply-prebid@indexexchange.com
+appnexus|Appnexus: prebid@microsoft.com
+pubmatic|Pubmatic: header-bidding@pubmatic.com
+openx|OpenX: : prebid@openx.com


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [X] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Seeding the code path notification with additional bidders before opening the door to the Prebid community. These ones will all ask anyhow.

