### PR TITLE
Adipolo: Add GVL ID

### DIFF
--- a/src/main/resources/bidder-config/xeworks.yaml
+++ b/src/main/resources/bidder-config/xeworks.yaml
@@ -12,6 +12,7 @@ adapters:
         endpoint: http://rtb.adipolo.live?pid={{SourceId}}&host={{Host}}&pbs=1
         meta-info:
           maintainer-email: smart@adipolo.com
+          vendor-id: 1456
         usersync:
           enabled: true
           cookie-family-name: adipolo


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

Adipolo GLV ID 1456 added as vendor-id property.