### PR TITLE
Test: Bidder Specific Imp Level Params Should Apply to a Specific Alias

### DIFF
--- a/src/test/groovy/org/prebid/server/functional/model/response/auction/ErrorType.groovy
+++ b/src/test/groovy/org/prebid/server/functional/model/response/auction/ErrorType.groovy
@@ -6,7 +6,6 @@ enum ErrorType {
 
     GENERAL("general"),
     GENERIC("generic"),
-    GENER_X("gener_x"),
     GENERIC_CAMEL_CASE("GeNerIc"),
     RUBICON("rubicon"),
     APPNEXUS("appnexus"),

--- a/src/test/groovy/org/prebid/server/functional/model/response/auction/ErrorType.groovy
+++ b/src/test/groovy/org/prebid/server/functional/model/response/auction/ErrorType.groovy
@@ -6,6 +6,7 @@ enum ErrorType {
 
     GENERAL("general"),
     GENERIC("generic"),
+    GENER_X("gener_x"),
     GENERIC_CAMEL_CASE("GeNerIc"),
     RUBICON("rubicon"),
     APPNEXUS("appnexus"),

--- a/src/test/groovy/org/prebid/server/functional/tests/ImpRequestSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/ImpRequestSpec.groovy
@@ -19,7 +19,7 @@ import static org.prebid.server.functional.model.bidder.BidderName.OPENX
 import static org.prebid.server.functional.model.bidder.BidderName.RUBICON
 import static org.prebid.server.functional.model.bidder.BidderName.UNKNOWN
 import static org.prebid.server.functional.model.bidder.BidderName.WILDCARD
-import static org.prebid.server.functional.model.response.auction.ErrorType.GENER_X
+import static org.prebid.server.functional.model.bidder.BidderName.GENER_X
 import static org.prebid.server.functional.model.response.auction.ErrorType.PREBID
 import static org.prebid.server.functional.testcontainers.Dependencies.getNetworkServiceContainer
 
@@ -138,14 +138,13 @@ class ImpRequestSpec extends BaseSpec {
         def originalPmp = Pmp.defaultPmp
         def bidRequest = BidRequest.defaultBidRequest.tap {
             imp.first.tap {
-                bidFloor = 15
                 pmp = originalPmp
                 ext.prebid.imp = [(aliasName): new Imp(pmp: storedPmp)]
                 ext.prebid.bidder.generic = null
                 ext.prebid.bidder.generX = new Generic()
                 ext.prebid.bidder.alias = new Generic()
             }
-            ext.prebid.aliases = [(GENER_X.value): bidderName,
+            ext.prebid.aliases = [(GENER_X.value)  : bidderName,
                                   (aliasName.value): bidderName,
             ]
         }
@@ -155,6 +154,7 @@ class ImpRequestSpec extends BaseSpec {
 
         then: "BidderRequest should update imp information for specific alias"
         def bidderRequests = getRequests(response)
+        assert bidderRequests.size() == 2
         assert bidderRequests[ALIAS.value].imp.pmp.flatten() == [storedPmp]
 
         and: "Left original information for other"

--- a/src/test/groovy/org/prebid/server/functional/tests/ImpRequestSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/ImpRequestSpec.groovy
@@ -19,6 +19,7 @@ import static org.prebid.server.functional.model.bidder.BidderName.OPENX
 import static org.prebid.server.functional.model.bidder.BidderName.RUBICON
 import static org.prebid.server.functional.model.bidder.BidderName.UNKNOWN
 import static org.prebid.server.functional.model.bidder.BidderName.WILDCARD
+import static org.prebid.server.functional.model.response.auction.ErrorType.GENER_X
 import static org.prebid.server.functional.model.response.auction.ErrorType.PREBID
 import static org.prebid.server.functional.testcontainers.Dependencies.getNetworkServiceContainer
 
@@ -122,6 +123,43 @@ class ImpRequestSpec extends BaseSpec {
 
         and: "PBS should remove imp.ext.prebid.bidder from bidderRequest"
         assert !bidderRequest?.imp?.first?.ext?.prebid?.bidder
+
+        where:
+        aliasName        | bidderName
+        ALIAS            | GENERIC
+        ALIAS_CAMEL_CASE | GENERIC
+        ALIAS            | GENERIC_CAMEL_CASE
+        ALIAS_CAMEL_CASE | GENERIC_CAMEL_CASE
+    }
+
+    def "PBS should update imp fields when imp.ext.prebid.imp contain bidder alias information2"() {
+        given: "Default basic BidRequest"
+        def storedPmp = Pmp.defaultPmp
+        def originalPmp = Pmp.defaultPmp
+        def bidRequest = BidRequest.defaultBidRequest.tap {
+            imp.first.tap {
+                bidFloor = 15
+                pmp = originalPmp
+                ext.prebid.imp = [(aliasName): new Imp(pmp: storedPmp)]
+                ext.prebid.bidder.generic = null
+                ext.prebid.bidder.generX = new Generic()
+                ext.prebid.bidder.alias = new Generic()
+            }
+            ext.prebid.aliases = [(GENER_X.value): bidderName,
+                                  (aliasName.value): bidderName,
+            ]
+        }
+
+        when: "Requesting PBS auction"
+        def response = defaultPbsService.sendAuctionRequest(bidRequest)
+
+        then: "BidderRequest should update imp information for specific alias"
+        def bidderRequests = getRequests(response)
+        assert bidderRequests[ALIAS.value].imp.pmp.flatten() == [storedPmp]
+
+        and: "Left original information for other"
+        assert bidderRequests[GENER_X.value].imp.pmp.flatten() == [originalPmp]
+
 
         where:
         aliasName        | bidderName

--- a/src/test/groovy/org/prebid/server/functional/tests/ImpRequestSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/ImpRequestSpec.groovy
@@ -132,7 +132,7 @@ class ImpRequestSpec extends BaseSpec {
         ALIAS_CAMEL_CASE | GENERIC_CAMEL_CASE
     }
 
-    def "PBS should update imp fields when imp.ext.prebid.imp contain bidder alias information2"() {
+    def "PBS should update imp fields only for specific alias when request has multiple aliases"() {
         given: "Default basic BidRequest"
         def storedPmp = Pmp.defaultPmp
         def originalPmp = Pmp.defaultPmp
@@ -159,7 +159,6 @@ class ImpRequestSpec extends BaseSpec {
 
         and: "Left original information for other"
         assert bidderRequests[GENER_X.value].imp.pmp.flatten() == [originalPmp]
-
 
         where:
         aliasName        | bidderName

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprSetUidSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/GdprSetUidSpec.groovy
@@ -58,7 +58,7 @@ class GdprSetUidSpec extends PrivacyBaseSpec {
                     .build()
         }
 
-        and: "Default uids cookie with gener_x bidder"
+        and: "Default uids cookie with generic bidder"
         def uidsCookie = UidsCookie.defaultUidsCookie.tap {
             it.tempUIDs = [(GENERIC): defaultUidWithExpiry]
         }


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
What's the context for the changes?

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
