### PR TITLE
Add ttd/thetradedesk alias

### DIFF
--- a/src/main/resources/bidder-config/thetradedesk.yaml
+++ b/src/main/resources/bidder-config/thetradedesk.yaml
@@ -1,6 +1,8 @@
 adapters:
   thetradedesk:
     endpoint: https://direct.adsrvr.org/bid/bidder/{{SupplyId}}
+    aliases:
+      ttd: ~
     meta-info:
       maintainer-email: Prebid-Maintainers@thetradedesk.com
       app-media-types:


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Allow integration to be done to The Trade Desk using either thetradedesk or ttd bidder code through an alias.

### 🧠 Rationale behind the change
Prebid.js uses ttd bidder code while PBS uses thetradedesk. Allow both to have a seamless experience.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Already tested by Magnite locally.

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
