### PR TITLE
Add aws default credentials provider

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
@@ -240,12 +240,10 @@ public class SettingsConfiguration {
 
         @Component
         @ConfigurationProperties(prefix = "settings.s3")
-        @ConditionalOnProperty(prefix = "settings.s3", name = {"accessKeyId", "secretAccessKey"})
         @Validated
         @Data
         @NoArgsConstructor
         protected static class S3ConfigurationProperties {
-
             /**
              * If accessKeyId and secretAccessKey are provided in the
              * configuration file then they will be used. Otherwise, the


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ x ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Currently, the S3 integration for prebid-server-java requires AWS credentials to be explicitly defined in the config yaml file. The SettingsConfiguration class in PBS Java uses AwsBasicCredentials to authenticate S3 requests, making credential storage in the YAML file mandatory. However, this is not good practice for credential management. This PR adds another credentials provider that will look for credentials in this order:
             * - Java System Properties
             * - Environment Variables
             * - Web Identity Token
             * - AWS credentials file (~/.aws/credentials)
             * - ECS container credentials
             * - EC2 instance profile

### 🧠 Rationale behind the change
I made these changes so that S3 integration can be used with the recommended practices for AWS credential management.

### 🧪 Test plan
The following cases have been manually tested. 
* If accessKeyId and secretAccessKey are provided in the config yaml file, are they still used? 
* If they are not provided in the config yaml file, does are credentials found in the following order:
             * - Java System Properties
             * - Environment Variables
             * - Web Identity Token
             * - AWS credentials file (~/.aws/credentials)
             * - ECS container credentials
             * - EC2 instance profile

### 🏎 Quality check
- [ x ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ no ] Are there any breaking changes in your code?
- [ tbd ] Does your test coverage exceed 90%?  These changes were made to S3AsyncClient, but  S3ApplicationSettingsTest mocks S3AsyncClient.
- [ no ] Are there any erroneous console logs, debuggers or leftover code in your changes?
