### PR TITLE
Seedtag: sets bid request's currency to USD

### DIFF
--- a/src/main/java/org/prebid/server/bidder/seedtag/SeedtagBidder.java
+++ b/src/main/java/org/prebid/server/bidder/seedtag/SeedtagBidder.java
@@ -72,6 +72,7 @@ public class SeedtagBidder implements Bidder<BidRequest> {
 
         final BidRequest modifiedBidRequest = request.toBuilder()
                 .imp(modifiedImps)
+                .cur(Collections.singletonList(BIDDER_CURRENCY))
                 .build();
         return Result.of(
                 Collections.singletonList(BidderUtil.defaultRequest(modifiedBidRequest, endpointUrl, mapper)),

--- a/src/test/java/org/prebid/server/bidder/seedtag/SeedtagBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/seedtag/SeedtagBidderTest.java
@@ -75,10 +75,9 @@ public class SeedtagBidderTest extends VertxTest {
 
         // then
         assertThat(result.getErrors()).isEmpty();
-        assertThat(result.getValue()).hasSize(1)
-                .extracting(HttpRequest::getPayload)
-                .flatExtracting(BidRequest::getImp)
-                .hasSize(2);
+        final BidRequest outgoingRequest = result.getValue().get(0).getPayload();
+        assertThat(outgoingRequest.getImp()).hasSize(2);
+        assertThat(outgoingRequest.getCur()).containsExactly("USD");
     }
 
     @Test


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Seedtag only supports USD as bidding currency

### 🧠 Rationale behind the change
Even though Seedtag always bids in USD and omits request currency, internally having other incoming currencies produces noise and misunderstandings, specially when debugging RTB funnel.

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
