### PR TITLE
Seedtag: Adds GPP macros on user-sync url

### DIFF
--- a/src/main/resources/bidder-config/seedtag.yaml
+++ b/src/main/resources/bidder-config/seedtag.yaml
@@ -12,6 +12,6 @@ adapters:
     usersync:
       cookie-family-name: seedtag
       iframe:
-        url: https://s.seedtag.com/cs/cookiesync/prebid?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&usp_consent={{us_privacy}}&redirect={{redirect_url}}
+        url: https://s.seedtag.com/cs/cookiesync/prebid?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&usp_consent={{us_privacy}}&gpp={{gpp}}&gpp_sid={{gpp_sid}}&redirect={{redirect_url}}
         support-cors: false
         uid-macro: '$UID'


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [x] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
We are supporting GPP regulation so this change allows us to propagate GPP signals when triggering our cookie sync

### 🧠 Rationale behind the change
Ditto
https://github.com/prebid/prebid-server/pull/4465

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
