### PR TITLE
51Degrees module: update `devicetype` mapping.

### DIFF
--- a/extra/modules/fiftyone-devicedetection/src/main/java/org/prebid/server/hooks/modules/fiftyone/devicedetection/v1/core/OrtbDeviceType.java
+++ b/extra/modules/fiftyone-devicedetection/src/main/java/org/prebid/server/hooks/modules/fiftyone/devicedetection/v1/core/OrtbDeviceType.java
@@ -27,7 +27,7 @@ public enum OrtbDeviceType {
             Map.entry("Mobile", OrtbDeviceType.MOBILE_TABLET),
             Map.entry("Router", OrtbDeviceType.CONNECTED_DEVICE),
             Map.entry("SmallScreen", OrtbDeviceType.CONNECTED_DEVICE),
-            Map.entry("SmartPhone", OrtbDeviceType.MOBILE_TABLET),
+            Map.entry("SmartPhone", OrtbDeviceType.PHONE),
             Map.entry("SmartSpeaker", OrtbDeviceType.CONNECTED_DEVICE),
             Map.entry("SmartWatch", OrtbDeviceType.CONNECTED_DEVICE),
             Map.entry("Tablet", OrtbDeviceType.TABLET),


### PR DESCRIPTION
Mapping phones to a more specific devicetype in the AdCOM Taxonomy

### 🔧 Type of changes
- [x] bugfix

### ✨ What's the context?
Phones were mapped to overly generic devicetype=1 (Mobile General), remapped to devicetype=4 (Phone)

### 🧠 Rationale behind the change
This is more precise and specific, bidders tend to value this more specific signal higher. 