### PR TITLE
Housekeeping: Move DB drivers to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,10 +163,12 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [X] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
mysql-connector-j and postgresql drivers moved to test scope since they're not used in core.

### 🧠 Rationale behind the change
Investigation into CVE-2025-30706 for mysql-connector-j showed both drivers are used in test and can be removed from the release build.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Local build, unit and functional tests complete successfully.

### 🏎 Quality check
- [Y] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [N] Are there any breaking changes in your code?
- [Y] Does your test coverage exceed 90%?
- [N] Are there any erroneous console logs, debuggers or leftover code in your changes?
