### PR TITLE
LI module: Use matcher instead of source for eid premission

### DIFF
--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -218,6 +218,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
+        // can just use the constant MATCHER here
         final Set<String> uniqueMatcher = CollectionUtils.emptyIfNull(resolvedEids).stream()
                 .map(Eid::getMatcher)
                 .filter(StringUtils::isNotEmpty)
@@ -259,10 +260,10 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
                 .build();
     }
 
-    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions(Set<String> matcher) {
-        return matcher.stream()
-                .map(liMatcher -> ExtRequestPrebidDataEidPermissions.builder()
-                        .matcher(liMatcher)
+    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions(Set<String> matchers) {
+        return matchers.stream()
+                .map(matcherInEid -> ExtRequestPrebidDataEidPermissions.builder()
+                        .matcher(matcherInEid)
                         .inserter(INSERTER)
                         .bidders(targetBidders.stream().toList())
                         .build())

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -59,7 +59,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private static final String INSERTER = "s2s.liveintent.com";
 
-    private static final String MATCHER = "liveintentStamp";
+    // from ulysses
+    private static final String MATCHER = "liveintent.com";
 
     private final LiveIntentOmniChannelProperties config;
     private final JacksonMapper mapper;

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -59,7 +59,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private static final String INSERTER = "s2s.liveintent.com";
 
-    // the IdResResponse is already stamped by Ulysses with "liveintent.com" as matcher
+    // IdResResponse is already stamped by Ulysses, in the EID's matcher field, it has "liveintent.com"
     private static final String MATCHER = "liveintent.com";
 
     private final LiveIntentOmniChannelProperties config;

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -10,7 +10,6 @@ import io.vertx.core.MultiMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.activity.Activity;
 import org.prebid.server.activity.ComponentType;
 import org.prebid.server.activity.infrastructure.ActivityInfrastructure;
@@ -50,269 +49,271 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements ProcessedAuctionRequestHook {
 
-    private static final ConditionalLogger conditionalLogger = new ConditionalLogger(LoggerFactory.getLogger(
-            LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.class));
+        private static final ConditionalLogger conditionalLogger = new ConditionalLogger(LoggerFactory.getLogger(
+                        LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.class));
 
-    private static final String CODE = "liveintent-omni-channel-identity-enrichment-hook";
+        private static final String CODE = "liveintent-omni-channel-identity-enrichment-hook";
 
-    private static final String INSERTER = "s2s.liveintent.com";
+        private static final String INSERTER = "s2s.liveintent.com";
 
-    private static final String MATCHER = "itsLiveintent";
+        private static final String MATCHER = "liveintentStamp";
 
-    private final LiveIntentOmniChannelProperties config;
-    private final JacksonMapper mapper;
-    private final HttpClient httpClient;
-    private final UserFpdActivityMask userFpdActivityMask;
-    private final double logSamplingRate;
-    private final Set<String> targetBidders;
+        private final LiveIntentOmniChannelProperties config;
+        private final JacksonMapper mapper;
+        private final HttpClient httpClient;
+        private final UserFpdActivityMask userFpdActivityMask;
+        private final double logSamplingRate;
+        private final Set<String> targetBidders;
 
-    public LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(LiveIntentOmniChannelProperties config,
-                                                                    UserFpdActivityMask userFpdActivityMask,
-                                                                    JacksonMapper mapper,
-                                                                    HttpClient httpClient,
-                                                                    double logSamplingRate) {
+        public LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(LiveIntentOmniChannelProperties config,
+                        UserFpdActivityMask userFpdActivityMask,
+                        JacksonMapper mapper,
+                        HttpClient httpClient,
+                        double logSamplingRate) {
 
-        this.config = Objects.requireNonNull(config);
-        HttpUtil.validateUrlSyntax(config.getIdentityResolutionEndpoint());
-        this.mapper = Objects.requireNonNull(mapper);
-        this.httpClient = Objects.requireNonNull(httpClient);
-        this.logSamplingRate = logSamplingRate;
-        this.userFpdActivityMask = Objects.requireNonNull(userFpdActivityMask);
-        this.targetBidders = SetUtils.emptyIfNull(config.getTargetBidders());
-    }
-
-    @Override
-    public Future<InvocationResult<AuctionRequestPayload>> call(AuctionRequestPayload auctionRequestPayload,
-                                                                AuctionInvocationContext invocationContext) {
-
-        return config.getTreatmentRate() > ThreadLocalRandom.current().nextFloat()
-                ? requestIdentities(auctionRequestPayload.bidRequest(), invocationContext.auctionContext())
-                .<InvocationResult<AuctionRequestPayload>>map(this::update)
-                .onFailure(throwable -> conditionalLogger.error(
-                        "Failed enrichment: %s".formatted(throwable.getMessage()), logSamplingRate))
-                : noAction();
-    }
-
-    private Future<IdResResponse> requestIdentities(BidRequest bidRequest, AuctionContext auctionContext) {
-        final BidRequest restrictedBidRequest = applyActivityRestrictions(bidRequest, auctionContext);
-        return httpClient.post(
-                        config.getIdentityResolutionEndpoint(),
-                        headers(),
-                        mapper.encodeToString(restrictedBidRequest),
-                        config.getRequestTimeoutMs())
-                .map(this::processResponse);
-    }
-
-    private BidRequest applyActivityRestrictions(BidRequest bidRequest, AuctionContext auctionContext) {
-        final ActivityInvocationPayload activityInvocationPayload = BidRequestActivityInvocationPayload.of(
-                ActivityInvocationPayloadImpl.of(
-                        ComponentType.GENERAL_MODULE,
-                        LiveIntentOmniChannelIdentityModule.CODE),
-                bidRequest);
-        final ActivityInfrastructure activityInfrastructure = auctionContext.getActivityInfrastructure();
-
-        final boolean disallowTransmitUfpd = !activityInfrastructure.isAllowed(
-                Activity.TRANSMIT_UFPD, activityInvocationPayload);
-        final boolean disallowTransmitEids = !activityInfrastructure.isAllowed(
-                Activity.TRANSMIT_EIDS, activityInvocationPayload);
-        final boolean disallowTransmitGeo = !activityInfrastructure.isAllowed(
-                Activity.TRANSMIT_GEO, activityInvocationPayload);
-        final boolean disallowTransmitTid = !activityInfrastructure.isAllowed(
-                Activity.TRANSMIT_TID, activityInvocationPayload);
-
-        return maskUserPersonalInfo(
-                bidRequest,
-                disallowTransmitUfpd,
-                disallowTransmitEids,
-                disallowTransmitGeo,
-                disallowTransmitTid);
-    }
-
-    private BidRequest maskUserPersonalInfo(BidRequest bidRequest,
-                                            boolean disallowTransmitUfpd,
-                                            boolean disallowTransmitEids,
-                                            boolean disallowTransmitGeo,
-                                            boolean disallowTransmitTid) {
-
-        final User maskedUser = userFpdActivityMask.maskUser(
-                bidRequest.getUser(), disallowTransmitUfpd, disallowTransmitEids);
-        final Device maskedDevice = userFpdActivityMask.maskDevice(
-                bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
-
-        final Source maskedSource = maskSource(bidRequest.getSource(), disallowTransmitUfpd, disallowTransmitTid);
-
-        return bidRequest.toBuilder()
-                .user(maskedUser)
-                .device(maskedDevice)
-                .source(maskedSource)
-                .build();
-    }
-
-    private Source maskSource(Source source, boolean mastUfpd, boolean maskTid) {
-        if (source == null || !(mastUfpd || maskTid)) {
-            return source;
+                this.config = Objects.requireNonNull(config);
+                HttpUtil.validateUrlSyntax(config.getIdentityResolutionEndpoint());
+                this.mapper = Objects.requireNonNull(mapper);
+                this.httpClient = Objects.requireNonNull(httpClient);
+                this.logSamplingRate = logSamplingRate;
+                this.userFpdActivityMask = Objects.requireNonNull(userFpdActivityMask);
+                this.targetBidders = SetUtils.emptyIfNull(config.getTargetBidders());
         }
 
-        return source.toBuilder().tid(null).build();
-    }
+        @Override
+        public Future<InvocationResult<AuctionRequestPayload>> call(AuctionRequestPayload auctionRequestPayload,
+                        AuctionInvocationContext invocationContext) {
 
-    private MultiMap headers() {
-        return MultiMap.caseInsensitiveMultiMap()
-                .add(HttpUtil.AUTHORIZATION_HEADER, "Bearer " + config.getAuthToken());
-    }
-
-    private IdResResponse processResponse(HttpClientResponse response) {
-        final IdResResponse res = mapper.decodeValue(response.getBody(), IdResResponse.class);
-        final List<Eid> eids = res.getEids();
-
-        if (CollectionUtils.isEmpty(eids)) {
-            return res;
+                return config.getTreatmentRate() > ThreadLocalRandom.current().nextFloat()
+                                ? requestIdentities(auctionRequestPayload.bidRequest(),
+                                                invocationContext.auctionContext())
+                                                .<InvocationResult<AuctionRequestPayload>>map(this::update)
+                                                .onFailure(throwable -> conditionalLogger.error(
+                                                                "Failed enrichment: %s"
+                                                                                .formatted(throwable.getMessage()),
+                                                                logSamplingRate))
+                                : noAction();
         }
 
-        final List<Eid> modifiedEids = eids.stream()
-                .map(eid -> eid.toBuilder().inserter(INSERTER).matcher(MATCHER).build())
-                .toList();
-
-        return IdResResponse.of(modifiedEids);
-    }
-
-    private static Future<InvocationResult<AuctionRequestPayload>> noAction() {
-        return Future.succeededFuture(InvocationResultImpl.<AuctionRequestPayload>builder()
-                .status(InvocationStatus.success)
-                .action(InvocationAction.no_action)
-                .build());
-    }
-
-    private InvocationResultImpl<AuctionRequestPayload> update(IdResResponse resolutionResult) {
-        return InvocationResultImpl.<AuctionRequestPayload>builder()
-                .status(InvocationStatus.success)
-                .action(InvocationAction.update)
-                .payloadUpdate(payload -> updatedPayload(payload, resolutionResult.getEids()))
-                .analyticsTags(TagsImpl.of(List.of(
-                        ActivityImpl.of(
-                                "liveintent-enriched", "success",
-                                List.of(
-                                        ResultImpl.of(
-                                                "",
-                                                mapper.mapper().createObjectNode()
-                                                        .put("treatmentRate", config.getTreatmentRate()),
-                                                null))))))
-                .build();
-    }
-
-    private AuctionRequestPayload updatedPayload(AuctionRequestPayload requestPayload, List<Eid> resolvedEids) {
-        return CollectionUtils.isNotEmpty(resolvedEids)
-                ? AuctionRequestPayloadImpl.of(updateBidRequest(requestPayload.bidRequest(), resolvedEids))
-                : requestPayload;
-    }
-
-    private BidRequest updateBidRequest(BidRequest bidRequest, List<Eid> resolvedEids) {
-        return bidRequest.toBuilder()
-                .ext(updateExtRequest(bidRequest.getExt(), resolvedEids))
-                .user(updateUser(bidRequest.getUser(), resolvedEids))
-                .build();
-    }
-
-    private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
-        // can just use the constant MATCHER here
-        final Set<String> uniqueMatcher = CollectionUtils.emptyIfNull(resolvedEids).stream()
-                .map(Eid::getMatcher)
-                .filter(StringUtils::isNotEmpty)
-                .collect(Collectors.toSet());
-
-        final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
-        final ExtRequestPrebidData extPrebidData = extPrebid != null ? extPrebid.getData() : null;
-        final List<ExtRequestPrebidDataEidPermissions> eidPermissions =
-                extPrebidData != null ? extPrebidData.getEidPermissions() : null;
-
-        final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils.isEmpty(eidPermissions)
-                ? createEidPermissions(uniqueMatcher)
-                : modifyEidPermissions(eidPermissions, uniqueMatcher);
-
-        final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
-                .map(ExtRequestPrebid::toBuilder)
-                .orElseGet(ExtRequestPrebid::builder)
-                .data(updatePrebidData(extPrebidData, modifiedEidPermissions))
-                .build();
-
-        final ExtRequest updatedExtRequest = ExtRequest.of(updatedExtPrebid);
-        if (ext != null) {
-            mapper.fillExtension(updatedExtRequest, ext.getProperties());
+        private Future<IdResResponse> requestIdentities(BidRequest bidRequest, AuctionContext auctionContext) {
+                final BidRequest restrictedBidRequest = applyActivityRestrictions(bidRequest, auctionContext);
+                return httpClient.post(
+                                config.getIdentityResolutionEndpoint(),
+                                headers(),
+                                mapper.encodeToString(restrictedBidRequest),
+                                config.getRequestTimeoutMs())
+                                .map(this::processResponse);
         }
 
-        return updatedExtRequest;
-    }
+        private BidRequest applyActivityRestrictions(BidRequest bidRequest, AuctionContext auctionContext) {
+                final ActivityInvocationPayload activityInvocationPayload = BidRequestActivityInvocationPayload.of(
+                                ActivityInvocationPayloadImpl.of(
+                                                ComponentType.GENERAL_MODULE,
+                                                LiveIntentOmniChannelIdentityModule.CODE),
+                                bidRequest);
+                final ActivityInfrastructure activityInfrastructure = auctionContext.getActivityInfrastructure();
 
-    private static User updateUser(User user, List<Eid> resolvedEids) {
-        final List<Eid> updatedEids = Optional.ofNullable(user)
-                .map(User::getEids)
-                .map(eids -> ListUtil.union(eids, resolvedEids))
-                .orElse(resolvedEids);
+                final boolean disallowTransmitUfpd = !activityInfrastructure.isAllowed(
+                                Activity.TRANSMIT_UFPD, activityInvocationPayload);
+                final boolean disallowTransmitEids = !activityInfrastructure.isAllowed(
+                                Activity.TRANSMIT_EIDS, activityInvocationPayload);
+                final boolean disallowTransmitGeo = !activityInfrastructure.isAllowed(
+                                Activity.TRANSMIT_GEO, activityInvocationPayload);
+                final boolean disallowTransmitTid = !activityInfrastructure.isAllowed(
+                                Activity.TRANSMIT_TID, activityInvocationPayload);
 
-        return Optional.ofNullable(user)
-                .map(User::toBuilder)
-                .orElseGet(User::builder)
-                .eids(updatedEids)
-                .build();
-    }
-
-    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions(Set<String> matchers) {
-        return matchers.stream()
-                .map(matcherInEid -> ExtRequestPrebidDataEidPermissions.builder()
-                        .matcher(matcherInEid)
-                        .inserter(INSERTER)
-                        .bidders(targetBidders.stream().toList())
-                        .build())
-                .toList();
-    }
-
-    private List<ExtRequestPrebidDataEidPermissions> modifyEidPermissions(
-            List<ExtRequestPrebidDataEidPermissions> eidPermissions,
-            Set<String> matcher) {
-        final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = eidPermissions.stream()
-                .map(it -> updateEidPermission(it, matcher))
-                .filter(Objects::nonNull)
-                .toList();
-        final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions(matcher);
-        return ListUtils.union(modifiedEidPermissions, defaultEidPermissions);
-    }
-
-    private ExtRequestPrebidData updatePrebidData(ExtRequestPrebidData extPrebidData,
-                                                  List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
-
-        final List<String> originalBidders = extPrebidData != null ? extPrebidData.getBidders() : null;
-
-        return ExtRequestPrebidData.of(originalBidders, eidPermissions);
-    }
-
-    private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission,
-                                                                   Set<String> matcher) {
-        if (!matcher.contains(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
-            return eidPermission;
+                return maskUserPersonalInfo(
+                                bidRequest,
+                                disallowTransmitUfpd,
+                                disallowTransmitEids,
+                                disallowTransmitGeo,
+                                disallowTransmitTid);
         }
 
-        final List<String> allowedBidders = ListUtils.emptyIfNull(eidPermission.getBidders());
-        final List<String> finalBidders = allowedBidders.stream()
-                .filter(targetBidders::contains)
-                .toList();
+        private BidRequest maskUserPersonalInfo(BidRequest bidRequest,
+                        boolean disallowTransmitUfpd,
+                        boolean disallowTransmitEids,
+                        boolean disallowTransmitGeo,
+                        boolean disallowTransmitTid) {
 
-        if (CollectionUtils.isEmpty(allowedBidders) || allowedBidders.contains("*")) {
-            return eidPermission.toBuilder().bidders(targetBidders.stream().toList()).build();
+                final User maskedUser = userFpdActivityMask.maskUser(
+                                bidRequest.getUser(), disallowTransmitUfpd, disallowTransmitEids);
+                final Device maskedDevice = userFpdActivityMask.maskDevice(
+                                bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
+
+                final Source maskedSource = maskSource(bidRequest.getSource(), disallowTransmitUfpd,
+                                disallowTransmitTid);
+
+                return bidRequest.toBuilder()
+                                .user(maskedUser)
+                                .device(maskedDevice)
+                                .source(maskedSource)
+                                .build();
         }
 
-        if (CollectionUtils.isEmpty(finalBidders)) {
-            return null;
+        private Source maskSource(Source source, boolean mastUfpd, boolean maskTid) {
+                if (source == null || !(mastUfpd || maskTid)) {
+                        return source;
+                }
+
+                return source.toBuilder().tid(null).build();
         }
 
-        return eidPermission.toBuilder().bidders(finalBidders).build();
-    }
+        private MultiMap headers() {
+                return MultiMap.caseInsensitiveMultiMap()
+                                .add(HttpUtil.AUTHORIZATION_HEADER, "Bearer " + config.getAuthToken());
+        }
 
-    @Override
-    public String code() {
-        return CODE;
-    }
+        private IdResResponse processResponse(HttpClientResponse response) {
+                final IdResResponse res = mapper.decodeValue(response.getBody(), IdResResponse.class);
+                final List<Eid> eids = res.getEids();
+
+                if (CollectionUtils.isEmpty(eids)) {
+                        return res;
+                }
+
+                final List<Eid> modifiedEids = eids.stream()
+                                .map(eid -> eid.toBuilder().inserter(INSERTER).matcher(MATCHER).build())
+                                .toList();
+
+                return IdResResponse.of(modifiedEids);
+        }
+
+        private static Future<InvocationResult<AuctionRequestPayload>> noAction() {
+                return Future.succeededFuture(InvocationResultImpl.<AuctionRequestPayload>builder()
+                                .status(InvocationStatus.success)
+                                .action(InvocationAction.no_action)
+                                .build());
+        }
+
+        private InvocationResultImpl<AuctionRequestPayload> update(IdResResponse resolutionResult) {
+                return InvocationResultImpl.<AuctionRequestPayload>builder()
+                                .status(InvocationStatus.success)
+                                .action(InvocationAction.update)
+                                .payloadUpdate(payload -> updatedPayload(payload, resolutionResult.getEids()))
+                                .analyticsTags(TagsImpl.of(List.of(
+                                                ActivityImpl.of(
+                                                                "liveintent-enriched", "success",
+                                                                List.of(
+                                                                                ResultImpl.of(
+                                                                                                "",
+                                                                                                mapper.mapper().createObjectNode()
+                                                                                                                .put("treatmentRate",
+                                                                                                                                config.getTreatmentRate()),
+                                                                                                null))))))
+                                .build();
+        }
+
+        private AuctionRequestPayload updatedPayload(AuctionRequestPayload requestPayload, List<Eid> resolvedEids) {
+                return CollectionUtils.isNotEmpty(resolvedEids)
+                                ? AuctionRequestPayloadImpl
+                                                .of(updateBidRequest(requestPayload.bidRequest(), resolvedEids))
+                                : requestPayload;
+        }
+
+        private BidRequest updateBidRequest(BidRequest bidRequest, List<Eid> resolvedEids) {
+                return bidRequest.toBuilder()
+                                .ext(updateExtRequest(bidRequest.getExt(), resolvedEids))
+                                .user(updateUser(bidRequest.getUser(), resolvedEids))
+                                .build();
+        }
+
+        private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
+                if (CollectionUtils.isEmpty(resolvedEids)) {
+                        return ext;
+                }
+
+                final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
+                final ExtRequestPrebidData extPrebidData = extPrebid != null ? extPrebid.getData() : null;
+                final List<ExtRequestPrebidDataEidPermissions> eidPermissions = extPrebidData != null
+                                ? extPrebidData.getEidPermissions()
+                                : null;
+
+                final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils
+                                .isEmpty(eidPermissions)
+                                                ? createEidPermissions()
+                                                : modifyEidPermissions(eidPermissions);
+
+                final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
+                                .map(ExtRequestPrebid::toBuilder)
+                                .orElseGet(ExtRequestPrebid::builder)
+                                .data(updatePrebidData(extPrebidData, modifiedEidPermissions))
+                                .build();
+
+                final ExtRequest updatedExtRequest = ExtRequest.of(updatedExtPrebid);
+                if (ext != null) {
+                        mapper.fillExtension(updatedExtRequest, ext.getProperties());
+                }
+
+                return updatedExtRequest;
+        }
+
+        private static User updateUser(User user, List<Eid> resolvedEids) {
+                final List<Eid> updatedEids = Optional.ofNullable(user)
+                                .map(User::getEids)
+                                .map(eids -> ListUtil.union(eids, resolvedEids))
+                                .orElse(resolvedEids);
+
+                return Optional.ofNullable(user)
+                                .map(User::toBuilder)
+                                .orElseGet(User::builder)
+                                .eids(updatedEids)
+                                .build();
+        }
+
+        private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
+                return List.of(ExtRequestPrebidDataEidPermissions.builder()
+                                .matcher(MATCHER)
+                                .inserter(INSERTER)
+                                .bidders(targetBidders.stream().toList())
+                                .build());
+        }
+
+        private List<ExtRequestPrebidDataEidPermissions> modifyEidPermissions(
+                        List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
+                final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = eidPermissions.stream()
+                                .map(this::updateEidPermission)
+                                .filter(Objects::nonNull)
+                                .toList();
+                final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions();
+                return ListUtils.union(modifiedEidPermissions, defaultEidPermissions);
+        }
+
+        private ExtRequestPrebidData updatePrebidData(ExtRequestPrebidData extPrebidData,
+                        List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
+
+                final List<String> originalBidders = extPrebidData != null ? extPrebidData.getBidders() : null;
+
+                return ExtRequestPrebidData.of(originalBidders, eidPermissions);
+        }
+
+        private ExtRequestPrebidDataEidPermissions updateEidPermission(
+                        ExtRequestPrebidDataEidPermissions eidPermission) {
+                if (!MATCHER.equals(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
+                        return eidPermission;
+                }
+
+                final List<String> allowedBidders = ListUtils.emptyIfNull(eidPermission.getBidders());
+                final List<String> finalBidders = allowedBidders.stream()
+                                .filter(targetBidders::contains)
+                                .toList();
+
+                if (CollectionUtils.isEmpty(allowedBidders) || allowedBidders.contains("*")) {
+                        return eidPermission.toBuilder().bidders(targetBidders.stream().toList()).build();
+                }
+
+                if (CollectionUtils.isEmpty(finalBidders)) {
+                        return null;
+                }
+
+                return eidPermission.toBuilder().bidders(finalBidders).build();
+        }
+
+        @Override
+        public String code() {
+                return CODE;
+        }
 }

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -59,7 +59,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private static final String INSERTER = "s2s.liveintent.com";
 
-    // from ulysses
+    // the IdResResponse is already stamped by Ulysses with "liveintent.com" as matcher
     private static final String MATCHER = "liveintent.com";
 
     private final LiveIntentOmniChannelProperties config;
@@ -173,7 +173,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         }
 
         final List<Eid> modifiedEids = eids.stream()
-                .map(eid -> eid.toBuilder().inserter(INSERTER).matcher(MATCHER).build())
+                .map(eid -> eid.toBuilder().inserter(INSERTER).build())
                 .toList();
 
         return IdResResponse.of(modifiedEids);
@@ -260,7 +260,6 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
         return List.of(ExtRequestPrebidDataEidPermissions.builder()
-                                .matcher(MATCHER)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())
                                 .build());

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -52,268 +52,260 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements ProcessedAuctionRequestHook {
 
-        private static final ConditionalLogger conditionalLogger = new ConditionalLogger(LoggerFactory.getLogger(
-                        LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.class));
+    private static final ConditionalLogger conditionalLogger = new ConditionalLogger(LoggerFactory.getLogger(
+            LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.class));
 
-        private static final String CODE = "liveintent-omni-channel-identity-enrichment-hook";
+    private static final String CODE = "liveintent-omni-channel-identity-enrichment-hook";
 
-        private static final String INSERTER = "s2s.liveintent.com";
+    private static final String INSERTER = "s2s.liveintent.com";
 
-        private static final String MATCHER = "liveintentStamp";
+    private static final String MATCHER = "liveintentStamp";
 
-        private final LiveIntentOmniChannelProperties config;
-        private final JacksonMapper mapper;
-        private final HttpClient httpClient;
-        private final UserFpdActivityMask userFpdActivityMask;
-        private final double logSamplingRate;
-        private final Set<String> targetBidders;
+    private final LiveIntentOmniChannelProperties config;
+    private final JacksonMapper mapper;
+    private final HttpClient httpClient;
+    private final UserFpdActivityMask userFpdActivityMask;
+    private final double logSamplingRate;
+    private final Set<String> targetBidders;
 
-        public LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(LiveIntentOmniChannelProperties config,
-                        UserFpdActivityMask userFpdActivityMask,
-                        JacksonMapper mapper,
-                        HttpClient httpClient,
-                        double logSamplingRate) {
+    public LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(LiveIntentOmniChannelProperties config,
+                                                                    UserFpdActivityMask userFpdActivityMask,
+                                                                    JacksonMapper mapper,
+                                                                    HttpClient httpClient,
+                                                                    double logSamplingRate) {
 
-                this.config = Objects.requireNonNull(config);
-                HttpUtil.validateUrlSyntax(config.getIdentityResolutionEndpoint());
-                this.mapper = Objects.requireNonNull(mapper);
-                this.httpClient = Objects.requireNonNull(httpClient);
-                this.logSamplingRate = logSamplingRate;
-                this.userFpdActivityMask = Objects.requireNonNull(userFpdActivityMask);
-                this.targetBidders = SetUtils.emptyIfNull(config.getTargetBidders());
+        this.config = Objects.requireNonNull(config);
+        HttpUtil.validateUrlSyntax(config.getIdentityResolutionEndpoint());
+        this.mapper = Objects.requireNonNull(mapper);
+        this.httpClient = Objects.requireNonNull(httpClient);
+        this.logSamplingRate = logSamplingRate;
+        this.userFpdActivityMask = Objects.requireNonNull(userFpdActivityMask);
+        this.targetBidders = SetUtils.emptyIfNull(config.getTargetBidders());
+    }
+
+    @Override
+    public Future<InvocationResult<AuctionRequestPayload>> call(AuctionRequestPayload auctionRequestPayload,
+                                                                AuctionInvocationContext invocationContext) {
+
+        return config.getTreatmentRate() > ThreadLocalRandom.current().nextFloat()
+                ? requestIdentities(auctionRequestPayload.bidRequest(), invocationContext.auctionContext())
+                .<InvocationResult<AuctionRequestPayload>>map(this::update)
+                .onFailure(throwable -> conditionalLogger.error(
+                        "Failed enrichment: %s".formatted(throwable.getMessage()), logSamplingRate))
+                : noAction();
+    }
+
+    private Future<IdResResponse> requestIdentities(BidRequest bidRequest, AuctionContext auctionContext) {
+        final BidRequest restrictedBidRequest = applyActivityRestrictions(bidRequest, auctionContext);
+        return httpClient.post(
+                        config.getIdentityResolutionEndpoint(),
+                        headers(),
+                        mapper.encodeToString(restrictedBidRequest),
+                        config.getRequestTimeoutMs())
+                .map(this::processResponse);
+    }
+
+    private BidRequest applyActivityRestrictions(BidRequest bidRequest, AuctionContext auctionContext) {
+        final ActivityInvocationPayload activityInvocationPayload = BidRequestActivityInvocationPayload.of(
+                ActivityInvocationPayloadImpl.of(
+                        ComponentType.GENERAL_MODULE,
+                        LiveIntentOmniChannelIdentityModule.CODE),
+                bidRequest);
+        final ActivityInfrastructure activityInfrastructure = auctionContext.getActivityInfrastructure();
+
+        final boolean disallowTransmitUfpd = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_UFPD, activityInvocationPayload);
+        final boolean disallowTransmitEids = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_EIDS, activityInvocationPayload);
+        final boolean disallowTransmitGeo = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_GEO, activityInvocationPayload);
+        final boolean disallowTransmitTid = !activityInfrastructure.isAllowed(
+                Activity.TRANSMIT_TID, activityInvocationPayload);
+
+        return maskUserPersonalInfo(
+                bidRequest,
+                disallowTransmitUfpd,
+                disallowTransmitEids,
+                disallowTransmitGeo,
+                disallowTransmitTid);
+    }
+
+    private BidRequest maskUserPersonalInfo(BidRequest bidRequest,
+                                            boolean disallowTransmitUfpd,
+                                            boolean disallowTransmitEids,
+                                            boolean disallowTransmitGeo,
+                                            boolean disallowTransmitTid) {
+
+        final User maskedUser = userFpdActivityMask.maskUser(
+                bidRequest.getUser(), disallowTransmitUfpd, disallowTransmitEids);
+        final Device maskedDevice = userFpdActivityMask.maskDevice(
+                bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
+
+        final Source maskedSource = maskSource(bidRequest.getSource(), disallowTransmitUfpd, disallowTransmitTid);
+
+        return bidRequest.toBuilder()
+                .user(maskedUser)
+                .device(maskedDevice)
+                .source(maskedSource)
+                .build();
+    }
+
+    private Source maskSource(Source source, boolean mastUfpd, boolean maskTid) {
+        if (source == null || !(mastUfpd || maskTid)) {
+            return source;
         }
 
-        @Override
-        public Future<InvocationResult<AuctionRequestPayload>> call(AuctionRequestPayload auctionRequestPayload,
-                        AuctionInvocationContext invocationContext) {
+        return source.toBuilder().tid(null).build();
+    }
 
-                return config.getTreatmentRate() > ThreadLocalRandom.current().nextFloat()
-                                ? requestIdentities(auctionRequestPayload.bidRequest(),
-                                                invocationContext.auctionContext())
-                                                .<InvocationResult<AuctionRequestPayload>>map(this::update)
-                                                .onFailure(throwable -> conditionalLogger.error(
-                                                                "Failed enrichment: %s"
-                                                                                .formatted(throwable.getMessage()),
-                                                                logSamplingRate))
-                                : noAction();
+    private MultiMap headers() {
+        return MultiMap.caseInsensitiveMultiMap()
+                .add(HttpUtil.AUTHORIZATION_HEADER, "Bearer " + config.getAuthToken());
+    }
+
+    private IdResResponse processResponse(HttpClientResponse response) {
+        final IdResResponse res = mapper.decodeValue(response.getBody(), IdResResponse.class);
+        final List<Eid> eids = res.getEids();
+
+        if (CollectionUtils.isEmpty(eids)) {
+            return res;
         }
 
-        private Future<IdResResponse> requestIdentities(BidRequest bidRequest, AuctionContext auctionContext) {
-                final BidRequest restrictedBidRequest = applyActivityRestrictions(bidRequest, auctionContext);
-                return httpClient.post(
-                                config.getIdentityResolutionEndpoint(),
-                                headers(),
-                                mapper.encodeToString(restrictedBidRequest),
-                                config.getRequestTimeoutMs())
-                                .map(this::processResponse);
-        }
+        final List<Eid> modifiedEids = eids.stream()
+                .map(eid -> eid.toBuilder().inserter(INSERTER).matcher(MATCHER).build())
+                .toList();
 
-        private BidRequest applyActivityRestrictions(BidRequest bidRequest, AuctionContext auctionContext) {
-                final ActivityInvocationPayload activityInvocationPayload = BidRequestActivityInvocationPayload.of(
-                                ActivityInvocationPayloadImpl.of(
-                                                ComponentType.GENERAL_MODULE,
-                                                LiveIntentOmniChannelIdentityModule.CODE),
-                                bidRequest);
-                final ActivityInfrastructure activityInfrastructure = auctionContext.getActivityInfrastructure();
+        return IdResResponse.of(modifiedEids);
+    }
 
-                final boolean disallowTransmitUfpd = !activityInfrastructure.isAllowed(
-                                Activity.TRANSMIT_UFPD, activityInvocationPayload);
-                final boolean disallowTransmitEids = !activityInfrastructure.isAllowed(
-                                Activity.TRANSMIT_EIDS, activityInvocationPayload);
-                final boolean disallowTransmitGeo = !activityInfrastructure.isAllowed(
-                                Activity.TRANSMIT_GEO, activityInvocationPayload);
-                final boolean disallowTransmitTid = !activityInfrastructure.isAllowed(
-                                Activity.TRANSMIT_TID, activityInvocationPayload);
+    private static Future<InvocationResult<AuctionRequestPayload>> noAction() {
+        return Future.succeededFuture(InvocationResultImpl.<AuctionRequestPayload>builder()
+                .status(InvocationStatus.success)
+                .action(InvocationAction.no_action)
+                .build());
+    }
 
-                return maskUserPersonalInfo(
-                                bidRequest,
-                                disallowTransmitUfpd,
-                                disallowTransmitEids,
-                                disallowTransmitGeo,
-                                disallowTransmitTid);
-        }
+    private InvocationResultImpl<AuctionRequestPayload> update(IdResResponse resolutionResult) {
+        return InvocationResultImpl.<AuctionRequestPayload>builder()
+                .status(InvocationStatus.success)
+                .action(InvocationAction.update)
+                .payloadUpdate(payload -> updatedPayload(payload, resolutionResult.getEids()))
+                .analyticsTags(TagsImpl.of(List.of(
+                        ActivityImpl.of(
+                                "liveintent-enriched", "success",
+                                List.of(
+                                        ResultImpl.of(
+                                                "",
+                                                mapper.mapper().createObjectNode()
+                                                        .put("treatmentRate", config.getTreatmentRate()),
+                                                null))))))
+                .build();
+    }
 
-        private BidRequest maskUserPersonalInfo(BidRequest bidRequest,
-                        boolean disallowTransmitUfpd,
-                        boolean disallowTransmitEids,
-                        boolean disallowTransmitGeo,
-                        boolean disallowTransmitTid) {
+    private AuctionRequestPayload updatedPayload(AuctionRequestPayload requestPayload, List<Eid> resolvedEids) {
+        return CollectionUtils.isNotEmpty(resolvedEids)
+                ? AuctionRequestPayloadImpl.of(updateBidRequest(requestPayload.bidRequest(), resolvedEids))
+                : requestPayload;
+    }
 
-                final User maskedUser = userFpdActivityMask.maskUser(
-                                bidRequest.getUser(), disallowTransmitUfpd, disallowTransmitEids);
-                final Device maskedDevice = userFpdActivityMask.maskDevice(
-                                bidRequest.getDevice(), disallowTransmitUfpd, disallowTransmitGeo);
+    private BidRequest updateBidRequest(BidRequest bidRequest, List<Eid> resolvedEids) {
+        return bidRequest.toBuilder()
+                .ext(updateExtRequest(bidRequest.getExt(), resolvedEids))
+                .user(updateUser(bidRequest.getUser(), resolvedEids))
+                .build();
+    }
 
-                final Source maskedSource = maskSource(bidRequest.getSource(), disallowTransmitUfpd,
-                                disallowTransmitTid);
-
-                return bidRequest.toBuilder()
-                                .user(maskedUser)
-                                .device(maskedDevice)
-                                .source(maskedSource)
-                                .build();
-        }
-
-        private Source maskSource(Source source, boolean mastUfpd, boolean maskTid) {
-                if (source == null || !(mastUfpd || maskTid)) {
-                        return source;
-                }
-
-                return source.toBuilder().tid(null).build();
-        }
-
-        private MultiMap headers() {
-                return MultiMap.caseInsensitiveMultiMap()
-                                .add(HttpUtil.AUTHORIZATION_HEADER, "Bearer " + config.getAuthToken());
-        }
-
-        private IdResResponse processResponse(HttpClientResponse response) {
-                final IdResResponse res = mapper.decodeValue(response.getBody(), IdResResponse.class);
-                final List<Eid> eids = res.getEids();
-
-                if (CollectionUtils.isEmpty(eids)) {
-                        return res;
-                }
-
-                final List<Eid> modifiedEids = eids.stream()
-                                .map(eid -> eid.toBuilder().inserter(INSERTER).matcher(MATCHER).build())
-                                .toList();
-
-                return IdResResponse.of(modifiedEids);
-        }
-
-        private static Future<InvocationResult<AuctionRequestPayload>> noAction() {
-                return Future.succeededFuture(InvocationResultImpl.<AuctionRequestPayload>builder()
-                                .status(InvocationStatus.success)
-                                .action(InvocationAction.no_action)
-                                .build());
-        }
-
-        private InvocationResultImpl<AuctionRequestPayload> update(IdResResponse resolutionResult) {
-                return InvocationResultImpl.<AuctionRequestPayload>builder()
-                                .status(InvocationStatus.success)
-                                .action(InvocationAction.update)
-                                .payloadUpdate(payload -> updatedPayload(payload, resolutionResult.getEids()))
-                                .analyticsTags(TagsImpl.of(List.of(
-                                                ActivityImpl.of(
-                                                                "liveintent-enriched", "success",
-                                                                List.of(
-                                                                                ResultImpl.of(
-                                                                                                "",
-                                                                                                mapper.mapper().createObjectNode()
-                                                                                                                .put("treatmentRate",
-                                                                                                                                config.getTreatmentRate()),
-                                                                                                null))))))
-                                .build();
-        }
-
-        private AuctionRequestPayload updatedPayload(AuctionRequestPayload requestPayload, List<Eid> resolvedEids) {
-                return CollectionUtils.isNotEmpty(resolvedEids)
-                                ? AuctionRequestPayloadImpl
-                                                .of(updateBidRequest(requestPayload.bidRequest(), resolvedEids))
-                                : requestPayload;
-        }
-
-        private BidRequest updateBidRequest(BidRequest bidRequest, List<Eid> resolvedEids) {
-                return bidRequest.toBuilder()
-                                .ext(updateExtRequest(bidRequest.getExt(), resolvedEids))
-                                .user(updateUser(bidRequest.getUser(), resolvedEids))
-                                .build();
-        }
-
-        private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
+    private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
                 if (CollectionUtils.isEmpty(resolvedEids)) {
                         return ext;
                 }
 
-                final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
-                final ExtRequestPrebidData extPrebidData = extPrebid != null ? extPrebid.getData() : null;
-                final List<ExtRequestPrebidDataEidPermissions> eidPermissions = extPrebidData != null
-                                ? extPrebidData.getEidPermissions()
-                                : null;
+        final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
+        final ExtRequestPrebidData extPrebidData = extPrebid != null ? extPrebid.getData() : null;
+        final List<ExtRequestPrebidDataEidPermissions> eidPermissions =
+                extPrebidData != null ? extPrebidData.getEidPermissions() : null;
 
-                final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils
-                                .isEmpty(eidPermissions)
-                                                ? createEidPermissions()
-                                                : modifyEidPermissions(eidPermissions);
+        final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils
+                .isEmpty(eidPermissions)
+                ? createEidPermissions()
+                : modifyEidPermissions(eidPermissions);
 
-                final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
-                                .map(ExtRequestPrebid::toBuilder)
-                                .orElseGet(ExtRequestPrebid::builder)
-                                .data(updatePrebidData(extPrebidData, modifiedEidPermissions))
-                                .build();
+        final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
+                .map(ExtRequestPrebid::toBuilder)
+                .orElseGet(ExtRequestPrebid::builder)
+                .data(updatePrebidData(extPrebidData, modifiedEidPermissions))
+                .build();
 
-                final ExtRequest updatedExtRequest = ExtRequest.of(updatedExtPrebid);
-                if (ext != null) {
-                        mapper.fillExtension(updatedExtRequest, ext.getProperties());
-                }
-
-                return updatedExtRequest;
+        final ExtRequest updatedExtRequest = ExtRequest.of(updatedExtPrebid);
+        if (ext != null) {
+            mapper.fillExtension(updatedExtRequest, ext.getProperties());
         }
 
-        private static User updateUser(User user, List<Eid> resolvedEids) {
-                final List<Eid> updatedEids = Optional.ofNullable(user)
-                                .map(User::getEids)
-                                .map(eids -> ListUtil.union(eids, resolvedEids))
-                                .orElse(resolvedEids);
+        return updatedExtRequest;
+    }
 
-                return Optional.ofNullable(user)
-                                .map(User::toBuilder)
-                                .orElseGet(User::builder)
-                                .eids(updatedEids)
-                                .build();
-        }
+    private static User updateUser(User user, List<Eid> resolvedEids) {
+        final List<Eid> updatedEids = Optional.ofNullable(user)
+                .map(User::getEids)
+                .map(eids -> ListUtil.union(eids, resolvedEids))
+                .orElse(resolvedEids);
 
-        private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
-                return List.of(ExtRequestPrebidDataEidPermissions.builder()
+        return Optional.ofNullable(user)
+                .map(User::toBuilder)
+                .orElseGet(User::builder)
+                .eids(updatedEids)
+                .build();
+    }
+
+    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
+        return List.of(ExtRequestPrebidDataEidPermissions.builder()
                                 .matcher(MATCHER)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())
                                 .build());
-        }
+    }
 
-        private List<ExtRequestPrebidDataEidPermissions> modifyEidPermissions(
-                        List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
-                final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = eidPermissions.stream()
+    private List<ExtRequestPrebidDataEidPermissions> modifyEidPermissions(
+            List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
+        final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = eidPermissions.stream()
                                 .map(this::updateEidPermission)
                                 .filter(Objects::nonNull)
                                 .toList();
-                final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions();
-                return ListUtils.union(modifiedEidPermissions, defaultEidPermissions);
-        }
+        final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions();
+        return ListUtils.union(modifiedEidPermissions, defaultEidPermissions);
+    }
 
-        private ExtRequestPrebidData updatePrebidData(ExtRequestPrebidData extPrebidData,
-                        List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
+    private ExtRequestPrebidData updatePrebidData(ExtRequestPrebidData extPrebidData,
+                                                  List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
 
-                final List<String> originalBidders = extPrebidData != null ? extPrebidData.getBidders() : null;
+        final List<String> originalBidders = extPrebidData != null ? extPrebidData.getBidders() : null;
 
-                return ExtRequestPrebidData.of(originalBidders, eidPermissions);
-        }
+        return ExtRequestPrebidData.of(originalBidders, eidPermissions);
+    }
 
-        private ExtRequestPrebidDataEidPermissions updateEidPermission(
-                        ExtRequestPrebidDataEidPermissions eidPermission) {
-                if (!MATCHER.equals(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
+    private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission) {
+        if (!MATCHER.equals(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
                         return eidPermission;
-                }
-
-                final List<String> allowedBidders = ListUtils.emptyIfNull(eidPermission.getBidders());
-                final List<String> finalBidders = allowedBidders.stream()
-                                .filter(targetBidders::contains)
-                                .toList();
-
-                if (CollectionUtils.isEmpty(allowedBidders) || allowedBidders.contains("*")) {
-                        return eidPermission.toBuilder().bidders(targetBidders.stream().toList()).build();
-                }
-
-                if (CollectionUtils.isEmpty(finalBidders)) {
-                        return null;
-                }
-
-                return eidPermission.toBuilder().bidders(finalBidders).build();
         }
 
-        @Override
-        public String code() {
-                return CODE;
+        final List<String> allowedBidders = ListUtils.emptyIfNull(eidPermission.getBidders());
+        final List<String> finalBidders = allowedBidders.stream()
+                .filter(targetBidders::contains)
+                .toList();
+
+        if (CollectionUtils.isEmpty(allowedBidders) || allowedBidders.contains("*")) {
+            return eidPermission.toBuilder().bidders(targetBidders.stream().toList()).build();
         }
+
+        if (CollectionUtils.isEmpty(finalBidders)) {
+            return null;
+        }
+
+        return eidPermission.toBuilder().bidders(finalBidders).build();
+    }
+
+    @Override
+    public String code() {
+        return CODE;
+    }
 }

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -61,6 +61,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private static final String INSERTER = "s2s.liveintent.com";
 
+    private static final String MATCHER = "itsLiveintent";
+
     private final LiveIntentOmniChannelProperties config;
     private final JacksonMapper mapper;
     private final HttpClient httpClient;
@@ -172,7 +174,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         }
 
         final List<Eid> modifiedEids = eids.stream()
-                .map(eid -> eid.toBuilder().inserter(INSERTER).build())
+                .map(eid -> eid.toBuilder().inserter(INSERTER).matcher(MATCHER).build())
                 .toList();
 
         return IdResResponse.of(modifiedEids);
@@ -216,8 +218,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
-        final Set<String> uniqueSources = CollectionUtils.emptyIfNull(resolvedEids).stream()
-                .map(Eid::getSource)
+        final Set<String> uniqueMatcher = CollectionUtils.emptyIfNull(resolvedEids).stream()
+                .map(Eid::getMatcher)
                 .filter(StringUtils::isNotEmpty)
                 .collect(Collectors.toSet());
 
@@ -227,8 +229,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
                 extPrebidData != null ? extPrebidData.getEidPermissions() : null;
 
         final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils.isEmpty(eidPermissions)
-                ? createEidPermissions(uniqueSources)
-                : modifyEidPermissions(eidPermissions, uniqueSources);
+                ? createEidPermissions(uniqueMatcher)
+                : modifyEidPermissions(eidPermissions, uniqueMatcher);
 
         final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
                 .map(ExtRequestPrebid::toBuilder)
@@ -257,10 +259,10 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
                 .build();
     }
 
-    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions(Set<String> sources) {
-        return sources.stream()
-                .map(source -> ExtRequestPrebidDataEidPermissions.builder()
-                        .source(source)
+    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions(Set<String> matcher) {
+        return matcher.stream()
+                .map(liMatcher -> ExtRequestPrebidDataEidPermissions.builder()
+                        .matcher(liMatcher)
                         .inserter(INSERTER)
                         .bidders(targetBidders.stream().toList())
                         .build())
@@ -269,12 +271,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private List<ExtRequestPrebidDataEidPermissions> modifyEidPermissions(
             List<ExtRequestPrebidDataEidPermissions> eidPermissions,
-            Set<String> sources) {
+            Set<String> matcher) {
         final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = eidPermissions.stream()
-                .map(it -> updateEidPermission(it, sources))
+                .map(it -> updateEidPermission(it, matcher))
                 .filter(Objects::nonNull)
                 .toList();
-        final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions(sources);
+        final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions(matcher);
         return ListUtils.union(modifiedEidPermissions, defaultEidPermissions);
     }
 
@@ -287,8 +289,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission,
-                                                                   Set<String> sources) {
-        if (!sources.contains(eidPermission.getSource()) || !INSERTER.equals(eidPermission.getInserter())) {
+                                                                   Set<String> matcher) {
+        if (!matcher.contains(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
             return eidPermission;
         }
 

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -260,6 +260,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
         return List.of(ExtRequestPrebidDataEidPermissions.builder()
+                                .matcher(MATCHER)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())
                                 .build());

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -49,7 +49,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-
 import java.util.Collections;
 
 public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements ProcessedAuctionRequestHook {

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -218,7 +218,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
         if (CollectionUtils.isEmpty(resolvedEids)) {
-                return ext;
+            return ext;
         }
 
         final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
@@ -285,7 +285,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission) {
         if (!MATCHER.equals(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
-                return eidPermission;
+            return eidPermission;
         }
 
         final List<String> allowedBidders = ListUtils.emptyIfNull(eidPermission.getBidders());

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -50,6 +50,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
+import java.util.Collections;
+
 public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements ProcessedAuctionRequestHook {
 
     private static final ConditionalLogger conditionalLogger = new ConditionalLogger(LoggerFactory.getLogger(
@@ -258,7 +260,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
-        return Collections.singletonList(ExtRequestPrebidDataEidPermissions.builder()
+        return List.of(ExtRequestPrebidDataEidPermissions.builder()
                                 .matcher(MATCHER)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -217,9 +217,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private ExtRequest updateExtRequest(ExtRequest ext, List<Eid> resolvedEids) {
-                if (CollectionUtils.isEmpty(resolvedEids)) {
-                        return ext;
-                }
+        if (CollectionUtils.isEmpty(resolvedEids)) {
+                return ext;
+        }
 
         final ExtRequestPrebid extPrebid = ext != null ? ext.getPrebid() : null;
         final ExtRequestPrebidData extPrebidData = extPrebid != null ? extPrebid.getData() : null;
@@ -286,7 +286,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
 
     private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission) {
         if (!MATCHER.equals(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
-                        return eidPermission;
+                return eidPermission;
         }
 
         final List<String> allowedBidders = ListUtils.emptyIfNull(eidPermission.getBidders());

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -49,7 +49,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.Collections;
 
 public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements ProcessedAuctionRequestHook {
 
@@ -59,9 +58,6 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     private static final String CODE = "liveintent-omni-channel-identity-enrichment-hook";
 
     private static final String INSERTER = "s2s.liveintent.com";
-
-    // IdResResponse is already stamped by Ulysses, in the EID's matcher field, it has "liveintent.com"
-    private static final String MATCHER = "liveintent.com";
 
     private final LiveIntentOmniChannelProperties config;
     private final JacksonMapper mapper;
@@ -227,9 +223,15 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         final List<ExtRequestPrebidDataEidPermissions> eidPermissions =
                 extPrebidData != null ? extPrebidData.getEidPermissions() : null;
 
+        final String matcher = resolvedEids.stream()
+                .map(Eid::getMatcher)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
         final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils.isEmpty(eidPermissions)
-                ? createEidPermissions()
-                : modifyEidPermissions(eidPermissions);
+                ? createEidPermissions(matcher)
+                : modifyEidPermissions(eidPermissions, matcher);
 
         final ExtRequestPrebid updatedExtPrebid = Optional.ofNullable(extPrebid)
                 .map(ExtRequestPrebid::toBuilder)
@@ -258,22 +260,21 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
                 .build();
     }
 
-    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
-        return Collections.singletonList(ExtRequestPrebidDataEidPermissions.builder()
-                                .matcher(MATCHER)
+    private List<ExtRequestPrebidDataEidPermissions> createEidPermissions(String matcher) {
+        return List.of(ExtRequestPrebidDataEidPermissions.builder()
+                                .matcher(matcher)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())
                                 .build());
     }
 
     private List<ExtRequestPrebidDataEidPermissions> modifyEidPermissions(
-            List<ExtRequestPrebidDataEidPermissions> eidPermissions) {
+            List<ExtRequestPrebidDataEidPermissions> eidPermissions, String matcher) {
         final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = eidPermissions.stream()
-                                .map(this::updateEidPermission)
+                                .map(p -> updateEidPermission(p, matcher))
                                 .filter(Objects::nonNull)
                                 .toList();
-        final List<ExtRequestPrebidDataEidPermissions> defaultEidPermissions = createEidPermissions();
-        return ListUtils.union(modifiedEidPermissions, defaultEidPermissions);
+        return ListUtils.union(modifiedEidPermissions, createEidPermissions(matcher));
     }
 
     private ExtRequestPrebidData updatePrebidData(ExtRequestPrebidData extPrebidData,
@@ -284,8 +285,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         return ExtRequestPrebidData.of(originalBidders, eidPermissions);
     }
 
-    private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission) {
-        if (!MATCHER.equals(eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
+    private ExtRequestPrebidDataEidPermissions updateEidPermission(ExtRequestPrebidDataEidPermissions eidPermission,
+                                                                   String matcher) {
+        if (!Objects.equals(matcher, eidPermission.getMatcher()) || !INSERTER.equals(eidPermission.getInserter())) {
             return eidPermission;
         }
 

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -226,8 +226,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
         final List<ExtRequestPrebidDataEidPermissions> eidPermissions =
                 extPrebidData != null ? extPrebidData.getEidPermissions() : null;
 
-        final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils
-                .isEmpty(eidPermissions)
+        final List<ExtRequestPrebidDataEidPermissions> modifiedEidPermissions = CollectionUtils.isEmpty(eidPermissions)
                 ? createEidPermissions()
                 : modifyEidPermissions(eidPermissions);
 
@@ -259,7 +258,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
-        return List.of(ExtRequestPrebidDataEidPermissions.builder()
+        return Collections.singletonList(ExtRequestPrebidDataEidPermissions.builder()
                                 .matcher(MATCHER)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())

--- a/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/main/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/hooks/LiveIntentOmniChannelIdentityProcessedAuctionRequestHook.java
@@ -260,7 +260,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHook implements
     }
 
     private List<ExtRequestPrebidDataEidPermissions> createEidPermissions() {
-        return List.of(ExtRequestPrebidDataEidPermissions.builder()
+        return Collections.singletonList(ExtRequestPrebidDataEidPermissions.builder()
                                 .matcher(MATCHER)
                                 .inserter(INSERTER)
                                 .bidders(targetBidders.stream().toList())

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -91,7 +91,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         defaultPermissions = ExtRequestPrebidDataEidPermissions.builder()
                 .inserter("s2s.liveintent.com")
-                .matcher("liveintentStamp")
+                .matcher("liveintent.com")
                 .bidders(configuredBidders.stream().toList())
                 .build();
 
@@ -284,7 +284,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(User::getEids)
                 .isEqualTo(List.of(givenEid, apiResponseEid.toBuilder()
                         .inserter("s2s.liveintent.com")
-                        .matcher("liveintentStamp")
+                        .matcher("liveintent.com")
                         .build()));
 
         verify(httpClient).post(
@@ -329,7 +329,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(User::getEids)
                 .isEqualTo(List.of(apiResponseEid.toBuilder()
                         .inserter("s2s.liveintent.com")
-                        .matcher("liveintentStamp")
+                        .matcher("liveintent.com")
                         .build()));
 
         verify(httpClient).post(
@@ -404,12 +404,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .build();
 
         final ExtRequestPrebidDataEidPermissions liBidder2 = ExtRequestPrebidDataEidPermissions.builder()
-                .matcher("liveintentStamp")
+                .matcher("liveintent.com")
                 .inserter("s2s.liveintent.com")
                 .bidders(singletonList("bidder2"))
                 .build();
         final ExtRequestPrebidDataEidPermissions liBidder23 = ExtRequestPrebidDataEidPermissions.builder()
-                .matcher("liveintentStamp")
+                .matcher("liveintent.com")
                 .inserter("s2s.liveintent.com")
                 .bidders(List.of("bidder2", "bidder3"))
                 .build();
@@ -471,7 +471,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderGlobal"),
                 List.of(
                         ExtRequestPrebidDataEidPermissions.builder()
-                                .matcher("liveintentStamp")
+                                .matcher("liveintent.com")
                                 .inserter("s2s.liveintent.com")
                                 .bidders(singletonList("not-allowed"))
                                 .build(),

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -256,6 +256,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         final Eid apiResponseEid = Eid.builder()
                 .source("liveintent.com")
+                .matcher("liveintent.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
                 .build();
 
@@ -278,14 +279,24 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         // then
         assertThat(result.status()).isEqualTo(InvocationStatus.success);
         assertThat(result.action()).isEqualTo(InvocationAction.update);
-        assertThat(result.payloadUpdate().apply(AuctionRequestPayloadImpl.of(givenBidRequest)))
+
+        final AuctionRequestPayload updatedPayload =
+                result.payloadUpdate().apply(AuctionRequestPayloadImpl.of(givenBidRequest));
+
+        assertThat(updatedPayload)
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
                 .isEqualTo(List.of(givenEid, apiResponseEid.toBuilder()
                         .inserter("s2s.liveintent.com")
-                        .matcher("liveintent.com")
                         .build()));
+
+        assertThat(updatedPayload)
+                .extracting(AuctionRequestPayload::bidRequest)
+                .extracting(BidRequest::getExt)
+                .extracting(ExtRequest::getPrebid)
+                .extracting(ExtRequestPrebid::getData)
+                .isEqualTo(ExtRequestPrebidData.of(null, List.of(defaultPermissions)));
 
         verify(httpClient).post(
                 eq("https://test.com/idres"),

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -91,7 +91,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         defaultPermissions = ExtRequestPrebidDataEidPermissions.builder()
                 .inserter("s2s.liveintent.com")
-                .matcher("itsLiveintent")
+                .matcher("liveintentStamp")
                 .bidders(configuredBidders.stream().toList())
                 .build();
 
@@ -254,13 +254,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         final User givenUser = User.builder().eids(singletonList(givenEid)).build();
         final BidRequest givenBidRequest = BidRequest.builder().id("request").user(givenUser).build();
 
-        final Eid expectedEid = Eid.builder()
+        final Eid apiResponseEid = Eid.builder()
                 .source("liveintent.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
-                .matcher("itsLiveintent")
                 .build();
 
-        final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
+        final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(apiResponseEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));
 
@@ -283,9 +282,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
-                .isEqualTo(List.of(givenEid, expectedEid.toBuilder()
+                .isEqualTo(List.of(givenEid, apiResponseEid.toBuilder()
                         .inserter("s2s.liveintent.com")
-                        .matcher("itsLiveintent")
+                        .matcher("liveintentStamp")
                         .build()));
 
         verify(httpClient).post(
@@ -300,13 +299,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         // given
         final BidRequest givenBidRequest = BidRequest.builder().id("request").user(null).build();
 
-        final Eid expectedEid = Eid.builder()
+        final Eid apiResponseEid = Eid.builder()
                 .source("liveintent.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
-                .matcher("itsLiveintent")
                 .build();
 
-        final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
+        final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(apiResponseEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));
 
@@ -329,9 +327,9 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
-                .isEqualTo(List.of(expectedEid.toBuilder()
+                .isEqualTo(List.of(apiResponseEid.toBuilder()
                         .inserter("s2s.liveintent.com")
-                        .matcher("itsLiveintent")
+                        .matcher("liveintentStamp")
                         .build()));
 
         verify(httpClient).post(
@@ -406,12 +404,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .build();
 
         final ExtRequestPrebidDataEidPermissions liBidder2 = ExtRequestPrebidDataEidPermissions.builder()
-                .matcher("itsLiveintent")
+                .matcher("liveintentStamp")
                 .inserter("s2s.liveintent.com")
                 .bidders(singletonList("bidder2"))
                 .build();
         final ExtRequestPrebidDataEidPermissions liBidder23 = ExtRequestPrebidDataEidPermissions.builder()
-                .matcher("itsLiveintent")
+                .matcher("liveintentStamp")
                 .inserter("s2s.liveintent.com")
                 .bidders(List.of("bidder2", "bidder3"))
                 .build();
@@ -429,7 +427,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderX"),
                 ListUtil.union(List.of(otherBidder, liBidder2), List.of(defaultPermissions)));
 
-        final Eid expectedEid = Eid.builder().matcher("itsLiveintent").build();
+        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
 
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
@@ -473,7 +471,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderGlobal"),
                 List.of(
                         ExtRequestPrebidDataEidPermissions.builder()
-                                .matcher("itsLiveintent")
+                                .matcher("liveintentStamp")
                                 .inserter("s2s.liveintent.com")
                                 .bidders(singletonList("not-allowed"))
                                 .build(),
@@ -488,7 +486,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .ext(ExtRequest.of(ExtRequestPrebid.builder().data(givenData).build()))
                 .build();
 
-        final Eid expectedEid = Eid.builder().matcher("itsLiveintent").build();
+        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -91,8 +91,8 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         defaultPermissions = ExtRequestPrebidDataEidPermissions.builder()
                 .inserter("s2s.liveintent.com")
+                .matcher("itsLiveintent")
                 .bidders(configuredBidders.stream().toList())
-                .source("liveintent.com")
                 .build();
 
         target = new LiveIntentOmniChannelIdentityProcessedAuctionRequestHook(
@@ -257,7 +257,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         final Eid expectedEid = Eid.builder()
                 .source("liveintent.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
-                .matcher("liveintent.com")
+                .matcher("itsLiveintent")
                 .build();
 
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
@@ -283,7 +283,10 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
-                .isEqualTo(List.of(givenEid, expectedEid.toBuilder().inserter("s2s.liveintent.com").build()));
+                .isEqualTo(List.of(givenEid, expectedEid.toBuilder()
+                        .inserter("s2s.liveintent.com")
+                        .matcher("itsLiveintent")
+                        .build()));
 
         verify(httpClient).post(
                 eq("https://test.com/idres"),
@@ -300,7 +303,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
         final Eid expectedEid = Eid.builder()
                 .source("liveintent.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
-                .matcher("liveintent.com")
+                .matcher("itsLiveintent")
                 .build();
 
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
@@ -326,7 +329,10 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(AuctionRequestPayload::bidRequest)
                 .extracting(BidRequest::getUser)
                 .extracting(User::getEids)
-                .isEqualTo(List.of(expectedEid.toBuilder().inserter("s2s.liveintent.com").build()));
+                .isEqualTo(List.of(expectedEid.toBuilder()
+                        .inserter("s2s.liveintent.com")
+                        .matcher("itsLiveintent")
+                        .build()));
 
         verify(httpClient).post(
                 eq("https://test.com/idres"),
@@ -400,12 +406,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .build();
 
         final ExtRequestPrebidDataEidPermissions liBidder2 = ExtRequestPrebidDataEidPermissions.builder()
-                .source("liveintent.com")
+                .matcher("itsLiveintent")
                 .inserter("s2s.liveintent.com")
                 .bidders(singletonList("bidder2"))
                 .build();
         final ExtRequestPrebidDataEidPermissions liBidder23 = ExtRequestPrebidDataEidPermissions.builder()
-                .source("liveintent.com")
+                .matcher("itsLiveintent")
                 .inserter("s2s.liveintent.com")
                 .bidders(List.of("bidder2", "bidder3"))
                 .build();
@@ -423,70 +429,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderX"),
                 ListUtil.union(List.of(otherBidder, liBidder2), List.of(defaultPermissions)));
 
-        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
-
-        final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
-        given(httpClient.post(any(), any(), any(), anyLong()))
-                .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));
-
-        given(auctionInvocationContext.auctionContext()).willReturn(auctionContext);
-        given(auctionContext.getActivityInfrastructure()).willReturn(activityInfrastructure);
-        given(activityInfrastructure.isAllowed(any(), any())).willReturn(true);
-        given(userFpdActivityMask.maskUser(any(), eq(false), eq(false)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-        given(userFpdActivityMask.maskDevice(any(), eq(false), eq(false)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        final InvocationResult<AuctionRequestPayload> result =
-                target.call(AuctionRequestPayloadImpl.of(givenBidRequest), auctionInvocationContext).result();
-        // then
-        assertThat(result.status()).isEqualTo(InvocationStatus.success);
-        assertThat(result.payloadUpdate().apply(AuctionRequestPayloadImpl.of(givenBidRequest)))
-                .extracting(AuctionRequestPayload::bidRequest)
-                .extracting(BidRequest::getExt)
-                .extracting(ExtRequest::getPrebid)
-                .extracting(ExtRequestPrebid::getData)
-                .isEqualTo(expectedData);
-
-        verify(httpClient).post(
-                eq("https://test.com/idres"),
-                argThat(headers -> headers.contains("Authorization", "Bearer auth_token", true)),
-                eq(MAPPER.encodeToString(givenBidRequest)),
-                eq(5L));
-    }
-
-    @Test
-    public void shouldNotAddNewEidPermissionsOrModifyGlobalBiddersWhenSourceNotPresent() {
-        // given
-        final Uid givenUid = Uid.builder().id("id1").atype(2).build();
-        final Eid givenEid = Eid.builder().source("some.source.com").uids(singletonList(givenUid)).build();
-        final User givenUser = User.builder().eids(singletonList(givenEid)).build();
-        final ExtRequestPrebidDataEidPermissions bidder1 = ExtRequestPrebidDataEidPermissions.builder()
-                .source("some.other-source.com")
-                .inserter("some.other-inserter.com")
-                .bidders(singletonList("bidder3"))
-                .build();
-        final ExtRequestPrebidDataEidPermissions bidder2 = ExtRequestPrebidDataEidPermissions.builder()
-                .source("some.source.com")
-                .inserter("s2s.liveintent.com")
-                .bidders(singletonList("bidder3"))
-                .build();
-
-        final List<ExtRequestPrebidDataEidPermissions> bidders = List.of(bidder1, bidder2);
-
-        final BidRequest givenBidRequest = BidRequest.builder()
-                .id("request")
-                .user(givenUser)
-                .ext(ExtRequest.of(ExtRequestPrebid.builder()
-                        .data(ExtRequestPrebidData.of(singletonList("bidder3"), bidders))
-                        .build()))
-                .build();
-
-        final ExtRequestPrebidData expectedData = ExtRequestPrebidData.of(List.of("bidder3"),
-                ListUtil.union(bidders, List.of(defaultPermissions)));
-
-        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
+        final Eid expectedEid = Eid.builder().matcher("itsLiveintent").build();
 
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
@@ -530,7 +473,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderGlobal"),
                 List.of(
                         ExtRequestPrebidDataEidPermissions.builder()
-                                .source("liveintent.com")
+                                .matcher("itsLiveintent")
                                 .inserter("s2s.liveintent.com")
                                 .bidders(singletonList("not-allowed"))
                                 .build(),
@@ -545,7 +488,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .ext(ExtRequest.of(ExtRequestPrebid.builder().data(givenData).build()))
                 .build();
 
-        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
+        final Eid expectedEid = Eid.builder().matcher("itsLiveintent").build();
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));

--- a/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
+++ b/extra/modules/live-intent-omni-channel-identity/src/test/java/org/prebid/server/hooks/modules/liveintent/omni/channel/identity/v1/LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest.java
@@ -91,7 +91,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         defaultPermissions = ExtRequestPrebidDataEidPermissions.builder()
                 .inserter("s2s.liveintent.com")
-                .matcher("liveintent.com")
+                .matcher("test.matcher.com")
                 .bidders(configuredBidders.stream().toList())
                 .build();
 
@@ -256,7 +256,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         final Eid apiResponseEid = Eid.builder()
                 .source("liveintent.com")
-                .matcher("liveintent.com")
+                .matcher("test.matcher.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
                 .build();
 
@@ -312,6 +312,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
 
         final Eid apiResponseEid = Eid.builder()
                 .source("liveintent.com")
+                .matcher("test.matcher.com")
                 .uids(singletonList(Uid.builder().id("id2").atype(3).build()))
                 .build();
 
@@ -340,7 +341,6 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .extracting(User::getEids)
                 .isEqualTo(List.of(apiResponseEid.toBuilder()
                         .inserter("s2s.liveintent.com")
-                        .matcher("liveintent.com")
                         .build()));
 
         verify(httpClient).post(
@@ -415,12 +415,12 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .build();
 
         final ExtRequestPrebidDataEidPermissions liBidder2 = ExtRequestPrebidDataEidPermissions.builder()
-                .matcher("liveintent.com")
+                .matcher("test.matcher.com")
                 .inserter("s2s.liveintent.com")
                 .bidders(singletonList("bidder2"))
                 .build();
         final ExtRequestPrebidDataEidPermissions liBidder23 = ExtRequestPrebidDataEidPermissions.builder()
-                .matcher("liveintent.com")
+                .matcher("test.matcher.com")
                 .inserter("s2s.liveintent.com")
                 .bidders(List.of("bidder2", "bidder3"))
                 .build();
@@ -438,7 +438,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderX"),
                 ListUtil.union(List.of(otherBidder, liBidder2), List.of(defaultPermissions)));
 
-        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
+        final Eid expectedEid = Eid.builder().source("liveintent.com").matcher("test.matcher.com").build();
 
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
@@ -482,7 +482,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 List.of("bidderGlobal"),
                 List.of(
                         ExtRequestPrebidDataEidPermissions.builder()
-                                .matcher("liveintent.com")
+                                .matcher("test.matcher.com")
                                 .inserter("s2s.liveintent.com")
                                 .bidders(singletonList("not-allowed"))
                                 .build(),
@@ -497,7 +497,7 @@ public class LiveIntentOmniChannelIdentityProcessedAuctionRequestHookTest {
                 .ext(ExtRequest.of(ExtRequestPrebid.builder().data(givenData).build()))
                 .build();
 
-        final Eid expectedEid = Eid.builder().source("liveintent.com").build();
+        final Eid expectedEid = Eid.builder().source("liveintent.com").matcher("test.matcher.com").build();
         final String responseBody = MAPPER.encodeToString(IdResResponse.of(List.of(expectedEid)));
         given(httpClient.post(any(), any(), any(), anyLong()))
                 .willReturn(Future.succeededFuture(HttpClientResponse.of(200, null, responseBody)));


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [x] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Use matcher to determine when to apply EID permissions, instead of source names, to avoid collisions with unrelated traffic and ensure we only permission IDs we enrich.


### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
