### PR TITLE
Fix #4304: incorrect naming in userSync configs

### DIFF
--- a/src/main/resources/bidder-config/amx.yaml
+++ b/src/main/resources/bidder-config/amx.yaml
@@ -19,8 +19,8 @@ adapters:
       redirect:
         url: https://prebid.a-mo.net/cchain/0?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&cb={{redirect_url}}
         support-cors: false
-        userMacro: "$UID"
+        uid-macro: "$UID"
       iframe:
         url: https://prebid.a-mo.net/isyn?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&gpp={{gpp}}&gpp_sid={{gpp_sid}}&s=pbs&cb={{redirect_url}}
-        userMacro: "$UID"
+        uid-macro: "$UID"
         support-cors: false

--- a/src/main/resources/bidder-config/inmobi.yaml
+++ b/src/main/resources/bidder-config/inmobi.yaml
@@ -22,4 +22,4 @@ adapters:
       redirect:
         url: https://sync.inmobi.com/prebid?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&gpp={{gpp}}&gpp_sid={{gpp_sid}}&redirect={{redirect_url}}
         support-cors: false
-        userMacro: '{ID5UID}'
+        uid-macro: '{ID5UID}'

--- a/src/main/resources/bidder-config/tpmn.yaml
+++ b/src/main/resources/bidder-config/tpmn.yaml
@@ -19,5 +19,5 @@ adapters:
       cookie-family-name: tpmn
       iframe:
         url: https://gat.tpmn.io/sync/redirect?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&redir={{redirect_url}}
-        userMacro: $UID
+        uid-macro: $UID
         support-cors: false

--- a/src/main/resources/bidder-config/vox.yaml
+++ b/src/main/resources/bidder-config/vox.yaml
@@ -17,5 +17,5 @@ adapters:
       cookie-family-name: vox
       iframe:
         url: https://ssp.hybrid.ai/prebid/server/v1/userSync?consent={{gdpr_consent}}&redirect={{redirect_url}}
-        userMacro: $UID
+        uid-macro: $UID
         support-cors: false


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [X] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
I assume that these erroneous entries were introduced when porting Go changes to PBS-Java without changing the naming, e.g. [inmobi.yaml at PBS-Go](https://github.com/SiddhantAgrawal/prebid-server/blob/master/static/bidder-info/inmobi.yaml). This caused the yaml config to be incorrectly decoded into [UsersyncMethodConfigurationProperties.java](https://github.com/prebid/prebid-server-java/blob/fb5adaf680912e454de614e9bed70145446ea0ea/src/main/java/org/prebid/server/spring/config/bidder/model/usersync/UsersyncMethodConfigurationProperties.java#L19)

### 🧠 Rationale behind the change
Incorrect configs cause low cookiesync rates, which in return influences Bidder's performance

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [] Does your test coverage exceed 90%?
- [X] Are there any erroneous console logs, debuggers or leftover code in your changes?
