### PR TITLE
Add aws default credentials provider v2

### DIFF
--- a/docs/application-settings.md
+++ b/docs/application-settings.md
@@ -277,8 +277,8 @@ The general idea is that you'll place all the account-specific settings in a sep
 ```yaml
 settings:
   s3:
-      accessKeyId: <S3 access key>
-      secretAccessKey: <S3 access key>
+      accessKeyId: <S3 access key> # optional
+      secretAccessKey: <S3 access key> #optional
       endpoint: <endpoint> # http://s3.storage.com
       bucket: <bucket name> # prebid-application-settings
       region: <region name> # if not provided AWS_GLOBAL will be used. Example value: 'eu-central-1'
@@ -297,6 +297,14 @@ settings:
           refresh-rate: 900000 # Refresh every 15 minutes
           timeout: 5000
 ```
+
+If `accessKeyId` and `secretAccessKey` are not specified in the Prebid Server configuration  then AWS credentials will be looked up in this order:
+- Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
+- Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+- Web Identity Token credentials from system properties or environment variables
+- Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
+- Credentials delivered through the Amazon EC2 container service if "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
+- Instance profile credentials delivered through the Amazon EC2 metadata service
 
 ### File format
 

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -391,8 +391,8 @@ contain 'WHERE last_updated > ?' for MySQL and 'WHERE last_updated > $1' for Pos
 
 For S3 storage configuration
 - `settings.in-memory-cache.s3-update.refresh-rate` - refresh period in ms for stored request updates in S3
-- `settings.s3.access-key-id` - an access key
-- `settings.s3.secret-access-key` - a secret access key
+- `settings.s3.access-key-id` - an access key (optional)
+- `settings.s3.secret-access-key` - a secret access key (optional)
 - `settings.s3.region` - a region, AWS_GLOBAL by default
 - `settings.s3.endpoint` - an endpoint
 - `settings.s3.bucket` - a bucket name
@@ -401,6 +401,15 @@ For S3 storage configuration
 - `settings.s3.stored-imps-dir` - a directory with stored imps
 - `settings.s3.stored-requests-dir` - a directory with stored requests
 - `settings.s3.stored-responses-dir` - a directory with stored responses
+
+If `settings.s3.access-key-id` and `settings.s3.secret-access-key` are not specified in the Prebid Server configuration then AWS credentials will be looked up in this order:
+- Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
+- Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+- Web Identity Token credentials from system properties or environment variables 
+- Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
+- Credentials delivered through the Amazon EC2 container service if "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
+- Instance profile credentials delivered through the Amazon EC2 metadata service
+
 
 For targeting available next options:
 - `settings.targeting.truncate-attr-chars` - set the max length for names of targeting keywords (0 means no truncation).

--- a/src/test/java/org/prebid/server/hooks/execution/HookStageExecutorTest.java
+++ b/src/test/java/org/prebid/server/hooks/execution/HookStageExecutorTest.java
@@ -654,7 +654,7 @@ public class HookStageExecutorTest extends VertxTest {
                                             assertThat(hookOutcome.getStatus())
                                                     .isEqualTo(ExecutionStatus.execution_failure);
                                             assertThat(hookOutcome.getMessage()).isEqualTo("Failed after a while");
-                                            assertThat(hookOutcome.getExecutionTime()).isBetween(50L, 70L);
+                                            assertThat(hookOutcome.getExecutionTime()).isBetween(50L, 80L);
                                         });
 
                                         assertThat(group0Hooks.get(1)).satisfies(hookOutcome -> {


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Currently, the S3 integration for prebid-server-java requires AWS credentials to be explicitly defined in the config yaml file. The SettingsConfiguration class in PBS Java uses AwsBasicCredentials to authenticate S3 requests, making credential storage in the YAML file mandatory. However, this is not good practice for credential management. This PR adds another credentials provider that will look for credentials in this order:
  * Java System Properties
  * Environment Variables
  * Web Identity Token
  * AWS credentials file (~/.aws/credentials)
  * ECS container credentials
  * EC2 instance profile

### 🧠 Rationale behind the change
So that S3 integration can be used with the recommended practices for AWS credential management.

### 🧪 Test plan
* If accessKeyId and secretAccessKey are provided in the config yaml file, then verify that they are still used. 
* If they are not provided in the config yaml file, then verify that AWS credentials are found in the order described above.

### 🏎 Quality check
- [ x ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ no ] Are there any breaking changes in your code?
- [ yes ] Does your test coverage exceed 90%? 
- [ no ] Are there any erroneous console logs, debuggers or leftover code in your changes?

