### PR TITLE
AudienceNetwork (S2S): add missing ext.security_app_id in OpenRTB requests to fix production auth failures

### DIFF
--- a/src/main/java/org/prebid/server/bidder/audiencenetwork/AudienceNetworkBidder.java
+++ b/src/main/java/org/prebid/server/bidder/audiencenetwork/AudienceNetworkBidder.java
@@ -118,7 +118,7 @@ public class AudienceNetworkBidder implements Bidder<BidRequest> {
                 .imp(Collections.singletonList(modifiedImp))
                 .app(makeApp(bidRequest.getApp(), publisherId))
                 .ext(mapper.fillExtension(
-                        ExtRequest.empty(), AudienceNetworkExt.of(platformId, makeAuthId(bidRequest.getId(), platformId))))
+                        ExtRequest.empty(), AudienceNetworkExt.of(platformId, makeAuthId(bidRequest.getId()), platformId)))
                 .build();
 
         return HttpRequest.<BidRequest>builder()

--- a/src/main/java/org/prebid/server/bidder/audiencenetwork/AudienceNetworkBidder.java
+++ b/src/main/java/org/prebid/server/bidder/audiencenetwork/AudienceNetworkBidder.java
@@ -118,7 +118,7 @@ public class AudienceNetworkBidder implements Bidder<BidRequest> {
                 .imp(Collections.singletonList(modifiedImp))
                 .app(makeApp(bidRequest.getApp(), publisherId))
                 .ext(mapper.fillExtension(
-                        ExtRequest.empty(), AudienceNetworkExt.of(platformId, makeAuthId(bidRequest.getId()))))
+                        ExtRequest.empty(), AudienceNetworkExt.of(platformId, makeAuthId(bidRequest.getId(), platformId))))
                 .build();
 
         return HttpRequest.<BidRequest>builder()

--- a/src/main/java/org/prebid/server/bidder/audiencenetwork/proto/AudienceNetworkExt.java
+++ b/src/main/java/org/prebid/server/bidder/audiencenetwork/proto/AudienceNetworkExt.java
@@ -4,8 +4,12 @@ import lombok.Value;
 
 @Value(staticConstructor = "of")
 public class AudienceNetworkExt {
-
+    @JsonProperty("platformid")
     String platformid;
 
+    @JsonProperty("authentication_id")
     String authenticationId;
+
+    @JsonProperty("security_app_id")
+    String securityAppId;
 }


### PR DESCRIPTION
In short: 
AudienceNetwork (S2S): include ext.security_app_id in OpenRTB requests.
Fixes a production-only 400 ("Error validating authentication token") when test=0,
while test=1 works. Adds field wiring in AudienceNetworkExt and passes it through
AudienceNetworkBidder. Verified end-to-end with Meta Audience Network engineers.


Summary

This PR fixes a production-only failure in the Meta Audience Network (AN) S2S bidding integration within Prebid Server Java.
In production (test=0), AN requires ext.security_app_id alongside ext.authentication_id for request authentication. The field was not present in outgoing requests, leading to 400 responses (x-fb-an-errors: Error validating authentication token).
Adding ext.security_app_id resolves the issue. Test mode (test=1) remained unaffected, which masked the missing field during integration testing.

Problem Statement
	# Observed:
	       •	test=1 requests succeed end-to-end.
	       •	test=0 requests fail with HTTP 400, headers include x-fb-an-errors=Error validating authentication token, often with empty body and standard Meta edge headers.
	# Impact: Audience Network bidding seat is effectively disabled in production traffic, reducing competition and potential yield.