### PR TITLE
add activity metric to prometheus-labels.yaml

### DIFF
--- a/src/main/resources/metrics-config/prometheus-labels.yaml
+++ b/src/main/resources/metrics-config/prometheus-labels.yaml
@@ -202,3 +202,9 @@ mappers:
     labels:
       adapter: ${0}
       action: ${1}
+  - match: adapter.*.activity.*.*.count
+    name: adapter.activity
+    labels:
+      adapter: ${0}
+      activity: ${1}
+      action: ${2}


### PR DESCRIPTION
A new metric was added, but the prometheus labels were missing

### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?

A new metric was added ( activity ) without adding a prometheus match rule

### 🧠 Rationale behind the change

Prometheus labels work as expected

### 🧪 Test plan

We run it in production already

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code? - there are, but it's broken before, so meh.
- [x] Does your test coverage exceed 90%?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
