### PR TITLE
Yieldlab Adapter: Forward ADomain to OpenRTB bid

### DIFF
--- a/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
@@ -464,6 +464,7 @@ public class YieldlabBidder implements Bidder<Void> {
         }
 
         final Format adsize = resolveAdSize(yieldlabBid.getAdSize());
+        final String advertiser = yieldlabBid.getAdvertiser();
         final Bid bid = Bid.builder()
                 .id(adSlotId)
                 .price(BigDecimal.valueOf(yieldlabBid.getPrice() / 100))
@@ -476,6 +477,7 @@ public class YieldlabBidder implements Bidder<Void> {
                         : makeBanner(bidRequest, extImp, yieldlabBid))
                 .w(adsize.getW())
                 .h(adsize.getH())
+                .adomain(advertiser != null ? Collections.singletonList(advertiser) : null)
                 .ext(resolveBidExt(yieldlabBid, errors))
                 .build();
 

--- a/src/test/java/org/prebid/server/bidder/yieldlab/YieldlabBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/yieldlab/YieldlabBidderTest.java
@@ -278,6 +278,7 @@ public class YieldlabBidderTest extends VertxTest {
                         .w(728)
                         .h(90)
                         .adm(adm)
+                        .adomain(singletonList("yieldlab"))
                         .build(),
                 BidType.banner, "EUR");
 

--- a/src/test/resources/org/prebid/server/it/openrtb2/yieldlab/test-auction-yieldlab-response.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/yieldlab/test-auction-yieldlab-response.json
@@ -13,6 +13,9 @@
           "w": 400,
           "h": 300,
           "adm": "",
+          "adomain": [
+            "yieldlab"
+          ],
           "ext": {
             "origbidcpm": 2.01,
             "origbidcur": "EUR",


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
What's the context for the changes?

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
