### PR TITLE
33across: adapter maintenance

### DIFF
--- a/src/main/java/org/prebid/server/bidder/thirtythreeacross/ThirtyThreeAcrossBidder.java
+++ b/src/main/java/org/prebid/server/bidder/thirtythreeacross/ThirtyThreeAcrossBidder.java
@@ -165,22 +165,11 @@ public class ThirtyThreeAcrossBidder implements Bidder<BidRequest> {
 
         return video.toBuilder()
                 .startdelay(resolveStartDelay(video.getStartdelay(), productId))
-                .placement(resolvePlacement(video.getPlacement(), productId))
                 .build();
     }
 
     private static Integer resolveStartDelay(Integer startDelay, String productId) {
         return Objects.equals(productId, "instream") ? Integer.valueOf(0) : startDelay;
-    }
-
-    private static Integer resolvePlacement(Integer videoPlacement, String productId) {
-        if (Objects.equals(productId, "instream")) {
-            return 1;
-        }
-        if (BidderUtil.isNullOrZero(videoPlacement)) {
-            return 2;
-        }
-        return videoPlacement;
     }
 
     private static String getImpGroupName(ThirtyThreeAcrossImpExt impExt) {

--- a/src/main/resources/bidder-config/thirtythreeacross.yaml
+++ b/src/main/resources/bidder-config/thirtythreeacross.yaml
@@ -20,6 +20,6 @@ adapters:
     usersync:
       cookie-family-name: 33across
       iframe:
-        url: https://ssc-cms.33across.com/ps/?m=xch&rt=html&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&id=zzz000000000002zzz&ru={{redirect_url}}
+        url: https://ssc-cms.33across.com/ps/?m=xch&rt=html&gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&gpp={{gpp}}&gpp_sid={{gpp_sid}}&id=zzz000000000002zzz&ru={{redirect_url}}
         support-cors: false
         uid-macro: '33XUSERID33X'

--- a/src/main/resources/static/bidder-params/thirtythreeacross.json
+++ b/src/main/resources/static/bidder-params/thirtythreeacross.json
@@ -10,15 +10,25 @@
     },
     "siteId": {
       "type": "string",
-      "description": "Site Id"
+      "description": "[Deprecated use zoneId instead] Site Id"
     },
     "zoneId": {
       "type": "string",
       "description": "Zone Id"
     }
   },
-  "required": [
-    "productId",
-    "siteId"
+  "anyOf": [
+    {
+      "required": [
+        "productId",
+        "zoneId"
+      ]
+    },
+    {
+      "required": [
+        "productId",
+        "siteId"
+      ]
+    }
   ]
 }

--- a/src/test/java/org/prebid/server/bidder/thirtythreeacross/ThirtyThreeAcrossBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/thirtythreeacross/ThirtyThreeAcrossBidderTest.java
@@ -32,7 +32,6 @@ import static java.util.Collections.singletonList;
 import static java.util.function.UnaryOperator.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.prebid.server.proto.openrtb.ext.response.BidType.banner;
 import static org.prebid.server.proto.openrtb.ext.response.BidType.video;
 
@@ -197,30 +196,6 @@ public class ThirtyThreeAcrossBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldUpdateNotPresentPlacement() {
-        // given
-        final ExtPrebid<?, ExtImpThirtyThreeAcross> ext = ExtPrebid.of(null,
-                ExtImpThirtyThreeAcross.of("11", null, "3"));
-        final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(givenImp(impBuilder -> impBuilder
-                        .video(validVideo())
-                        .ext(mapper.valueToTree(ext)))))
-                .build();
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).isEmpty();
-        assertThat(result.getValue())
-                .extracting(HttpRequest::getPayload)
-                .flatExtracting(BidRequest::getImp)
-                .extracting(Imp::getVideo)
-                .extracting(Video::getPlacement)
-                .containsExactly(2);
-    }
-
-    @Test
     public void makeHttpRequestsShouldNotUpdatePlacementWhenProductIdIsNotInstreamAndPlacementIsNotZero() {
         // given
         final ExtPrebid<?, ExtImpThirtyThreeAcross> ext = ExtPrebid.of(null,
@@ -245,7 +220,7 @@ public class ThirtyThreeAcrossBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldUpdatePlacementAndStartDelayIfProdIsInstream() {
+    public void makeHttpRequestsShouldUpdateStartDelayIfProdIsInstream() {
         // given
         final ExtPrebid<?, ExtImpThirtyThreeAcross> ext = ExtPrebid.of(null,
                 ExtImpThirtyThreeAcross.of("11", null, "instream"));
@@ -264,8 +239,8 @@ public class ThirtyThreeAcrossBidderTest extends VertxTest {
                 .extracting(HttpRequest::getPayload)
                 .flatExtracting(BidRequest::getImp)
                 .extracting(Imp::getVideo)
-                .extracting(Video::getPlacement, Video::getStartdelay)
-                .containsExactly(tuple(1, 0));
+                .extracting(Video::getStartdelay)
+                .containsExactly(0);
     }
 
     @Test


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [X] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Bring this adapter up-to-date with recent changes that have been done in the PBS Go Adapter and PBJS Adapter.
- Remove default values for the deprecated attribute video.placement
- Add missing GPP and GPP_SID params to the user sync request
- Allow config option "zoneId" to be used as a replacement for siteId.

### 🧠 Rationale behind the change
Adapter needed an update and it's not reflecting important data that we need such as GPP parameters.

### 🧪 Test plan
How do you know the changes are safe to ship to production?
Specs coverage and QA applied.

### 🏎 Quality check
- [X] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)? yes
- [X] Are there any breaking changes in your code?
- [X] Does your test coverage exceed 90%?
- [X] Are there any erroneous console logs, debuggers or leftover code in your changes?
