### PR TITLE
OpenX Adapter: Set buyer exts fields in `bid.ext.prebid.meta`

### DIFF
--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -362,10 +362,9 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
         final var modifiedExtBidPrebid = ExtBidPrebid.builder().meta(updatedMeta).build();
 
-        final var updatedExt = ext.deepCopy();
-        updatedExt.set(PREBID_EXT, mapper.mapper().valueToTree(modifiedExtBidPrebid));
+        ext.set(PREBID_EXT, mapper.mapper().valueToTree(modifiedExtBidPrebid));
 
-        return updatedExt;
+        return ext;
     }
 
     private OpenxBidExt parseOpenxBidExt(ObjectNode ext) {

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -340,12 +340,12 @@ public class OpenxBidder implements Bidder<BidRequest> {
     }
 
     private ObjectNode updateBidMeta(Bid bid) {
-        final var ext = bid.getExt();
+        final ObjectNode ext = bid.getExt();
         if (ext == null) {
             return null;
         }
 
-        final var openxBidExt = parseOpenxBidExt(ext);
+        final OpenxBidExt openxBidExt = parseOpenxBidExt(ext);
         final int buyerId = parseStringToInt(openxBidExt.getBuyerId());
         final int dspId = parseStringToInt(openxBidExt.getDspId());
         final int brandId = parseStringToInt(openxBidExt.getBrandId());
@@ -354,13 +354,13 @@ public class OpenxBidder implements Bidder<BidRequest> {
             return ext;
         }
 
-        final var updatedMeta = ExtBidPrebidMeta.builder()
+        final ExtBidPrebidMeta updatedMeta = ExtBidPrebidMeta.builder()
                 .networkId(dspId)
                 .advertiserId(buyerId)
                 .brandId(brandId)
                 .build();
 
-        final var modifiedExtBidPrebid = ExtBidPrebid.builder().meta(updatedMeta).build();
+        final ExtBidPrebid modifiedExtBidPrebid = ExtBidPrebid.builder().meta(updatedMeta).build();
 
         ext.set(PREBID_EXT, mapper.mapper().valueToTree(modifiedExtBidPrebid));
 

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -62,9 +62,6 @@ public class OpenxBidder implements Bidder<BidRequest> {
     private static final TypeReference<ExtPrebid<ExtImpPrebid, ExtImpOpenx>> OPENX_EXT_TYPE_REFERENCE =
             new TypeReference<>() {
             };
-    private static final TypeReference<ExtPrebid<ExtBidPrebid, ObjectNode>> EXT_PREBID_TYPE_REFERENCE =
-            new TypeReference<>() {
-            };
 
     private final String endpointUrl;
     private final JacksonMapper mapper;
@@ -357,16 +354,13 @@ public class OpenxBidder implements Bidder<BidRequest> {
             return ext;
         }
 
-        final var extPrebid = getExtPrebid(ext, bid.getId());
         final var updatedMeta = ExtBidPrebidMeta.builder()
                 .networkId(dspId)
                 .advertiserId(buyerId)
                 .brandId(brandId)
                 .build();
 
-        final var modifiedExtBidPrebid = Optional.ofNullable(extPrebid.getPrebid())
-                .map(p -> p.toBuilder().meta(updatedMeta).build())
-                .orElse(ExtBidPrebid.builder().meta(updatedMeta).build());
+        final var modifiedExtBidPrebid = ExtBidPrebid.builder().meta(updatedMeta).build();
 
         final var updatedExt = ext.deepCopy();
         updatedExt.set(PREBID_EXT, mapper.mapper().valueToTree(modifiedExtBidPrebid));
@@ -379,14 +373,6 @@ public class OpenxBidder implements Bidder<BidRequest> {
             return mapper.mapper().convertValue(ext, OpenxBidExt.class);
         } catch (IllegalArgumentException e) {
             return new OpenxBidExt();
-        }
-    }
-
-    private ExtPrebid<ExtBidPrebid, ObjectNode> getExtPrebid(ObjectNode bidExt, String bidId) {
-        try {
-            return mapper.mapper().convertValue(bidExt, EXT_PREBID_TYPE_REFERENCE);
-        } catch (IllegalArgumentException e) {
-            throw new PreBidException("Invalid ext in bid with id: " + bidId, e);
         }
     }
 

--- a/src/main/java/org/prebid/server/bidder/openx/proto/OpenxBidExt.java
+++ b/src/main/java/org/prebid/server/bidder/openx/proto/OpenxBidExt.java
@@ -1,9 +1,15 @@
 package org.prebid.server.bidder.openx.proto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OpenxBidExt {
 
     @JsonProperty("dsp_id")

--- a/src/main/java/org/prebid/server/bidder/openx/proto/OpenxBidExt.java
+++ b/src/main/java/org/prebid/server/bidder/openx/proto/OpenxBidExt.java
@@ -1,0 +1,15 @@
+package org.prebid.server.bidder.openx.proto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class OpenxBidExt {
+
+    @JsonProperty("dsp_id")
+    String dspId;
+    @JsonProperty("buyer_id")
+    String buyerId;
+    @JsonProperty("brand_id")
+    String brandId;
+}

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -1017,7 +1017,8 @@ public class OpenxBidderTest extends VertxTest {
         return Stream.of(
                 Arguments.of(allBuyerExt, allBuyerExpectedExt),
                 Arguments.of(onlyBrandExt, onlyBrandExpectedExt),
-                Arguments.of(badExt, badExpectedExt)
+                Arguments.of(badExt, badExpectedExt),
+                Arguments.of(null, null)
         );
     }
 

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -995,23 +995,23 @@ public class OpenxBidderTest extends VertxTest {
     @Test
     public void makeBidsShouldReturnBidMeta() throws JsonProcessingException {
         // given
-        final var allBuyerExt = new ObjectNode(JsonNodeFactory.instance);
-        final var onlyBrandExt = new ObjectNode(JsonNodeFactory.instance);
-        final var badExt = new ObjectNode(JsonNodeFactory.instance);
+        final ObjectNode allBuyerExt = new ObjectNode(JsonNodeFactory.instance);
+        final ObjectNode onlyBrandExt = new ObjectNode(JsonNodeFactory.instance);
+        final ObjectNode badExt = new ObjectNode(JsonNodeFactory.instance);
 
         allBuyerExt.put("dsp_id", "1").put("buyer_id", "2").put("brand_id", "3");
         onlyBrandExt.put("brand_id", "4");
         badExt.put("dsp_id", "abc").put("brand_id", "cba");
 
-        final var allBuyerExpectedExtJson = "{\"dsp_id\":\"1\",\"buyer_id\":\"2\",\"brand_id\":\"3\",\"prebid\":"
+        final String allBuyerExpectedExtJson = "{\"dsp_id\":\"1\",\"buyer_id\":\"2\",\"brand_id\":\"3\",\"prebid\":"
                 + "{\"meta\":{\"advertiserId\":2,\"brandId\":3,\"networkId\":1}}}";
-        final var onlyBrandExpectedExtJson = "{\"brand_id\":\"4\",\"prebid\":{\"meta\":{\"advertiserId\":0,"
+        final String onlyBrandExpectedExtJson = "{\"brand_id\":\"4\",\"prebid\":{\"meta\":{\"advertiserId\":0,"
                 + "\"brandId\":4,\"networkId\":0}}}";
-        final var badExpectedExtJson = "{\"dsp_id\":\"abc\",\"brand_id\":\"cba\"}";
+        final String badExpectedExtJson = "{\"dsp_id\":\"abc\",\"brand_id\":\"cba\"}";
 
-        final var allBuyerExpectedExt = (ObjectNode) mapper.readTree(allBuyerExpectedExtJson);
-        final var onlyBrandExpectedExt = (ObjectNode) mapper.readTree(onlyBrandExpectedExtJson);
-        final var badExpectedExt = (ObjectNode) mapper.readTree(badExpectedExtJson);
+        final ObjectNode allBuyerExpectedExt = (ObjectNode) mapper.readTree(allBuyerExpectedExtJson);
+        final ObjectNode onlyBrandExpectedExt = (ObjectNode) mapper.readTree(onlyBrandExpectedExtJson);
+        final ObjectNode badExpectedExt = (ObjectNode) mapper.readTree(badExpectedExtJson);
 
         final BidderCall<BidRequest> httpCall = givenHttpCall(mapper.writeValueAsString(BidResponse.builder()
                 .seatbid(singletonList(SeatBid.builder()
@@ -1042,8 +1042,7 @@ public class OpenxBidderTest extends VertxTest {
                                         .dealid("dealid3")
                                         .adm("<div>This is an Ad</div>")
                                         .ext(badExt)
-                                        .build()
-                                ))
+                                        .build()))
                         .build()))
                 .build()));
 
@@ -1053,8 +1052,7 @@ public class OpenxBidderTest extends VertxTest {
                         Imp.builder()
                                 .id("impId1")
                                 .banner(Banner.builder().build())
-                                .build()
-                ))
+                                .build()))
                 .build();
 
         // when

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -1002,7 +1002,6 @@ public class OpenxBidderTest extends VertxTest {
         allBuyerExt.put("dsp_id", "1").put("buyer_id", "2").put("brand_id", "3");
         onlyBrandExt.put("brand_id", "4");
         badExt.put("dsp_id", "abc").put("brand_id", "cba");
-        badExt.put("something", "abc");
 
         final var allBuyerExpectedExtJson = "{\"dsp_id\":\"1\",\"buyer_id\":\"2\",\"brand_id\":\"3\",\"prebid\":"
                 + "{\"meta\":{\"advertiserId\":2,\"brandId\":3,\"networkId\":1}}}";

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -2,7 +2,6 @@ package org.prebid.server.bidder.openx;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.Audio;
 import com.iab.openrtb.request.Banner;


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
We want to start returning `advertiserId`, `networkId` and `brandId` in `bid.ext.prebid.meta` as we already do in [prebid.js adapter](https://github.com/prebid/Prebid.js/blob/72c7f184028f51ba15cdac744d56590b0f2b1f1e/modules/openxBidAdapter.js#L84-L86).

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
