### PR TITLE
Add aws default credentials provider

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/SettingsConfiguration.java
@@ -240,12 +240,10 @@ public class SettingsConfiguration {
 
         @Component
         @ConfigurationProperties(prefix = "settings.s3")
-        @ConditionalOnProperty(prefix = "settings.s3", name = {"accessKeyId", "secretAccessKey"})
         @Validated
         @Data
         @NoArgsConstructor
         protected static class S3ConfigurationProperties {
-
             /**
              * If accessKeyId and secretAccessKey are provided in the
              * configuration file then they will be used. Otherwise, the

--- a/src/main/java/org/prebid/server/spring/config/SettingsConfigurationTest.java
+++ b/src/main/java/org/prebid/server/spring/config/SettingsConfigurationTest.java
@@ -1,0 +1,74 @@
+package org.prebid.server.spring.config;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SettingsConfigurationTest {
+
+    @Test
+    public void useStaticCredentialsShouldReturnTrueWhenStaticCredentialsAreUsed() {
+        // given
+        SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties s3Properties = new SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties();
+        s3Properties.setAccessKeyId("testAccessKeyId");
+        s3Properties.setSecretAccessKey("testSecretAccessKey");
+
+        // when
+        final boolean result = s3Properties.useStaticCredentials();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void useStaticCredentialsShouldReturnFalseWhenStaticCredentialsAreNotUsed() {
+        // given
+        SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties s3Properties = new SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties();
+
+        // when
+        final boolean result = s3Properties.useStaticCredentials();
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldCreateClientWhenStaticCredentialsNotUsed() throws URISyntaxException {
+        // given
+        SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties s3Properties = new SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties();
+        s3Properties.setEndpoint("http://example.com");
+        s3Properties.setForcePathStyle(true);
+        s3Properties.setRegion("us-east-1");
+        // Not setting access key and secret key properties should
+        // cause the S3AsyncClient to use DefaultCredentialsProvider.
+
+        // when
+        S3AsyncClient client = new SettingsConfiguration.S3SettingsConfiguration().s3AsyncClient(s3Properties);
+
+        // then
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    void shouldCreateClientWhenStaticCredentialsUsed() throws URISyntaxException {
+        // given
+        SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties s3Properties = new SettingsConfiguration.S3SettingsConfiguration.S3ConfigurationProperties();
+        s3Properties.setEndpoint("http://localhost:4566");
+        s3Properties.setForcePathStyle(true);
+        s3Properties.setRegion("us-east-1");
+        // Setting access key and secret key properties should cause
+        // the S3AsyncClient to use StaticCredentialsProvider.
+        s3Properties.setAccessKeyId("testAccessKeyId");
+        s3Properties.setSecretAccessKey("testSecretAccessKey");
+
+        // when
+        S3AsyncClient client = new SettingsConfiguration.S3SettingsConfiguration().s3AsyncClient(s3Properties);
+
+        // then
+        assertThat(client).isNotNull();
+    }
+
+}


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Currently, the S3 integration for prebid-server-java requires AWS credentials to be explicitly defined in the config yaml file. The SettingsConfiguration class in PBS Java uses AwsBasicCredentials to authenticate S3 requests, making credential storage in the YAML file mandatory. However, this is not good practice for credential management. This PR adds another credentials provider that will look for credentials in this order:
  * Java System Properties
  * Environment Variables
  * Web Identity Token
  * AWS credentials file (~/.aws/credentials)
  * ECS container credentials
  * EC2 instance profile

### 🧠 Rationale behind the change
So that S3 integration can be used with the recommended practices for AWS credential management.

### 🧪 Test plan
* If accessKeyId and secretAccessKey are provided in the config yaml file, then verify that they are still used. 
* If they are not provided in the config yaml file, then verify that AWS credentials are found in the order described above.

### 🏎 Quality check
- [ x ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ no ] Are there any breaking changes in your code?
- [ yes ] Does your test coverage exceed 90%? 
- [ no ] Are there any erroneous console logs, debuggers or leftover code in your changes?
