### PR TITLE
optable-targeting: update macros, fail early if tenant and origin are not configured

### DIFF
--- a/extra/modules/optable-targeting/sample-requests/data.json
+++ b/extra/modules/optable-targeting/sample-requests/data.json
@@ -46,7 +46,7 @@
     {
       "optable":
       {
-        "email": "fd911bd8cac2e603a80efafca2210b7a917c97410f0c29d9f2bfb99867e5a589"
+        "email": "5837d278eabede28e37b5766399ed0d1a4cdc36acee8d35710a255032f45beda"
       },
       "eids":
       [
@@ -75,16 +75,6 @@
           [
             {
               "id": "dd1b31e65f5e45548c11a0275ba3a8072c00e3a2a0493e8f5a8f54f8067e8b00",
-              "atype": 1
-            }
-          ]
-        },
-        {
-          "source": "id5-sync.com",
-          "uids":
-          [
-            {
-              "id": "ID5*dd1b31e65f5e45548c11a0275ba3a8072c00e3a2a0493e8f5a8f54f8067e8b00",
               "atype": 1
             }
           ]

--- a/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/config/OptableTargetingConfig.java
+++ b/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/config/OptableTargetingConfig.java
@@ -90,13 +90,15 @@ public class OptableTargetingConfig {
     OptableTargetingModule optableTargetingModule(ConfigResolver configResolver,
                                                   OptableTargeting optableTargeting,
                                                   UserFpdActivityMask userFpdActivityMask,
-                                                  JsonMerger jsonMerger) {
+                                                  JsonMerger jsonMerger,
+                                                  @Value("${logging.sampling-rate:0.01}") double logSamplingRate) {
 
         return new OptableTargetingModule(List.of(
                 new OptableTargetingProcessedAuctionRequestHook(
                         configResolver,
                         optableTargeting,
-                        userFpdActivityMask),
+                        userFpdActivityMask,
+                        logSamplingRate),
                 new OptableTargetingAuctionResponseHook(
                         configResolver,
                         ObjectMapperProvider.mapper(),

--- a/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/v1/OptableTargetingProcessedAuctionRequestHook.java
+++ b/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/v1/OptableTargetingProcessedAuctionRequestHook.java
@@ -4,6 +4,7 @@ import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.User;
 import io.vertx.core.Future;
+import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.activity.Activity;
 import org.prebid.server.activity.ComponentType;
 import org.prebid.server.activity.infrastructure.ActivityInfrastructure;
@@ -32,24 +33,32 @@ import org.prebid.server.hooks.v1.PayloadUpdate;
 import org.prebid.server.hooks.v1.auction.AuctionInvocationContext;
 import org.prebid.server.hooks.v1.auction.AuctionRequestPayload;
 import org.prebid.server.hooks.v1.auction.ProcessedAuctionRequestHook;
+import org.prebid.server.log.ConditionalLogger;
+import org.prebid.server.log.LoggerFactory;
 
 import java.util.Objects;
 
 public class OptableTargetingProcessedAuctionRequestHook implements ProcessedAuctionRequestHook {
+
+    private static final ConditionalLogger conditionalLogger = new ConditionalLogger(
+            LoggerFactory.getLogger(OptableTargetingProcessedAuctionRequestHook.class));
 
     public static final String CODE = "optable-targeting-processed-auction-request-hook";
 
     private final ConfigResolver configResolver;
     private final OptableTargeting optableTargeting;
     private final UserFpdActivityMask userFpdActivityMask;
+    private final double logSamplingRate;
 
     public OptableTargetingProcessedAuctionRequestHook(ConfigResolver configResolver,
                                                        OptableTargeting optableTargeting,
-                                                       UserFpdActivityMask userFpdActivityMask) {
+                                                       UserFpdActivityMask userFpdActivityMask,
+                                                       double logSamplingRate) {
 
         this.configResolver = Objects.requireNonNull(configResolver);
         this.optableTargeting = Objects.requireNonNull(optableTargeting);
         this.userFpdActivityMask = Objects.requireNonNull(userFpdActivityMask);
+        this.logSamplingRate = logSamplingRate;
     }
 
     @Override
@@ -58,6 +67,16 @@ public class OptableTargetingProcessedAuctionRequestHook implements ProcessedAuc
 
         final OptableTargetingProperties properties = configResolver.resolve(invocationContext.accountConfig());
         final ModuleContext moduleContext = new ModuleContext();
+        final long callTargetingAPITimestamp = System.currentTimeMillis();
+
+        if (!validateTargetingProperties(properties)) {
+            conditionalLogger.error(
+                    "Account not properly configured: tenant and/or origin is missing.", logSamplingRate);
+
+            moduleContext.setOptableTargetingExecutionTime(System.currentTimeMillis() - callTargetingAPITimestamp);
+            moduleContext.setEnrichRequestStatus(EnrichmentStatus.failure());
+            return update(BidRequestCleaner.instance(), moduleContext);
+        }
 
         final BidRequest bidRequest = applyActivityRestrictions(auctionRequestPayload.bidRequest(), invocationContext);
 
@@ -66,7 +85,6 @@ public class OptableTargetingProcessedAuctionRequestHook implements ProcessedAuc
                 invocationContext.auctionContext(),
                 properties.getTimeout());
 
-        final long callTargetingAPITimestamp = System.currentTimeMillis();
         return optableTargeting.getTargeting(properties, bidRequest, attributes, timeout)
                 .compose(targetingResult -> {
                     moduleContext.setOptableTargetingExecutionTime(
@@ -79,6 +97,10 @@ public class OptableTargetingProcessedAuctionRequestHook implements ProcessedAuc
                     moduleContext.setEnrichRequestStatus(EnrichmentStatus.failure());
                     return update(BidRequestCleaner.instance(), moduleContext);
                 });
+    }
+
+    private boolean validateTargetingProperties(OptableTargetingProperties properties) {
+        return !StringUtils.isEmpty(properties.getOrigin()) && !StringUtils.isEmpty(properties.getTenant());
     }
 
     private BidRequest applyActivityRestrictions(BidRequest bidRequest,

--- a/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/v1/OptableTargetingProcessedAuctionRequestHook.java
+++ b/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/v1/OptableTargetingProcessedAuctionRequestHook.java
@@ -69,7 +69,7 @@ public class OptableTargetingProcessedAuctionRequestHook implements ProcessedAuc
         final ModuleContext moduleContext = new ModuleContext();
         final long callTargetingAPITimestamp = System.currentTimeMillis();
 
-        if (!validateTargetingProperties(properties)) {
+        if (!isTargetingPropertiesValid(properties)) {
             conditionalLogger.error(
                     "Account not properly configured: tenant and/or origin is missing.", logSamplingRate);
 
@@ -99,7 +99,7 @@ public class OptableTargetingProcessedAuctionRequestHook implements ProcessedAuc
                 });
     }
 
-    private boolean validateTargetingProperties(OptableTargetingProperties properties) {
+    private boolean isTargetingPropertiesValid(OptableTargetingProperties properties) {
         return !StringUtils.isEmpty(properties.getOrigin()) && !StringUtils.isEmpty(properties.getTenant());
     }
 

--- a/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/v1/net/APIClientImpl.java
+++ b/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/v1/net/APIClientImpl.java
@@ -27,8 +27,8 @@ public class APIClientImpl implements APIClient {
     private static final Logger logger = LoggerFactory.getLogger(APIClientImpl.class);
     private static final ConditionalLogger conditionalLogger = new ConditionalLogger(logger);
 
-    private static final String TENANT = "{TENANT}";
-    private static final String ORIGIN = "{ORIGIN}";
+    private static final String TENANT = "{{TENANT}}";
+    private static final String ORIGIN = "{{ORIGIN}}";
 
     private final String endpoint;
     private final HttpClient httpClient;

--- a/extra/modules/optable-targeting/src/test/java/org/prebid/server/hooks/modules/optable/targeting/v1/BaseOptableTest.java
+++ b/extra/modules/optable-targeting/src/test/java/org/prebid/server/hooks/modules/optable/targeting/v1/BaseOptableTest.java
@@ -245,6 +245,6 @@ public abstract class BaseOptableTest {
     }
 
     protected Query givenQuery() {
-        return Query.of("que", "ry");
+        return Query.of("?que", "ry");
     }
 }

--- a/extra/modules/optable-targeting/src/test/java/org/prebid/server/hooks/modules/optable/targeting/v1/BaseOptableTest.java
+++ b/extra/modules/optable-targeting/src/test/java/org/prebid/server/hooks/modules/optable/targeting/v1/BaseOptableTest.java
@@ -224,17 +224,24 @@ public abstract class BaseOptableTest {
     }
 
     protected OptableTargetingProperties givenOptableTargetingProperties(boolean enableCache) {
-        return givenOptableTargetingProperties("key", enableCache);
+        return givenOptableTargetingProperties("key", "accountId", "origin", enableCache);
     }
 
     protected OptableTargetingProperties givenOptableTargetingProperties(String key, boolean enableCache) {
+        return givenOptableTargetingProperties(key, "accountId", "origin", enableCache);
+    }
+
+    protected OptableTargetingProperties givenOptableTargetingProperties(String key,
+                                                                         String tenant,
+                                                                         String origin,
+                                                                         boolean enableCache) {
         final CacheProperties cacheProperties = new CacheProperties();
         cacheProperties.setEnabled(enableCache);
 
         final OptableTargetingProperties optableTargetingProperties = new OptableTargetingProperties();
         optableTargetingProperties.setApiEndpoint("endpoint");
-        optableTargetingProperties.setTenant("accountId");
-        optableTargetingProperties.setOrigin("origin");
+        optableTargetingProperties.setTenant(tenant);
+        optableTargetingProperties.setOrigin(origin);
         optableTargetingProperties.setApiKey(key);
         optableTargetingProperties.setPpidMapping(Map.of("c", "id"));
         optableTargetingProperties.setAdserverTargeting(true);

--- a/sample/configs/prebid-config-with-optable.yaml
+++ b/sample/configs/prebid-config-with-optable.yaml
@@ -50,4 +50,4 @@ hooks:
     enabled: true
   modules:
     optable-targeting:
-      api-endpoint: https://na.edge.optable.co/v2/targeting?t={TENANT}&o={ORIGIN}
+      api-endpoint: https://na.edge.optable.co/v2/targeting?t={{TENANT}}&o={{ORIGIN}}


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bugfix

### ✨ What's the context?
Macros in the endpoint URL should be enclosed into double curly bracket '{{}}', not single '{}'.  Also if tenant or origin are not provided in the account configuration the hook fails early with a 1% error logging rate. 

### 🧠 Rationale behind the change
A requirement to macros to potentially prevent syntax collisions.  Also if account is misconfigured to not include tenant or origin params - these are mandatory - the hook fails early with appropriate error message with 1% error logging rate. 

### 🧪 Test plan
Unit tests + ran manual integration testing. 

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code? - Yes it will require a change of host configuration slightly - they will have to use {{}} to enclose the macros - need to update the docs