### PR TITLE
optable-targeting: Fix query string construction when IDs are missing.

### DIFF
--- a/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/model/Query.java
+++ b/extra/modules/optable-targeting/src/main/java/org/prebid/server/hooks/modules/optable/targeting/model/Query.java
@@ -1,7 +1,6 @@
 package org.prebid.server.hooks.modules.optable.targeting.model;
 
 import lombok.Value;
-import org.apache.commons.lang3.StringUtils;
 
 @Value(staticConstructor = "of")
 public class Query {
@@ -11,10 +10,6 @@ public class Query {
     String attributes;
 
     public String toQueryString() {
-        if (StringUtils.isEmpty(ids) && !StringUtils.isEmpty(attributes)) {
-            return attributes.substring(1);
-        }
-
         return ids + attributes;
     }
 }

--- a/extra/modules/optable-targeting/src/test/java/org/prebid/server/hooks/modules/optable/targeting/v1/core/QueryBuilderTest.java
+++ b/extra/modules/optable-targeting/src/test/java/org/prebid/server/hooks/modules/optable/targeting/v1/core/QueryBuilderTest.java
@@ -39,6 +39,8 @@ public class QueryBuilderTest {
         // then
         assertThat(query.getIds()).isEqualTo("&id=e%3Aemail&id=p%3A123");
         assertThat(query.getAttributes()).isEqualTo("&gdpr_consent=tcf&gdpr=1&timeout=100ms");
+        assertThat(query.toQueryString())
+                .isEqualTo("&id=e%3Aemail&id=p%3A123&gdpr_consent=tcf&gdpr=1&timeout=100ms");
     }
 
     @Test
@@ -94,7 +96,7 @@ public class QueryBuilderTest {
 
         // then
         assertThat(query).isNotNull();
-        assertThat(query.toQueryString()).isEqualTo("gdpr=0");
+        assertThat(query.toQueryString()).isEqualTo("&gdpr=0");
     }
 
     @Test


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bugfix

### ✨ What's the context?
When there was no input IDs extracted from the incoming request to be sent to Optable Targeting Endpoint - the query string appended to the main endpoint (already containing &t=&o= parameters)  would be formed without a leading `&` essentially leading to query strings like `&t=tenant&origin=origingdpr=0` instead of `&t=tenant=tenant&origin=origin&gdpr=0` - that lead to Targeting API requests failing with a 404.  The test was there, but the test itself was incorrect, thus the bug was not caught :(  The code and test are fixed now.  

### 🧠 Rationale behind the change
To eliminate the majority of Targeting API calls resulting in 404s in production

### 🧪 Test plan
How do you know the changes are safe to ship to production? 
- Unit Tests
- Manual Integration Tests

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?  **Should be**
- [x] Are there any breaking changes in your code? **No breaking changes**
- [x] Does your test coverage exceed 90%? **Should be**
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?  **None**
