### PR TITLE
Smartadserver: Add second endpoint for programmatic guaranteed

### DIFF
--- a/src/main/java/org/prebid/server/bidder/smartadserver/SmartadserverBidder.java
+++ b/src/main/java/org/prebid/server/bidder/smartadserver/SmartadserverBidder.java
@@ -62,9 +62,7 @@ public class SmartadserverBidder implements Bidder<BidRequest> {
         for (Imp imp : request.getImp()) {
             try {
                 final ExtImpSmartadserver extImp = parseImpExt(imp);
-                if (!isProgrammaticGuaranteed && extImp.isProgrammaticGuaranteed()) {
-                    isProgrammaticGuaranteed = true;
-                }
+                isProgrammaticGuaranteed |= extImp.isProgrammaticGuaranteed();
                 impToExtImpMap.put(imp, extImp);
             } catch (PreBidException e) {
                 errors.add(BidderError.badInput(e.getMessage()));
@@ -122,8 +120,9 @@ public class SmartadserverBidder implements Bidder<BidRequest> {
     }
 
     private String makeUrl(boolean isProgrammaticGuaranteed) {
+        final String url = isProgrammaticGuaranteed ? secondaryEndpointUrl : endpointUrl;
         try {
-            final URI uri = new URI(isProgrammaticGuaranteed ? secondaryEndpointUrl : endpointUrl);
+            final URI uri = new URI(url);
             final String path = isProgrammaticGuaranteed ? "/ortb" : "/api/bid";
             final URIBuilder uriBuilder = new URIBuilder(uri)
                     .setPath(StringUtils.removeEnd(uri.getPath(), "/") + path);
@@ -134,7 +133,7 @@ public class SmartadserverBidder implements Bidder<BidRequest> {
 
             return uriBuilder.toString();
         } catch (URISyntaxException e) {
-            throw new PreBidException("Malformed URL: %s.".formatted(secondaryEndpointUrl));
+            throw new PreBidException("Malformed URL: %s.".formatted(url));
         }
     }
 

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/smartadserver/ExtImpSmartadserver.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/smartadserver/ExtImpSmartadserver.java
@@ -3,9 +3,6 @@ package org.prebid.server.proto.openrtb.ext.request.smartadserver;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Value;
 
-/**
- * Defines the contract for bidrequest.imp[i].ext.smartadserver
- */
 @Value(staticConstructor = "of")
 public class ExtImpSmartadserver {
 
@@ -20,4 +17,7 @@ public class ExtImpSmartadserver {
 
     @JsonProperty("networkId")
     Integer networkId;
+
+    @JsonProperty(value = "programmaticGuaranteed", access = JsonProperty.Access.WRITE_ONLY)
+    boolean programmaticGuaranteed;
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/SmartadserverConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/SmartadserverConfiguration.java
@@ -24,14 +24,6 @@ public class SmartadserverConfiguration {
 
     private static final String BIDDER_NAME = "smartadserver";
 
-    @Data
-    @EqualsAndHashCode(callSuper = true)
-    @NoArgsConstructor
-    private static class SmartadserverConfigurationProperties extends BidderConfigurationProperties {
-
-        private String secondaryEndpoint;
-    }
-
     @Bean("smartadserverConfigurationProperties")
     @ConfigurationProperties("adapters.smartadserver")
     SmartadserverConfigurationProperties configurationProperties() {
@@ -49,5 +41,13 @@ public class SmartadserverConfiguration {
                 .bidderCreator(config -> new SmartadserverBidder(
                         config.getEndpoint(), config.getSecondaryEndpoint(), mapper))
                 .assemble();
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @NoArgsConstructor
+    private static class SmartadserverConfigurationProperties extends BidderConfigurationProperties {
+
+        private String secondaryEndpoint;
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/SmartadserverConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/SmartadserverConfiguration.java
@@ -1,5 +1,8 @@
 package org.prebid.server.spring.config.bidder;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.prebid.server.bidder.BidderDeps;
 import org.prebid.server.bidder.smartadserver.SmartadserverBidder;
 import org.prebid.server.json.JacksonMapper;
@@ -21,21 +24,30 @@ public class SmartadserverConfiguration {
 
     private static final String BIDDER_NAME = "smartadserver";
 
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @NoArgsConstructor
+    private static class SmartadserverConfigurationProperties extends BidderConfigurationProperties {
+
+        private String secondaryEndpoint;
+    }
+
     @Bean("smartadserverConfigurationProperties")
     @ConfigurationProperties("adapters.smartadserver")
-    BidderConfigurationProperties configurationProperties() {
-        return new BidderConfigurationProperties();
+    SmartadserverConfigurationProperties configurationProperties() {
+        return new SmartadserverConfigurationProperties();
     }
 
     @Bean
-    BidderDeps smartadserverBidderDeps(BidderConfigurationProperties smartadserverConfigurationProperties,
+    BidderDeps smartadserverBidderDeps(SmartadserverConfigurationProperties smartadserverConfigurationProperties,
                                        @NotBlank @Value("${external-url}") String externalUrl,
                                        JacksonMapper mapper) {
 
-        return BidderDepsAssembler.forBidder(BIDDER_NAME)
+        return BidderDepsAssembler.<SmartadserverConfigurationProperties>forBidder(BIDDER_NAME)
                 .withConfig(smartadserverConfigurationProperties)
                 .usersyncerCreator(UsersyncerCreator.create(externalUrl))
-                .bidderCreator(config -> new SmartadserverBidder(config.getEndpoint(), mapper))
+                .bidderCreator(config -> new SmartadserverBidder(
+                        config.getEndpoint(), config.getSecondaryEndpoint(), mapper))
                 .assemble();
     }
 }

--- a/src/main/resources/bidder-config/smartadserver.yaml
+++ b/src/main/resources/bidder-config/smartadserver.yaml
@@ -1,6 +1,7 @@
 adapters:
   smartadserver:
     endpoint: https://ssb-global.smartadserver.com
+    secondary-endpoint: https://prebid-global.smartadserver.com
     endpoint-compression: gzip
     aliases:
       equativ:

--- a/src/test/java/org/prebid/server/bidder/smartadserver/SmartadserverBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/smartadserver/SmartadserverBidderTest.java
@@ -1,6 +1,7 @@
 package org.prebid.server.bidder.smartadserver;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
@@ -37,12 +38,20 @@ import static org.prebid.server.proto.openrtb.ext.response.BidType.xNative;
 public class SmartadserverBidderTest extends VertxTest {
 
     private static final String ENDPOINT_URL = "https://test.endpoint.com/path?testParam=testVal";
+    private static final String SECONDARY_URL = "https://test.endpoint2.com/path?testParam=testVal";
 
-    private final SmartadserverBidder target = new SmartadserverBidder(ENDPOINT_URL, jacksonMapper);
+    private final SmartadserverBidder target = new SmartadserverBidder(ENDPOINT_URL, SECONDARY_URL, jacksonMapper);
 
     @Test
     public void creationShouldFailOnInvalidEndpointUrl() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new SmartadserverBidder("invalid_url", jacksonMapper));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new SmartadserverBidder("invalid_url", SECONDARY_URL, jacksonMapper));
+    }
+
+    @Test
+    public void creationShouldFailOnInvalidSecondaryEndpointUrl() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new SmartadserverBidder(ENDPOINT_URL, "invalid_url", jacksonMapper));
     }
 
     @Test
@@ -64,10 +73,50 @@ public class SmartadserverBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldCreateCorrectURL() {
+    public void makeHttpRequestsShouldCreateCorrectPrimaryURLWhenProgrammaticGuaranteedIsAbsent() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(givenImp(identity())))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1);
+        assertThat(result.getValue().getFirst().getUri())
+                .isEqualTo("https://test.endpoint.com/path/api/bid?testParam=testVal&callerId=5");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldCreateCorrectSecondaryURLWhenProgrammaticGuaranteedIsTrue() {
+        // given
+        final ObjectNode givenImpExt = mapper.createObjectNode()
+                .set("bidder", mapper.createObjectNode().put("programmaticGuaranteed", true));
+
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(givenImp(imp -> imp.ext(givenImpExt))))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1);
+        assertThat(result.getValue().getFirst().getUri())
+                .isEqualTo("https://test.endpoint2.com/path/ortb?testParam=testVal");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldCreateCorrectPrimaryURLWhenProgrammaticGuaranteedIsFalse() {
+        // given
+        final ObjectNode givenImpExt = mapper.createObjectNode()
+                .set("bidder", mapper.createObjectNode().put("programmaticGuaranteed", false));
+
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(givenImp(imp -> imp.ext(givenImpExt))))
                 .build();
 
         // when
@@ -150,6 +199,56 @@ public class SmartadserverBidderTest extends VertxTest {
                 .flatExtracting(BidRequest::getImp)
                 .extracting(Imp::getId)
                 .containsExactly("123");
+    }
+
+    @Test
+    public void makeHttpRequestsShouldModifyImpWhenProgrammaticGuaranteedIsTrueAtLeastInOneValidImp() {
+        // given
+        final ObjectNode givenImpExt1 = mapper.createObjectNode()
+                .set("bidder", mapper.createObjectNode()
+                        .put("programmaticGuaranteed", false)
+                        .put("networkId", 1)
+                        .put("siteId", 2)
+                        .put("formatId", 3)
+                        .put("pageId", 4));
+        final ObjectNode givenImpExt2 = mapper.createObjectNode()
+                .set("bidder", mapper.createObjectNode()
+                        .put("programmaticGuaranteed", true)
+                        .put("networkId", 5)
+                        .put("siteId", 6)
+                        .put("formatId", 7)
+                        .put("pageId", 8));
+
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(List.of(
+                        givenImp(imp -> imp.id("impId1").ext(givenImpExt1)),
+                        givenImp(imp -> imp.id("impId2").ext(givenImpExt2))))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        final ObjectNode expectedImpExt1 = mapper.createObjectNode()
+                .set("smartadserver", mapper.createObjectNode()
+                        .put("networkId", 1)
+                        .put("siteId", 2)
+                        .put("formatId", 3)
+                        .put("pageId", 4));
+        final ObjectNode expectedImpExt2 = mapper.createObjectNode()
+                .set("smartadserver", mapper.createObjectNode()
+                        .put("networkId", 5)
+                        .put("siteId", 6)
+                        .put("formatId", 7)
+                        .put("pageId", 8));
+
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1);
+        assertThat(result.getValue())
+                .extracting(HttpRequest::getPayload)
+                .flatExtracting(BidRequest::getImp)
+                .extracting(Imp::getExt)
+                .containsExactly(expectedImpExt1, expectedImpExt2);
     }
 
     @Test
@@ -299,10 +398,12 @@ public class SmartadserverBidderTest extends VertxTest {
 
     private static Imp givenImp(Function<Imp.ImpBuilder, Imp.ImpBuilder> impCustomizer) {
         return impCustomizer.apply(Imp.builder()
-                        .id("123"))
-                .banner(Banner.builder().build())
-                .video(Video.builder().build())
-                .ext(mapper.valueToTree(ExtPrebid.of(null, ExtImpSmartadserver.of(1, 2, 3, 4))))
+                        .id("123")
+                        .banner(Banner.builder().build())
+                        .video(Video.builder().build())
+                        .ext(mapper.valueToTree(ExtPrebid.of(
+                                null,
+                                ExtImpSmartadserver.of(1, 2, 3, 4, false)))))
                 .build();
     }
 

--- a/src/test/java/org/prebid/server/it/SmartadserverTest.java
+++ b/src/test/java/org/prebid/server/it/SmartadserverTest.java
@@ -18,7 +18,7 @@ public class SmartadserverTest extends IntegrationTest {
     @Test
     public void openrtb2AuctionShouldRespondWithBidsFromSmartadserver() throws IOException, JSONException {
         // given
-        WIRE_MOCK_RULE.stubFor(post(urlPathEqualTo("/smartadserver-exchange/api/bid"))
+        WIRE_MOCK_RULE.stubFor(post(urlPathEqualTo("/smartadserver-secondary-exchange/ortb"))
                 .withRequestBody(equalToJson(jsonFrom("openrtb2/smartadserver/test-smartadserver-bid-request.json")))
                 .willReturn(aResponse()
                         .withBody(jsonFrom("openrtb2/smartadserver/test-smartadserver-bid-response.json"))));

--- a/src/test/resources/org/prebid/server/it/openrtb2/smartadserver/test-auction-smartadserver-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/smartadserver/test-auction-smartadserver-request.json
@@ -14,7 +14,8 @@
               "siteId": 1,
               "pageId": 2,
               "formatId": 3,
-              "networkId": 73
+              "networkId": 73,
+              "programmaticGuaranteed": true
             }
           }
         }

--- a/src/test/resources/org/prebid/server/it/openrtb2/smartadserver/test-smartadserver-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/smartadserver/test-smartadserver-bid-request.json
@@ -10,7 +10,7 @@
       },
       "ext": {
         "tid": "${json-unit.any-string}",
-        "bidder": {
+        "smartadserver": {
           "siteId": 1,
           "pageId": 2,
           "formatId": 3,

--- a/src/test/resources/org/prebid/server/it/test-application.properties
+++ b/src/test/resources/org/prebid/server/it/test-application.properties
@@ -491,6 +491,7 @@ adapters.smaato.enabled=true
 adapters.smaato.endpoint=http://localhost:8090/smaato-exchange
 adapters.smartadserver.enabled=true
 adapters.smartadserver.endpoint=http://localhost:8090/smartadserver-exchange
+adapters.smartadserver.secondary-endpoint=http://localhost:8090/smartadserver-secondary-exchange
 adapters.smartadserver.aliases.equativ.enabled=true
 adapters.smartrtb.enabled=true
 adapters.smartrtb.endpoint=http://localhost:8090/smartrtb-exchange/


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
What's the context for the changes?

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
