### PR TITLE
Core: Add toggle to enable round-robin inet address selection of the ip address to use 

### DIFF
--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -14,6 +14,7 @@ This section can be extended against standard [Spring configuration](https://doc
 This parameter exists to allow to change the location of the directory Vert.x will create because it will and there is no way to make it not.
 - `vertx.init-timeout-ms` - time to wait for asynchronous initialization steps completion before considering them stuck. When exceeded - exception is thrown and Prebid Server stops.
 - `vertx.enable-per-client-endpoint-metrics` - enables HTTP client metrics per destination endpoint (`host:port`)
+- `vertx.round-robin-inet-address` - enables round-robin inet address selection of the ip address to use
 
 ## Server
 - `server.max-headers-size` - set the maximum length of all headers.

--- a/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
@@ -35,7 +35,7 @@ public class VertxConfiguration {
             metricsOptions.addMonitoredHttpClientEndpoint(new Match().setValue(".*").setType(MatchType.REGEX));
         }
 
-        AddressResolverOptions addressResolverOptions = new AddressResolverOptions();
+        final AddressResolverOptions addressResolverOptions = new AddressResolverOptions();
         addressResolverOptions.setRoundRobinInetAddress(roundRobinInetAddress);
 
         final VertxOptions vertxOptions = new VertxOptions()

--- a/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/VertxConfiguration.java
@@ -2,6 +2,7 @@ package org.prebid.server.spring.config;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.file.FileSystem;
 import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
 import io.vertx.ext.dropwizard.Match;
@@ -23,7 +24,9 @@ public class VertxConfiguration {
     @Bean
     Vertx vertx(@Value("${vertx.worker-pool-size}") int workerPoolSize,
                 @Value("${vertx.enable-per-client-endpoint-metrics}") boolean enablePerClientEndpointMetrics,
-                @Value("${metrics.jmx.enabled}") boolean jmxEnabled) {
+                @Value("${metrics.jmx.enabled}") boolean jmxEnabled,
+                @Value("${vertx.round-robin-inet-address}") boolean roundRobinInetAddress) {
+
         final DropwizardMetricsOptions metricsOptions = new DropwizardMetricsOptions()
                 .setEnabled(true)
                 .setJmxEnabled(jmxEnabled)
@@ -32,10 +35,14 @@ public class VertxConfiguration {
             metricsOptions.addMonitoredHttpClientEndpoint(new Match().setValue(".*").setType(MatchType.REGEX));
         }
 
+        AddressResolverOptions addressResolverOptions = new AddressResolverOptions();
+        addressResolverOptions.setRoundRobinInetAddress(roundRobinInetAddress);
+
         final VertxOptions vertxOptions = new VertxOptions()
                 .setPreferNativeTransport(true)
                 .setWorkerPoolSize(workerPoolSize)
-                .setMetricsOptions(metricsOptions);
+                .setMetricsOptions(metricsOptions)
+                .setAddressResolverOptions(addressResolverOptions);
 
         final Vertx vertx = Vertx.vertx(vertxOptions);
         logger.info("Native transport enabled: {}", vertx.isNativeTransportEnabled());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ vertx:
   uploads-dir: file-uploads
   init-timeout-ms: 5000
   enable-per-client-endpoint-metrics: false
+  round-robin-inet-address: false
 server:
   max-initial-line-length: 8092
   max-headers-size: 16384


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [x] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Added new property to enable round-robin inet address selection of the ip address to use.

### 🧠 Rationale behind the change
This change will add new toggle to control ip address selection to not hit same ip and evenly distribute load.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
Doesn't need tests since its just vertx library feature toggle.

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
