### PR TITLE
Missena Bid Adapter: add GPP params to cookie sync URL

### DIFF
--- a/src/main/resources/bidder-config/missena.yaml
+++ b/src/main/resources/bidder-config/missena.yaml
@@ -1,6 +1,7 @@
 adapters:
   missena:
     endpoint: https://bid.missena.io/?t={{PublisherID}}
+    endpoint-compression: gzip
     meta-info:
       maintainer-email: prebid@missena.com
       modifying-vast-xml-allowed: true


### PR DESCRIPTION
Append `gpp` and `gpp_sid` macros to the usersync iframe URL so that GPP consent data is forwarded during cookie sync.

### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [x] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
The Missena usersync iframe URL currently passes GDPR (`gdpr`, `consent`) and US Privacy (`us_privacy`) parameters but does not forward GPP consent data. The IAB's Global Privacy Platform has superseded US Privacy strings, and Prebid Server already resolves `{{gpp}}` and `{{gpp_sid}}` macros in usersync URLs.

### 🧠 Rationale behind the change
Adding `gpp={{gpp}}&gpp_sid={{gpp_sid}}` to the existing usersync URL ensures that GPP consent signals are forwarded to the Missena sync endpoint. This is a configuration-only change — no code is modified, only the `missena.yaml` bidder config file. Existing GDPR and US Privacy parameters are preserved for backward compatibility.

### 🔎 New Bid Adapter Checklist
N/A — this is a config update to an existing adapter.

### 🧪 Test plan
- Verified that the `{{gpp}}` and `{{gpp_sid}}` macros are supported by Prebid Server Java's usersync URL resolution
- Corresponding Prebid.js client-side change adds GPP support to `getUserSyncs` (PR pending on `prebid/Prebid.js`)
- Corresponding docs change adds `gpp_sids` declaration to `dev-docs/bidders/missena.md` (PR pending on `prebid/prebid.github.io`)

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code? — No
- [x] Does your test coverage exceed 90%? — N/A, config-only change
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes? — No