### PR TITLE
IX Adapter feature dynamic account id support

### DIFF
--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ix/ExtImpIx.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ix/ExtImpIx.java
@@ -16,4 +16,8 @@ public class ExtImpIx {
     List<Integer> size;
 
     String sid;
+
+    @JsonProperty("accountId")
+    @JsonAlias({"accountid", "ixAccountId"})
+    String accountId;
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/IxConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/IxConfiguration.java
@@ -37,7 +37,11 @@ public class IxConfiguration {
         return BidderDepsAssembler.forBidder(BIDDER_NAME)
                 .withConfig(ixConfigurationProperties)
                 .usersyncerCreator(UsersyncerCreator.create(externalUrl))
-                .bidderCreator(config -> new IxBidder(config.getEndpoint(), prebidVersionProvider, mapper))
+                .bidderCreator(config -> new IxBidder(
+                    config.getEndpoint(),
+                    config.getDefaultAccountId(),
+                    prebidVersionProvider,
+                    mapper))
                 .assemble();
     }
 }

--- a/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/model/BidderConfigurationProperties.java
@@ -32,6 +32,8 @@ public class BidderConfigurationProperties {
     @NotBlank
     private String endpoint;
 
+    private String defaultAccountId;
+
     private Boolean pbsEnforcesCcpa;
 
     private Boolean modifyingVastXmlAllowed;


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [X] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
What's the context for the changes?
Macro support for IX bid endpoint. Ability to pass accountId to PBS for IX to be autopopulated in endpoint to handle multiople account id scenarios

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?
See above
