### PR TITLE
Teal: Add GPP params to usersync

### DIFF
--- a/src/main/resources/bidder-config/teal.yaml
+++ b/src/main/resources/bidder-config/teal.yaml
@@ -26,5 +26,5 @@ adapters:
     usersync:
       cookie-family-name: teal
       iframe:
-        url: https://bids.ws/load-pbs.html?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&redirect_url={{redirect_url}}
+        url: https://bids.ws/load-pbs.html?gdpr={{gdpr}}&gdpr_consent={{gdpr_consent}}&us_privacy={{us_privacy}}&gpp={{gpp}}&gpp_sid={{gpp_sid}}&redirect_url={{redirect_url}}
         support-cors: false


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
US privacy is deprecated, endpoint already supports GPP

### 🧠 Rationale behind the change
Missed the params in initial version

### 🔎 New Bid Adapter Checklist
- [x] verify email contact works
- [x] NO fully dynamic hostnames
- [x] geographic host parameters are NOT required
- [x] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [x] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [x] cover an adapter configuration with an integration test

### 🧪 Test plan
Config change has been tested

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
