### PR TITLE
LiveIntent module: Restrict LI enrichment based on allowed activity

### DIFF
--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/config/LiveIntentOmniChannelIdentityConfiguration.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/config/LiveIntentOmniChannelIdentityConfiguration.java
@@ -1,5 +1,6 @@
 package org.prebid.server.hooks.modules.liveintent.omni.channel.identity.config;
 
+import org.prebid.server.auction.privacy.enforcement.mask.UserFpdActivityMask;
 import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.model.config.LiveIntentOmniChannelProperties;
 import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.v1.LiveIntentOmniChannelIdentityModule;
 import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.v1.hooks.LiveIntentOmniChannelIdentityProcessedAuctionRequestHook;
@@ -30,12 +31,13 @@ public class LiveIntentOmniChannelIdentityConfiguration {
     @Bean
     Module liveIntentOmniChannelIdentityModule(LiveIntentOmniChannelProperties properties,
                                                JacksonMapper mapper,
+                                               UserFpdActivityMask userFpdActivityMask,
                                                HttpClient httpClient,
                                                @Value("${logging.sampling-rate:0.01}") double logSamplingRate) {
 
         final LiveIntentOmniChannelIdentityProcessedAuctionRequestHook hook =
                 new LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(
-                        properties, mapper, httpClient, logSamplingRate);
+                        properties, userFpdActivityMask, mapper, httpClient, logSamplingRate);
 
         return new LiveIntentOmniChannelIdentityModule(Collections.singleton(hook));
     }

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -1,15 +1,26 @@
 package org.prebid.server.hooks.modules.liveintent.omni.channel.identity.v1.hooks;
 
 import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.Eid;
+import com.iab.openrtb.request.Source;
 import com.iab.openrtb.request.User;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import org.apache.commons.collections4.ListUtils;
+import org.prebid.server.activity.Activity;
+import org.prebid.server.activity.ComponentType;
+import org.prebid.server.activity.infrastructure.ActivityInfrastructure;
+import org.prebid.server.activity.infrastructure.payload.ActivityInvocationPayload;
+import org.prebid.server.activity.infrastructure.payload.impl.ActivityInvocationPayloadImpl;
+import org.prebid.server.activity.infrastructure.payload.impl.BidRequestActivityInvocationPayload;
+import org.prebid.server.auction.model.AuctionContext;
+import org.prebid.server.auction.privacy.enforcement.mask.UserFpdActivityMask;
 import org.prebid.server.hooks.execution.v1.InvocationResultImpl;
 import org.prebid.server.hooks.execution.v1.auction.AuctionRequestPayloadImpl;
 import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.model.IdResResponse;
 import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.model.config.LiveIntentOmniChannelProperties;
+import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.v1.LiveIntentOmniChannelIdentityModule;
 import org.prebid.server.hooks.v1.InvocationAction;
 import org.prebid.server.hooks.v1.InvocationResult;
 import org.prebid.server.hooks.v1.InvocationStatus;
@@ -39,9 +50,11 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     private final LiveIntentOmniChannelProperties config;
     private final JacksonMapper mapper;
     private final HttpClient httpClient;
+    private final UserFpdActivityMask userFpdActivityMask;
     private final double logSamplingRate;
 
     public LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(LiveIntentOmniChannelProperties config,
+                                                                    UserFpdActivityMask userFpdActivityMask,
                                                                     JacksonMapper mapper,
                                                                     HttpClient httpClient,
                                                                     double logSamplingRate) {
@@ -51,6 +64,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         this.mapper = Objects.requireNonNull(mapper);
         this.httpClient = Objects.requireNonNull(httpClient);
         this.logSamplingRate = logSamplingRate;
+        this.userFpdActivityMask = Objects.requireNonNull(userFpdActivityMask);
     }
 
     @Override
@@ -58,20 +72,66 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
                                                                 AuctionInvocationContext invocationContext) {
 
         return config.getTreatmentRate() > ThreadLocalRandom.current().nextFloat()
-                ? requestIdentities(auctionRequestPayload.bidRequest())
+                ? requestIdentities(auctionRequestPayload.bidRequest(), invocationContext.auctionContext())
                 .<InvocationResult<AuctionRequestPayload>>map(this::update)
                 .onFailure(throwable -> conditionalLogger.error(
                         "Failed enrichment: %s".formatted(throwable.getMessage()), logSamplingRate))
                 : noAction();
     }
 
-    private Future<IdResResponse> requestIdentities(BidRequest bidRequest) {
+    private Future<IdResResponse> requestIdentities(BidRequest bidRequest, AuctionContext auctionContext) {
+        final BidRequest restrictedBidRequest = applyActivityRestrictions(bidRequest, auctionContext);
         return httpClient.post(
                         config.getIdentityResolutionEndpoint(),
                         headers(),
-                        mapper.encodeToString(bidRequest),
+                        mapper.encodeToString(restrictedBidRequest),
                         config.getRequestTimeoutMs())
                 .map(this::processResponse);
+    }
+
+    private BidRequest applyActivityRestrictions(BidRequest bidRequest, AuctionContext auctionContext) {
+        final ActivityInvocationPayload activityInvocationPayload = BidRequestActivityInvocationPayload.of(
+                ActivityInvocationPayloadImpl.of(ComponentType.GENERAL_MODULE, LiveIntentOmniChannelIdentityModule.CODE),
+                bidRequest);
+        final ActivityInfrastructure activityInfrastructure = auctionContext.getActivityInfrastructure();
+
+        final boolean disallowTransmitUfpd = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_UFPD, activityInvocationPayload);
+        final boolean disallowTransmitEids = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_EIDS, activityInvocationPayload);
+        final boolean disallowTransmitGeo = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_GEO, activityInvocationPayload);
+        final boolean disallowTransmitTid = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_TID, activityInvocationPayload);
+
+        return maskUserPersonalInfo(
+                bidRequest,
+                disallowTransmitUfpd,
+                disallowTransmitEids,
+                disallowTransmitGeo,
+                disallowTransmitTid);
+    }
+
+    private BidRequest maskUserPersonalInfo(BidRequest bidRequest,
+                                            boolean disallowTransmitUfpd,
+                                            boolean disallowTransmitEids,
+                                            boolean disallowTransmitGeo,
+                                            boolean disallowTransmitTid) {
+
+        final User maskedUser = userFpdActivityMask.maskUser(
+                bidRequest.getUser(), disallowTransmitUfpd, disallowTransmitEids);
+        final Device maskedDevice = userFpdActivityMask.maskDevice(
+                bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
+
+        final Source maskedSource = disallowTransmitTid
+                ? bidRequest.getSource().toBuilder().tid(null).build()
+                : bidRequest.getSource();
+
+        return bidRequest.toBuilder()
+                .user(maskedUser)
+                .device(maskedDevice)
+                .source(maskedSource)
+                .build();
     }
 
     private MultiMap headers() {

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -123,7 +123,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         final Device maskedDevice = userFpdActivityMask.maskDevice(
                 bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
 
-        final Source maskedSource = disallowTransmitTid
+        final Source maskedSource = (disallowTransmitUfpd && disallowTransmitTid)
                 ? bidRequest.getSource().toBuilder().tid(null).build()
                 : bidRequest.getSource();
 

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -91,7 +91,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private BidRequest applyActivityRestrictions(BidRequest bidRequest, AuctionContext auctionContext) {
         final ActivityInvocationPayload activityInvocationPayload = BidRequestActivityInvocationPayload.of(
-                ActivityInvocationPayloadImpl.of(ComponentType.GENERAL_MODULE, LiveIntentOmniChannelIdentityModule.CODE),
+                ActivityInvocationPayloadImpl.of(
+                        ComponentType.GENERAL_MODULE,
+                        LiveIntentOmniChannelIdentityModule.CODE),
                 bidRequest);
         final ActivityInfrastructure activityInfrastructure = auctionContext.getActivityInfrastructure();
 

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -125,15 +125,21 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         final Device maskedDevice = userFpdActivityMask.maskDevice(
                 bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
 
-        final Source maskedSource = (disallowTransmitUfpd && disallowTransmitTid)
-                ? bidRequest.getSource().toBuilder().tid(null).build()
-                : bidRequest.getSource();
+        final Source maskedSource = maskSource(bidRequest.getSource(), disallowTransmitUfpd, disallowTransmitTid);
 
         return bidRequest.toBuilder()
                 .user(maskedUser)
                 .device(maskedDevice)
                 .source(maskedSource)
                 .build();
+    }
+
+    private Source maskSource(Source source, boolean mastUfpd, boolean maskTid) {
+        if (source == null || !(mastUfpd || maskTid)) {
+            return source;
+        }
+
+        return source.toBuilder().tid(null).build();
     }
 
     private MultiMap headers() {

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.prebid.server.auction.privacy.enforcement.mask.UserFpdActivityMask;
 import org.prebid.server.hooks.execution.v1.auction.AuctionInvocationContextImpl;
 import org.prebid.server.hooks.execution.v1.auction.AuctionRequestPayloadImpl;
 import org.prebid.server.hooks.modules.liveintent.omni.channel.identity.model.IdResResponse;
@@ -45,6 +46,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
     private static final JacksonMapper MAPPER = new JacksonMapper(ObjectMapperProvider.mapper());
 
     @Mock
+    private UserFpdActivityMask userFpdActivityMask;
+
+    @Mock
     private HttpClient httpClient;
 
     @Mock(strictness = LENIENT)
@@ -60,7 +64,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         given(properties.getTreatmentRate()).willReturn(1.0f);
 
         target = new LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(
-                properties, MAPPER, httpClient, 0.01d);
+                properties, userFpdActivityMask, MAPPER, httpClient, 0.01d);
     }
 
     @Test
@@ -68,7 +72,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         given(properties.getIdentityResolutionEndpoint()).willReturn("invalid_url");
         assertThatIllegalArgumentException().isThrownBy(() ->
                 new LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(
-                        properties, MAPPER, httpClient, 0.01d));
+                        properties, userFpdActivityMask, MAPPER, httpClient, 0.01d));
     }
 
     @Test

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -78,10 +78,6 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         given(properties.getAuthToken()).willReturn("auth_token");
         given(properties.getTreatmentRate()).willReturn(1.0f);
 
-        given(auctionInvocationContext.auctionContext()).willReturn(auctionContext);
-        given(auctionContext.getActivityInfrastructure()).willReturn(activityInfrastructure);
-        given(activityInfrastructure.isAllowed(any(), any())).willReturn(true);
-
         target = new LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(
                 properties, userFpdActivityMask, MAPPER, httpClient, 0.01d);
     }
@@ -172,6 +168,10 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));
 
+        given(auctionInvocationContext.auctionContext()).willReturn(auctionContext);
+        given(auctionContext.getActivityInfrastructure()).willReturn(activityInfrastructure);
+        given(activityInfrastructure.isAllowed(any(), any())).willReturn(true);
+
         given(activityInfrastructure.isAllowed(eq(Activity.TRANSMIT_TID), any())).willReturn(false);
         given(activityInfrastructure.isAllowed(eq(Activity.TRANSMIT_UFPD), any())).willReturn(false);
 
@@ -205,6 +205,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));
 
+        given(auctionInvocationContext.auctionContext()).willReturn(auctionContext);
+        given(auctionContext.getActivityInfrastructure()).willReturn(activityInfrastructure);
+        given(activityInfrastructure.isAllowed(any(), any())).willReturn(true);
         given(activityInfrastructure.isAllowed(eq(Activity.TRANSMIT_EIDS), any())).willReturn(false);
         given(activityInfrastructure.isAllowed(eq(Activity.TRANSMIT_UFPD), any())).willReturn(false);
 


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [x] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Respecting activity restriction when enriching bid request from LiveIntent

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
