### PR TITLE
StroeerCore: Use bid.ext as-is from the response

### DIFF
--- a/src/main/java/org/prebid/server/bidder/stroeercore/StroeerCoreBidder.java
+++ b/src/main/java/org/prebid/server/bidder/stroeercore/StroeerCoreBidder.java
@@ -106,10 +106,6 @@ public class StroeerCoreBidder implements Bidder<BidRequest> {
             return null;
         }
 
-        final ObjectNode bidExt = stroeercoreBid.getDsa() != null
-                ? mapper.mapper().createObjectNode().set("dsa", stroeercoreBid.getDsa())
-                : null;
-
         return BidderBid.of(
                 Bid.builder()
                         .id(stroeercoreBid.getId())
@@ -121,10 +117,22 @@ public class StroeerCoreBidder implements Bidder<BidRequest> {
                         .crid(stroeercoreBid.getCreativeId())
                         .adomain(stroeercoreBid.getAdomain())
                         .mtype(bidType.ordinal() + 1)
-                        .ext(bidExt)
+                        .ext(getBidExt(stroeercoreBid))
                         .build(),
                 bidType,
                 BIDDER_CURRENCY);
+    }
+
+    private ObjectNode getBidExt(StroeerCoreBid stroeercoreBid) {
+        final ObjectNode dsa = stroeercoreBid.getDsa();
+        ObjectNode ext = stroeercoreBid.getExt();
+        if (dsa == null) {
+            return ext;
+        }
+        if (ext == null) {
+            ext = mapper.mapper().createObjectNode();
+        }
+        return ext.set("dsa", dsa);
     }
 
     private static BidType getBidType(String mtype) {

--- a/src/main/java/org/prebid/server/bidder/stroeercore/model/StroeerCoreBid.java
+++ b/src/main/java/org/prebid/server/bidder/stroeercore/model/StroeerCoreBid.java
@@ -29,9 +29,15 @@ public class StroeerCoreBid {
     @JsonProperty("crid")
     String creativeId;
 
+    /**
+     * @deprecated The dsa will move to the bid's ext.
+     */
+    @Deprecated(forRemoval = true)
     ObjectNode dsa;
 
     String mtype;
 
     List<String> adomain;
+
+    ObjectNode ext;
 }

--- a/src/test/java/org/prebid/server/bidder/stroeercore/StroeerCoreBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/stroeercore/StroeerCoreBidderTest.java
@@ -219,8 +219,7 @@ public class StroeerCoreBidderTest extends VertxTest {
                 .build();
 
         final StroeerCoreBidResponse response = StroeerCoreBidResponse.of(
-                List.of(bannerBidWithoutExt, bannerBidWithExt)
-        );
+                List.of(bannerBidWithoutExt, bannerBidWithExt));
         final BidderCall<BidRequest> httpCall = createHttpCall(response);
 
         // when
@@ -249,8 +248,7 @@ public class StroeerCoreBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue()).containsOnly(
                 BidderBid.of(expectedBid1, BidType.banner, "EUR"),
-                BidderBid.of(expectedBid2, BidType.banner, "EUR")
-        );
+                BidderBid.of(expectedBid2, BidType.banner, "EUR"));
     }
 
     @Test


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bid adapter update

Allows us to add to the bid ext without needing to update the adapter, which is especially convenient when adding fields for custom targeting. We intend to move dsa into ext in the near future, but we want to establish the PBS-Java version first.

Equivalent PBS-Go PR: https://github.com/prebid/prebid-server/pull/4633