### PR TITLE
51Degrees module: extend device detection module with new fields

### DIFF
--- a/extra/modules/fiftyone-devicedetection/pom.xml
+++ b/extra/modules/fiftyone-devicedetection/pom.xml
@@ -14,7 +14,7 @@
     <description>51Degrees Device Detection module</description>
 
     <properties>
-        <fiftyone-device-detection.version>4.4.226</fiftyone-device-detection.version>
+        <fiftyone-device-detection.version>4.5.51</fiftyone-device-detection.version>
     </properties>
 
     <dependencies>

--- a/extra/modules/fiftyone-devicedetection/src/main/java/org/prebid/server/hooks/modules/fiftyone/devicedetection/v1/core/DeviceEnricher.java
+++ b/extra/modules/fiftyone-devicedetection/src/main/java/org/prebid/server/hooks/modules/fiftyone/devicedetection/v1/core/DeviceEnricher.java
@@ -97,6 +97,12 @@ public class DeviceEnricher {
             updatedFields.add("model");
         }
 
+        final UpdateResult<String> resolvedHwv = resolveDeviceHwv(device, deviceData);
+        if (resolvedHwv.isUpdated()) {
+            deviceBuilder.hwv(resolvedHwv.getValue());
+            updatedFields.add("hwv");
+        }
+
         final UpdateResult<String> resolvedOs = resolveOs(device, deviceData);
         if (resolvedOs.isUpdated()) {
             deviceBuilder.os(resolvedOs.getValue());
@@ -182,6 +188,11 @@ public class DeviceEnricher {
         final String currentModel = device.getModel();
         if (StringUtils.isNotBlank(currentModel)) {
             return UpdateResult.unaltered(currentModel);
+        }
+
+        final String hardwareNamePrefix = getSafe(deviceData, DeviceData::getHardwareNamePrefix);
+        if (StringUtils.isNotBlank(hardwareNamePrefix)) {
+            return UpdateResult.updated(hardwareNamePrefix);
         }
 
         final String model = getSafe(deviceData, DeviceData::getHardwareModel);
@@ -282,6 +293,18 @@ public class DeviceEnricher {
         return StringUtils.isNotBlank(deviceID)
                 ? UpdateResult.updated(deviceID)
                 : UpdateResult.unaltered(currentDeviceId);
+    }
+
+    private UpdateResult<String> resolveDeviceHwv(Device device, DeviceData deviceData) {
+        final String currentDeviceHwv = device.getHwv();
+        if (StringUtils.isNotEmpty(currentDeviceHwv)) {
+            return UpdateResult.unaltered(currentDeviceHwv);
+        }
+
+        final String deviceHwv = getSafe(deviceData, DeviceData::getHardwareNameVersion);
+        return StringUtils.isNotEmpty(deviceHwv)
+                ? UpdateResult.updated(deviceHwv)
+                : UpdateResult.unaltered(currentDeviceHwv);
     }
 
     private static boolean isPositive(Integer value) {

--- a/extra/modules/fiftyone-devicedetection/src/test/java/org/prebid/server/hooks/modules/fiftyone/devicedetection/v1/core/DeviceEnricherTest.java
+++ b/extra/modules/fiftyone-devicedetection/src/test/java/org/prebid/server/hooks/modules/fiftyone/devicedetection/v1/core/DeviceEnricherTest.java
@@ -273,6 +273,7 @@ public class DeviceEnricherTest {
                 "devicetype",
                 "make",
                 "model",
+                "hwv",
                 "os",
                 "osv",
                 "h",
@@ -336,6 +337,28 @@ public class DeviceEnricherTest {
     }
 
     @Test
+    public void populateDeviceInfoShouldEnrichModelWithHardwareNamePrefixWhenItIsMissing() throws Exception {
+        // given
+        final Device testDevice = buildCompleteDevice().toBuilder()
+                .model(null)
+                .build();
+        final String expectedModel = "NinjaTech";
+        when(deviceData.getHardwareNamePrefix())
+                .thenReturn(aspectPropertyValueWith(expectedModel));
+        when(deviceData.getHardwareModel()).thenThrow(new RuntimeException());
+
+        // when
+        final CollectedEvidence collectedEvidence = CollectedEvidence.builder()
+                .deviceUA("fake-UserAgent")
+                .build();
+        final EnrichmentResult result = target.populateDeviceInfo(testDevice, collectedEvidence);
+
+        // then
+        assertThat(result.enrichedFields()).hasSize(1);
+        assertThat(result.enrichedDevice().getModel()).isEqualTo(expectedModel);
+    }
+
+    @Test
     public void populateDeviceInfoShouldEnrichModelWithHWNameWhenHWModelIsMissing() throws Exception {
         // given
         final Device testDevice = buildCompleteDevice().toBuilder()
@@ -366,6 +389,7 @@ public class DeviceEnricherTest {
 
         // when
         buildCompleteDeviceData();
+        when(deviceData.getHardwareNamePrefix()).thenReturn(null);
         final CollectedEvidence collectedEvidence = CollectedEvidence.builder()
                 .deviceUA("fake-UserAgent")
                 .build();
@@ -374,6 +398,28 @@ public class DeviceEnricherTest {
         // then
         assertThat(result.enrichedFields()).hasSize(1);
         assertThat(result.enrichedDevice().getModel()).isEqualTo(buildCompleteDevice().getModel());
+    }
+
+    @Test
+    public void populateDeviceInfoShouldEnrichHwvWithHardwareNameVersionWhenItIsMissing() throws Exception {
+        // given
+        final Device testDevice = buildCompleteDevice().toBuilder()
+                .hwv(null)
+                .build();
+        final String expectedHwv = "NinjaTech";
+        when(deviceData.getHardwareNameVersion())
+                .thenReturn(aspectPropertyValueWith(expectedHwv));
+        when(deviceData.getHardwareModel()).thenReturn(null);
+
+        // when
+        final CollectedEvidence collectedEvidence = CollectedEvidence.builder()
+                .deviceUA("fake-UserAgent")
+                .build();
+        final EnrichmentResult result = target.populateDeviceInfo(testDevice, collectedEvidence);
+
+        // then
+        assertThat(result.enrichedFields()).hasSize(1);
+        assertThat(result.enrichedDevice().getHwv()).isEqualTo(expectedHwv);
     }
 
     @Test
@@ -534,6 +580,7 @@ public class DeviceEnricherTest {
                 .devicetype(1)
                 .make("StarFleet")
                 .model("communicator")
+                .hwv("hmv")
                 .os("NeutronAI")
                 .osv("X-502")
                 .h(5051)
@@ -551,6 +598,8 @@ public class DeviceEnricherTest {
         when(deviceData.getHardwareVendor()).thenReturn(aspectPropertyValueWith("StarFleet"));
         when(deviceData.getHardwareModel()).thenReturn(aspectPropertyValueWith("communicator"));
         when(deviceData.getPlatformName()).thenReturn(aspectPropertyValueWith("NeutronAI"));
+        when(deviceData.getHardwareNamePrefix()).thenReturn(aspectPropertyValueWith("Prefix"));
+        when(deviceData.getHardwareNameVersion()).thenReturn(aspectPropertyValueWith("Version"));
         when(deviceData.getPlatformVersion()).thenReturn(aspectPropertyValueWith("X-502"));
         when(deviceData.getScreenPixelsHeight()).thenReturn(aspectPropertyValueWith(5051));
         when(deviceData.getScreenPixelsWidth()).thenReturn(aspectPropertyValueWith(3001));


### PR DESCRIPTION
## 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [x] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [x] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

## Description of change
51Degrees module now populates device.hwv and introduces smarter logic populating device.model with a less specific HardwareNamePrefix property that would exclude specific device version. F.e. if HardwareName is iPhone 12 Pro Max, HardwareNamePrefix would be iPhone and HardwareNameVersion would be 12 Pro Max.
This PR should improve chances of correct targeting for bidders that expect a less specific model name and prefer receiving hardware version separately.

### 🧪 Test plan
- Changes are covered by unit tests
- Manual testing

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
