### PR TITLE
Mobkoi: Always set the TagID with our placementID

### DIFF
--- a/src/main/java/org/prebid/server/bidder/mobkoi/MobkoiBidder.java
+++ b/src/main/java/org/prebid/server/bidder/mobkoi/MobkoiBidder.java
@@ -75,12 +75,12 @@ public class MobkoiBidder implements Bidder<BidRequest> {
     }
 
     private Imp modifyImp(Imp firstImp, ExtImpMobkoi extImpMobkoi) {
-        if (StringUtils.isNotBlank(firstImp.getTagid())) {
-            return firstImp;
-        }
-
         if (StringUtils.isNotBlank(extImpMobkoi.getPlacementId())) {
             return firstImp.toBuilder().tagid(extImpMobkoi.getPlacementId()).build();
+        }
+
+        if (StringUtils.isNotBlank(firstImp.getTagid())) {
+            return firstImp;
         }
 
         throw new PreBidException("invalid because it comes with neither request.imp[0].tagId nor "


### PR DESCRIPTION
### 🔧 Type of changes

- [x] bid adapter update

### ✨ What's the context?

We have a discrepancy between our Prebid Server and our Tag/PrebidJS integration. It’s not replacing the `bidrequest.Imp[0].TagID` with our internal value when a TagID is already present. We are able to deliver because the value is set in the `bidrequest.Imp[0].Ext.placementID` field, but this creates discrepancies between the connectors, and it’s not ideal.
