### PR TITLE
Bump spring.boot.version to 3.4.5

### DIFF
--- a/extra/pom.xml
+++ b/extra/pom.xml
@@ -33,7 +33,7 @@
         <checkstyle.version>10.17.0</checkstyle.version>
 
         <!-- Project production dependency versions -->
-        <spring.boot.version>3.4.4</spring.boot.version>
+        <spring.boot.version>3.4.5</spring.boot.version>
         <vertx.version>4.5.14</vertx.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <commons.collections.version>4.4</commons.collections.version>


### PR DESCRIPTION
Patch for CVE-2025-22235.

### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [X] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Bump spring.boot.version from 3.4.4 to 3.4.5 for [CVE-2025-22235](https://nvd.nist.gov/vuln/detail/CVE-2025-22235).

### 🧠 Rationale behind the change
Remove high CVE vulnerability.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Unit tests and functional tests pass after this change. 

### 🏎 Quality check
- [-] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [N] Are there any breaking changes in your code?
- [-] Does your test coverage exceed 90%?
- [N] Are there any erroneous console logs, debuggers or leftover code in your changes?
