### PR TITLE
LI id module: Fixing permission logic

### DIFF
--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -44,6 +44,7 @@ import org.prebid.server.util.ListUtil;
 import org.prebid.server.vertx.httpclient.HttpClient;
 import org.prebid.server.vertx.httpclient.model.HttpClientResponse;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -57,6 +58,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
             LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.class));
 
     private static final String CODE = "liveintent-omni-channel-identity-enrichment-hook";
+
+    private static final String INSERTER = "server";
 
     private final LiveIntentOmniChannelProperties config;
     private final JacksonMapper mapper;
@@ -161,7 +164,11 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private IdResResponse processResponse(HttpClientResponse response) {
-        return mapper.decodeValue(response.getBody(), IdResResponse.class);
+        final IdResResponse res = mapper.decodeValue(response.getBody(), IdResResponse.class);
+        final List<Eid> eids = res.getEids().stream()
+                .map(eid -> eid.toBuilder().inserter(INSERTER).build())
+                .toList();
+        return IdResResponse.of(eids);
     }
 
     private static Future<InvocationResult<AuctionRequestPayload>> noAction() {
@@ -208,14 +215,6 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
         final ExtRequestPrebidData extPrebidData = extPrebid != null ? extPrebid.getData() : null;
 
-        final List<ExtRequestPrebidDataEidPermissions> existingPerms = extPrebidData != null
-                ? extPrebidData.getEidPermissions()
-                : null;
-
-        if (CollectionUtils.isEmpty(existingPerms)) {
-            return bidRequest;
-        }
-
         final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
                 .map(ExtRequestPrebid::toBuilder)
                 .orElseGet(ExtRequestPrebid::builder)
@@ -237,7 +236,11 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
                 .map(Eid::getSource)
                 .collect(Collectors.toSet());
 
-        final List<ExtRequestPrebidDataEidPermissions> updatedPermissions = extPrebidData.getEidPermissions().stream()
+        final List<ExtRequestPrebidDataEidPermissions> eidPermissions = extPrebidData != null
+                ? ListUtils.emptyIfNull(extPrebidData.getEidPermissions())
+                : Collections.emptyList();
+
+        final List<ExtRequestPrebidDataEidPermissions> updatedPermissions = eidPermissions.stream()
                 .map(permission -> restrictEidPermission(permission, resolvedSources))
                 .filter(Objects::nonNull)
                 .toList();
@@ -252,16 +255,24 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
             return permission;
         }
 
+        final List<String> permittedBidders = ListUtils.emptyIfNull(permission.getBidders());
+
+        if (CollectionUtils.isEmpty(permittedBidders) || permittedBidders.contains("*")) {
+            return ExtRequestPrebidDataEidPermissions.builder()
+                    .source(permission.getSource())
+                    .bidders(targetBidders.stream().toList())
+                    .build();
+        }
+
         final List<String> finalBidders = ListUtils.emptyIfNull(permission.getBidders()).stream()
                 .filter(targetBidders::contains)
                 .toList();
 
         return CollectionUtils.isEmpty(finalBidders)
                 ? null
-                : ExtRequestPrebidDataEidPermissions
-                .builder()
-                .bidders(finalBidders)
+                : ExtRequestPrebidDataEidPermissions.builder()
                 .source(permission.getSource())
+                .bidders(finalBidders)
                 .build();
     }
 

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -273,7 +273,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
-                .isEqualTo(List.of(givenEid, expectedEid));
+                .isEqualTo(List.of(givenEid, expectedEid.toBuilder().inserter("server").build()));
 
         verify(httpClient).post(
                 eq("https://test.com/idres"),
@@ -315,7 +315,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
-                .isEqualTo(List.of(expectedEid));
+                .isEqualTo(List.of(expectedEid.toBuilder().inserter("server").build()));
 
         verify(httpClient).post(
                 eq("https://test.com/idres"),


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Fixing permission logic: empty permissions in bid request are treated as "allow all". A case of `*` is included.

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
