### PR TITLE
RTBHouse: Add PMP Removal and Publisher ID Extraction

### DIFF
--- a/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-rtbhouse-bid-request.json
+++ b/src/test/resources/org/prebid/server/it/openrtb2/rtbhouse/test-rtbhouse-bid-request.json
@@ -23,6 +23,7 @@
     "domain": "www.example.com",
     "page": "http://www.example.com",
     "publisher": {
+      "id": "publisherId",
       "domain": "example.com"
     },
     "ext": {


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bid adapter update
- [x] enhancement

### ✨ What's the context?
These changes address specific RTBHouse bidder requirements:
1. PMP Removal: RTBHouse bidder doesn't support private marketplace deals for Prebid Server and requires clean bid requests without PMP data
2. Publisher ID: Enables proper publisher identification in RTBHouse's system for better targeting and reporting

### 📋 Description
This PR implements two key enhancements to the RTBHouse bidder adapter:

1. PMP Deals Removal: Automatically removes the `imp[].pmp` object from all impressions in outgoing bid requests to RTBHouse
2. Publisher ID Extraction: Extracts publisher ID from impression extensions and propagates it to `site.publisher.id` in the bid request

### 🧪 Testing results
```Tests run: 27, Failures: 0, Errors: 0, Skipped: 0```
All RTBHouse bidder tests pass successfully, including:
- Unit tests for new functionality (13 tests)
- Integration test with updated mock expectations (1 test)
- Backward compatibility verification