### PR TITLE
Alternate bidder codes

### DIFF
--- a/src/main/java/org/prebid/server/auction/AllowedAlternateBidderCodes.java
+++ b/src/main/java/org/prebid/server/auction/AllowedAlternateBidderCodes.java
@@ -1,0 +1,64 @@
+package org.prebid.server.auction;
+
+import com.iab.openrtb.request.BidRequest;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodes;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodesBidder;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
+import org.prebid.server.util.ObjectUtil;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helper class for applying the allow-alternate-bidder-codes configuration
+ */
+public class AllowedAlternateBidderCodes {
+
+    private static final String WILDCARD = "*";
+
+    private AllowedAlternateBidderCodes() { }
+
+    public static Set<String> allowedCodesForBidder(String bidder, BidRequest bidRequest) {
+        final ExtRequestAlternateBidderCodes alternateBidderCodes = ObjectUtil.getIfNotNull(
+                bidRequest.getExt().getPrebid(), ExtRequestPrebid::getAlternatebiddercodes);
+
+        if (alternateBidderCodes == null) {
+            return null;
+        }
+
+        if (!alternateBidderCodes.getEnabled()) {
+            return null;
+        }
+
+        final Map<String, ExtRequestAlternateBidderCodesBidder> alternateBidderCodesBidderMap =
+                alternateBidderCodes.getBidders();
+
+        if (alternateBidderCodesBidderMap == null) {
+            return null;
+        }
+
+        final ExtRequestAlternateBidderCodesBidder alternateBidderCodesBidder =
+                alternateBidderCodesBidderMap.get(bidder);
+
+        if (alternateBidderCodesBidder == null || !alternateBidderCodesBidder.getEnabled()) {
+            return null;
+        }
+
+        final List<String> allowedAlternates = alternateBidderCodesBidder.getAllowedBidderCodes();
+        return allowedAlternates != null ? new HashSet<>(allowedAlternates) : null;
+    }
+
+    public static String applySeatForBid(Set<String> allowedAlternateBidderCodes, String bidder, String wantedSeat) {
+        if (allowedAlternateBidderCodes == null || wantedSeat == null) {
+            return bidder;
+        }
+
+        if (allowedAlternateBidderCodes.contains(wantedSeat) || allowedAlternateBidderCodes.contains(WILDCARD)) {
+            return wantedSeat;
+        }
+
+        return bidder;
+    }
+}

--- a/src/main/java/org/prebid/server/auction/BidResponseCreator.java
+++ b/src/main/java/org/prebid/server/auction/BidResponseCreator.java
@@ -1466,7 +1466,8 @@ public class BidResponseCreator {
                 continue;
             }
 
-            bidsByBidder.putIfAbsent(bidder, new ArrayList<>(1)).add(bid);
+            bidsByBidder.putIfAbsent(bidder, new ArrayList<>(1));
+            bidsByBidder.get(bidder).add(bid);
         }
 
         return bidsByBidder.entrySet().stream()

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -78,6 +78,8 @@ import org.prebid.server.proto.openrtb.ext.request.ExtApp;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidderConfigOrtb;
 import org.prebid.server.proto.openrtb.ext.request.ExtDooh;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodes;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodesBidder;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidBidderConfig;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidCache;
@@ -91,6 +93,7 @@ import org.prebid.server.proto.openrtb.ext.request.ExtUser;
 import org.prebid.server.settings.model.Account;
 import org.prebid.server.util.HttpUtil;
 import org.prebid.server.util.ListUtil;
+import org.prebid.server.util.ObjectUtil;
 import org.prebid.server.util.PbsUtil;
 import org.prebid.server.util.StreamUtil;
 
@@ -1201,6 +1204,7 @@ public class ExchangeService {
 
         final CaseInsensitiveMultiMap requestHeaders = auctionContext.getHttpRequest().getHeaders();
         final String bidderName = bidderRequest.getBidder();
+
         final String resolvedBidderName = aliases.resolveBidder(bidderName);
         final Bidder<?> bidder = bidderCatalog.bidderByName(resolvedBidderName);
         final long bidderTmaxDeductionMs = bidderCatalog.bidderInfoByName(resolvedBidderName).getTmaxDeductionMs();

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -78,8 +78,6 @@ import org.prebid.server.proto.openrtb.ext.request.ExtApp;
 import org.prebid.server.proto.openrtb.ext.request.ExtBidderConfigOrtb;
 import org.prebid.server.proto.openrtb.ext.request.ExtDooh;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
-import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodes;
-import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodesBidder;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidBidderConfig;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidCache;
@@ -93,7 +91,6 @@ import org.prebid.server.proto.openrtb.ext.request.ExtUser;
 import org.prebid.server.settings.model.Account;
 import org.prebid.server.util.HttpUtil;
 import org.prebid.server.util.ListUtil;
-import org.prebid.server.util.ObjectUtil;
 import org.prebid.server.util.PbsUtil;
 import org.prebid.server.util.StreamUtil;
 

--- a/src/main/java/org/prebid/server/auction/requestfactory/Ortb2ImplicitParametersResolver.java
+++ b/src/main/java/org/prebid/server/auction/requestfactory/Ortb2ImplicitParametersResolver.java
@@ -49,6 +49,7 @@ import org.prebid.server.proto.openrtb.ext.request.ExtDevice;
 import org.prebid.server.proto.openrtb.ext.request.ExtMediaTypePriceGranularity;
 import org.prebid.server.proto.openrtb.ext.request.ExtPriceGranularity;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodes;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidCache;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidChannel;
@@ -726,6 +727,8 @@ public class Ortb2ImplicitParametersResolver {
                                           Account account) {
 
         final ExtRequestPrebid prebid = ObjectUtil.getIfNotNull(ext, ExtRequest::getPrebid);
+        final ExtRequestAlternateBidderCodes accountAlternateBidderCodes = ObjectUtil.getIfNotNull(
+                ObjectUtil.getIfNotNull(account, Account::getAuction), AccountAuctionConfig::getAlternateBidderCodes);
 
         final ExtRequestTargeting updatedTargeting = targetingOrNull(prebid, imps, account);
         final ExtRequestPrebidCache updatedCache = cacheOrNull(prebid);
@@ -742,6 +745,10 @@ public class Ortb2ImplicitParametersResolver {
                         ObjectUtil.getIfNotNull(prebid, ExtRequestPrebid::getCache)))
                 .channel(ObjectUtils.defaultIfNull(updatedChannel,
                         ObjectUtil.getIfNotNull(prebid, ExtRequestPrebid::getChannel)))
+                .alternatebiddercodes(ObjectUtils.defaultIfNull(
+                    ObjectUtil.getIfNotNull(prebid, ExtRequestPrebid::getAlternatebiddercodes),
+                    accountAlternateBidderCodes
+                ))
                 .server(serverInfo.with(endpoint))
                 .build());
 

--- a/src/main/java/org/prebid/server/bidder/amx/AmxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/amx/AmxBidder.java
@@ -174,7 +174,9 @@ public class AmxBidder implements Bidder<BidRequest> {
             return null;
         }
 
-        return BidderBid.of(resolveBid(bid, amxBidExt.getDemandSource()), getBidType(amxBidExt), cur, amxBidExt.getBidderCode());
+        return BidderBid.of(
+                resolveBid(bid, amxBidExt.getDemandSource()),
+                getBidType(amxBidExt), cur, amxBidExt.getBidderCode());
     }
 
     private AmxBidExt parseBidderExt(ObjectNode ext) {

--- a/src/main/java/org/prebid/server/bidder/amx/AmxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/amx/AmxBidder.java
@@ -173,8 +173,8 @@ public class AmxBidder implements Bidder<BidRequest> {
             errors.add(BidderError.badInput(e.getMessage()));
             return null;
         }
-        // TODO: After adding support to change seat data, add bid.ext bidderCode processing
-        return BidderBid.of(resolveBid(bid, amxBidExt.getDemandSource()), getBidType(amxBidExt), cur);
+
+        return BidderBid.of(resolveBid(bid, amxBidExt.getDemandSource()), getBidType(amxBidExt), cur, amxBidExt.getBidderCode());
     }
 
     private AmxBidExt parseBidderExt(ObjectNode ext) {

--- a/src/main/java/org/prebid/server/bidder/model/BidderBid.java
+++ b/src/main/java/org/prebid/server/bidder/model/BidderBid.java
@@ -45,11 +45,22 @@ public class BidderBid {
      */
     PriceFloorInfo priceFloorInfo;
 
-    public static BidderBid of(Bid bid, BidType bidType, String bidCurrency) {
+    /**
+     * The seat, which will override the default seat (e.g. the bidder name)
+     * if alternate-bidder-codes (ext.prebid.alternatebiddercodes) are allowed
+     */
+    String seat;
+
+    public static BidderBid of(Bid bid, BidType bidType, String bidCurrency, String seat) {
         return BidderBid.builder()
                 .bid(bid)
                 .type(bidType)
                 .bidCurrency(bidCurrency)
+                .seat(seat)
                 .build();
+    }
+
+    public static BidderBid of(Bid bid, BidType bidType, String bidCurrency) {
+        return of(bid, bidType, bidCurrency, null);
     }
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestAlternateBidderCodes.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestAlternateBidderCodes.java
@@ -12,6 +12,7 @@ import java.util.Map;
 @Builder(toBuilder = true)
 @Value
 public class ExtRequestAlternateBidderCodes {
+
     /**
      * Is this feature enabled
      */

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestAlternateBidderCodes.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestAlternateBidderCodes.java
@@ -1,0 +1,21 @@
+package org.prebid.server.proto.openrtb.ext.request;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.Map;
+
+
+/**
+ * Defines the contract for bidrequest.ext.prebid.alternatebiddercodes
+ */
+@Builder(toBuilder = true)
+@Value
+public class ExtRequestAlternateBidderCodes {
+    /**
+     * Is this feature enabled
+     */
+    Boolean enabled;
+
+    Map<String, ExtRequestAlternateBidderCodesBidder> bidders;
+}

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestAlternateBidderCodesBidder.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestAlternateBidderCodesBidder.java
@@ -1,0 +1,15 @@
+package org.prebid.server.proto.openrtb.ext.request;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@Value
+public class ExtRequestAlternateBidderCodesBidder {
+
+    Boolean enabled;
+
+    List<String> allowedBidderCodes;
+}

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebid.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebid.java
@@ -42,6 +42,11 @@ public class ExtRequestPrebid {
     Map<String, String> aliases;
 
     /**
+     * Defines the contract for bidrequest.ext.prebid.alternatebiddercodes
+     */
+    ExtRequestAlternateBidderCodes alternatebiddercodes;
+
+    /**
      * Defines the contract for bidrequest.ext.prebid.aliasgvlids
      */
     Map<String, Integer> aliasgvlids;

--- a/src/main/java/org/prebid/server/settings/model/AccountAuctionConfig.java
+++ b/src/main/java/org/prebid/server/settings/model/AccountAuctionConfig.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Builder;
 import lombok.Value;
 import org.prebid.server.auction.model.PaaFormat;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestAlternateBidderCodes;
 import org.prebid.server.spring.config.bidder.model.MediaType;
 
 import java.util.Map;
@@ -31,6 +32,9 @@ public class AccountAuctionConfig {
 
     @JsonAlias("debug-allow")
     Boolean debugAllow;
+
+    @JsonAlias("alternate-bidder-codes")
+    ExtRequestAlternateBidderCodes alternateBidderCodes;
 
     @JsonAlias("bid-validations")
     AccountBidValidationConfig bidValidations;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -102,6 +102,7 @@ adapter-defaults:
     allow: true
 auction:
   ad-server-currency: USD
+  alternate-bidder-codes:
   blocklisted-accounts:
   blocklisted-apps:
   biddertmax:

--- a/src/test/java/org/prebid/server/bidder/amx/AmxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/amx/AmxBidderTest.java
@@ -316,6 +316,8 @@ public class AmxBidderTest extends VertxTest {
         // given
         final ObjectNode givenBidExt = mapper.createObjectNode();
         givenBidExt.set("ds", new TextNode("someDs"));
+        givenBidExt.set("bc", new TextNode("someBc"));
+
         final BidderCall<BidRequest> httpCall = givenHttpCall(
                 BidRequest.builder()
                         .imp(singletonList(Imp.builder().video(Video.builder().build()).id("123").build()))
@@ -328,6 +330,10 @@ public class AmxBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue())
+                .extracting(BidderBid::getSeat)
+                .containsExactly("someBc");
+
         assertThat(result.getValue())
                 .extracting(BidderBid::getBid)
                 .extracting(Bid::getExt)


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

The prebid-server (go) implementation supports alternate bidder codes (e.g. https://github.com/prebid/prebid-server/pull/2266, https://github.com/prebid/prebid-server/pull/2339 etc) -- which aligns with the implementation in prebid.js. This is an attempt at an implementation in prebid-server-java


### 🧠 Rationale behind the change

The AMX Bidder uses this feature, as well as pubmatic (in prebid-server & prebid.js)

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes


---

Note: this is a draft, tests are needed + fixes for existing tests
