### PR TITLE
Pin netty-handler for CVE-2025-24970

### DIFF
--- a/extra/pom.xml
+++ b/extra/pom.xml
@@ -53,6 +53,7 @@
         <protoc.version>${protobuf.version}</protoc.version>
         <json-logic.version>1.0.7</json-logic.version>
         <aws.awssdk.version>2.26.24</aws.awssdk.version>
+        <netty-handler.version>4.1.118.Final</netty-handler.version>
 
         <!-- Project test dependency versions -->
         <wiremock.version>3.9.1</wiremock.version>
@@ -77,7 +78,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.118.Final</version>
+                <version>${netty-handler.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/extra/pom.xml
+++ b/extra/pom.xml
@@ -4,14 +4,14 @@
 
     <groupId>org.prebid</groupId>
     <artifactId>prebid-server-aggregator</artifactId>
-    <version>3.23.0-SNAPSHOT</version>
+    <version>3.22.0</version>
     <packaging>pom</packaging>
 
     <scm>
         <url>https://github.com/prebid/prebid-server-java</url>
         <connection>scm:git:git@github.com:prebid/prebid-server-java.git</connection>
         <developerConnection>scm:git:git@github.com:prebid/prebid-server-java.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>3.22.0</tag>
     </scm>
 
     <properties>
@@ -74,6 +74,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/extra/pom.xml
+++ b/extra/pom.xml
@@ -4,14 +4,14 @@
 
     <groupId>org.prebid</groupId>
     <artifactId>prebid-server-aggregator</artifactId>
-    <version>3.22.0</version>
+    <version>3.23.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
         <url>https://github.com/prebid/prebid-server-java</url>
         <connection>scm:git:git@github.com:prebid/prebid-server-java.git</connection>
         <developerConnection>scm:git:git@github.com:prebid/prebid-server-java.git</developerConnection>
-        <tag>3.22.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/extra/pom.xml
+++ b/extra/pom.xml
@@ -75,6 +75,7 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- set netty-handler version for CVE-2025-24970-->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [X] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
This is for https://nvd.nist.gov/vuln/detail/CVE-2025-24970. netty-handler <4.1.118.Final has a high vulnerability related to SSL handling. vert.x >=4.5.13 pulls in this patched version of netty-handler, but a vert.x upgrade is a wider-reaching change. This is a pin for the fixed version of netty-handler only until a larger upgrade can be undertaken.

### 🧠 Rationale behind the change
This is a smaller and targeted pin for the patched version of netty-handler only versus attempting an larger upgrade to vert.x for the same CVE. No compatibility issues observed with netty-handler 4.1.118.Final.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Unit tests (`mvn test`) and functional tests (`mvn verify`) pass. 

### 🏎 Quality check
- [y] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [n] Are there any breaking changes in your code?
- [-] Does your test coverage exceed 90%?
- [n] Are there any erroneous console logs, debuggers or leftover code in your changes?
