### PR TITLE
Prebid Mobile: makes creative size transformation based on pxRatio.

### DIFF
--- a/src/main/java/org/prebid/server/auction/InterstitialProcessor.java
+++ b/src/main/java/org/prebid/server/auction/InterstitialProcessor.java
@@ -5,7 +5,9 @@ import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Device;
 import com.iab.openrtb.request.Format;
 import com.iab.openrtb.request.Imp;
+import lombok.Value;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.prebid.server.exception.InvalidRequestException;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevice;
 import org.prebid.server.proto.openrtb.ext.request.ExtDeviceInt;
@@ -18,6 +20,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 public class InterstitialProcessor {
 
@@ -49,8 +52,19 @@ public class InterstitialProcessor {
         return bidRequest;
     }
 
-    private Imp processInterstitialImp(Imp imp, Device device, int minWidthPerc, int minHeightPerc,
+    private static boolean usePxRatio(BidRequest bidRequest) {
+        final ExtRequest extRequest = bidRequest.getExt();
+        final ExtRequestPrebid prebid = extRequest != null ? extRequest.getPrebid() : null;
+        final ExtRequestPrebidSdk sdk = prebid != null ? prebid.getSdk() : null;
+        return sdk != null && BooleanUtils.isTrue(sdk.getUsePxRatio());
+    }
+
+    private Imp processInterstitialImp(Imp imp,
+                                       Device device,
+                                       int minWidthPerc,
+                                       int minHeightPerc,
                                        boolean usePxRatio) {
+
         if (!isInterstitial(imp)) {
             return imp;
         }
@@ -60,41 +74,58 @@ public class InterstitialProcessor {
             return imp;
         }
 
+        final InterstitialSize maxSize = getMaxSize(banner, device, imp.getId(), usePxRatio);
+        final double minWidth = getMinSize(maxSize.getW(), minWidthPerc);
+        final double minHeight = getMinSize(maxSize.getH(), minHeightPerc);
+
+        final List<Format> interstitialFormats = InterstitialSize.getNestedSizes(minWidth, minHeight, maxSize)
+                .map(size -> Format.builder().w(size.w).h(size.h).build())
+                .toList();
+
+        return CollectionUtils.isNotEmpty(interstitialFormats)
+                ? imp.toBuilder().banner(banner.toBuilder().format(interstitialFormats).build()).build()
+                : imp;
+    }
+
+    private static InterstitialSize getMaxSize(Banner banner, Device device, String impId, boolean usePxRatio) {
         final List<Format> formats = banner.getFormat();
         final Format firstFormat = CollectionUtils.isEmpty(formats) ? null : formats.getFirst();
-        Integer maxHeight = firstFormat != null ? firstFormat.getH() : null;
-        Integer maxWidth = firstFormat != null ? firstFormat.getW() : null;
+        final Integer firstFormatWidth = firstFormat != null ? firstFormat.getW() : null;
+        final Integer firstFormatHeight = firstFormat != null ? firstFormat.getH() : null;
 
-        if (maxHeight == null || maxWidth == null || (maxHeight == 1 && maxWidth == 1)) {
-            maxHeight = device.getH();
-            maxWidth = device.getW();
-            if (usePxRatio) {
-                final BigDecimal pxratio = device.getPxratio();
-                maxHeight = deviceSizeToDips(maxHeight, pxratio);
-                maxWidth = deviceSizeToDips(maxWidth, pxratio);
-            }
+        if (firstFormatWidth != null
+                && firstFormatHeight != null
+                && (firstFormatWidth != 1 || firstFormatHeight != 1)) {
+
+            return InterstitialSize.interstitialSize(firstFormatWidth, firstFormatHeight);
         }
 
-        if (maxHeight == null || maxWidth == null) {
+        final Integer deviceWidth = device.getW();
+        final Integer deviceHeight = device.getH();
+        if (deviceWidth == null || deviceHeight == null) {
             throw new InvalidRequestException(
                     "Unable to read max interstitial size for Imp id=%s (No Device sizes and no Format objects)"
-                            .formatted(imp.getId()));
+                            .formatted(impId));
         }
 
-        final double minHeight = (double) maxHeight / 100 * minHeightPerc;
-        final double minWidth = (double) maxWidth / 100 * minWidthPerc;
-
-        final List<Format> interstitialFormats =
-                InterstitialSize.getNestedSizes(minWidth, minHeight, maxWidth, maxHeight, MAX_SIZES_COUNT)
-                        .stream()
-                        .map(interstitialSize -> Format.builder().w(interstitialSize.w).h(interstitialSize.h).build())
-                        .toList();
-
-        if (CollectionUtils.isEmpty(interstitialFormats)) {
-            return imp;
+        if (usePxRatio) {
+            final BigDecimal pxRatio = device.getPxratio();
+            return InterstitialSize.interstitialSize(
+                    deviceSizeToDips(deviceWidth, pxRatio),
+                    deviceSizeToDips(deviceHeight, pxRatio));
         }
 
-        return imp.toBuilder().banner(banner.toBuilder().format(interstitialFormats).build()).build();
+        return InterstitialSize.interstitialSize(deviceWidth, deviceHeight);
+    }
+
+    private static int deviceSizeToDips(int size, BigDecimal pxRatio) {
+        return pxRatio != null && pxRatio.signum() > 0
+                ? Math.max(1, (int) Math.round(size / pxRatio.doubleValue()))
+                : size;
+    }
+
+    private static double getMinSize(int maxSize, int minSizePerc) {
+        return maxSize / 100.0 * minSizePerc;
     }
 
     private ExtDeviceInt getExtDeviceInt(Device device) {
@@ -103,21 +134,7 @@ public class InterstitialProcessor {
         return extDevicePrebid != null ? extDevicePrebid.getInterstitial() : null;
     }
 
-    private static boolean usePxRatio(BidRequest bidRequest) {
-        final ExtRequest extRequest = bidRequest.getExt();
-        final ExtRequestPrebid prebid = extRequest != null ? extRequest.getPrebid() : null;
-        final ExtRequestPrebidSdk sdk = prebid != null ? prebid.getSdk() : null;
-        return sdk != null && Objects.equals(sdk.getUsePxRatio(), true);
-    }
-
-    private static Integer deviceSizeToDips(Integer size, BigDecimal pxratio) {
-        if (size == null || pxratio == null || pxratio.signum() <= 0) {
-            return size;
-        }
-
-        return Math.max(1, (int) Math.round(size / pxratio.doubleValue()));
-    }
-
+    @Value(staticConstructor = "interstitialSize")
     private static class InterstitialSize {
 
         private static final List<InterstitialSize> INTERSTITIAL_SIZES = new ArrayList<>();
@@ -375,33 +392,19 @@ public class InterstitialProcessor {
             INTERSTITIAL_SIZES.add(interstitialSize(120, 20));
         }
 
-        private final Integer w;
-        private final Integer h;
+        int w;
+        int h;
 
-        private InterstitialSize(Integer w, Integer h) {
-            this.w = w;
-            this.h = h;
-        }
-
-        private static InterstitialSize interstitialSize(Integer w, Integer h) {
-            return new InterstitialSize(w, h);
-        }
-
-        private static List<InterstitialSize> getNestedSizes(double minWidth,
-                                                             double minHeight,
-                                                             double maxWidth,
-                                                             double maxHeight,
-                                                             int count) {
-
+        private static Stream<InterstitialSize> getNestedSizes(double minWidth, double minHeight,
+                                                                 InterstitialSize max) {
             return INTERSTITIAL_SIZES.stream()
-                    .filter(size -> isNested(size, minWidth, minHeight, maxWidth, maxHeight))
-                    .limit(count)
-                    .toList();
+                    .filter(size -> isNested(size, minWidth, minHeight, max))
+                    .limit(MAX_SIZES_COUNT);
         }
 
-        private static boolean isNested(InterstitialSize size, double minWidth, double minHeight, double maxWidth,
-                                        double maxHeight) {
-            return size.w >= minWidth && size.w <= maxWidth && size.h >= minHeight && size.h <= maxHeight;
+        private static boolean isNested(InterstitialSize size, double minWidth, double minHeight,
+                                         InterstitialSize max) {
+            return size.w >= minWidth && size.w <= max.w && size.h >= minHeight && size.h <= max.h;
         }
     }
 }

--- a/src/main/java/org/prebid/server/auction/InterstitialProcessor.java
+++ b/src/main/java/org/prebid/server/auction/InterstitialProcessor.java
@@ -10,7 +10,11 @@ import org.prebid.server.exception.InvalidRequestException;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevice;
 import org.prebid.server.proto.openrtb.ext.request.ExtDeviceInt;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevicePrebid;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidSdk;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -36,15 +40,17 @@ public class InterstitialProcessor {
         if (extDeviceInt != null) {
             final int minWidthPerc = extDeviceInt.getMinWidthPerc();
             final int minHeightPerc = extDeviceInt.getMinHeightPerc();
+            final boolean usePxRatio = usePxRatio(bidRequest);
             final List<Imp> updatedImps = bidRequest.getImp().stream()
-                    .map(imp -> processInterstitialImp(imp, device, minWidthPerc, minHeightPerc))
+                    .map(imp -> processInterstitialImp(imp, device, minWidthPerc, minHeightPerc, usePxRatio))
                     .toList();
             bidRequest = bidRequest.toBuilder().imp(updatedImps).build();
         }
         return bidRequest;
     }
 
-    private Imp processInterstitialImp(Imp imp, Device device, int minWidthPerc, int minHeightPerc) {
+    private Imp processInterstitialImp(Imp imp, Device device, int minWidthPerc, int minHeightPerc,
+                                       boolean usePxRatio) {
         if (!isInterstitial(imp)) {
             return imp;
         }
@@ -62,6 +68,11 @@ public class InterstitialProcessor {
         if (maxHeight == null || maxWidth == null || (maxHeight == 1 && maxWidth == 1)) {
             maxHeight = device.getH();
             maxWidth = device.getW();
+            if (usePxRatio) {
+                final BigDecimal pxratio = device.getPxratio();
+                maxHeight = deviceSizeToDips(maxHeight, pxratio);
+                maxWidth = deviceSizeToDips(maxWidth, pxratio);
+            }
         }
 
         if (maxHeight == null || maxWidth == null) {
@@ -90,6 +101,21 @@ public class InterstitialProcessor {
         final ExtDevice extDevice = device != null ? device.getExt() : null;
         final ExtDevicePrebid extDevicePrebid = extDevice != null ? extDevice.getPrebid() : null;
         return extDevicePrebid != null ? extDevicePrebid.getInterstitial() : null;
+    }
+
+    private static boolean usePxRatio(BidRequest bidRequest) {
+        final ExtRequest extRequest = bidRequest.getExt();
+        final ExtRequestPrebid prebid = extRequest != null ? extRequest.getPrebid() : null;
+        final ExtRequestPrebidSdk sdk = prebid != null ? prebid.getSdk() : null;
+        return sdk != null && Objects.equals(sdk.getUsePxRatio(), true);
+    }
+
+    private static Integer deviceSizeToDips(Integer size, BigDecimal pxratio) {
+        if (size == null || pxratio == null || pxratio.signum() <= 0) {
+            return size;
+        }
+
+        return Math.max(1, (int) Math.round(size / pxratio.doubleValue()));
     }
 
     private static class InterstitialSize {

--- a/src/main/java/org/prebid/server/auction/InterstitialProcessor.java
+++ b/src/main/java/org/prebid/server/auction/InterstitialProcessor.java
@@ -395,15 +395,18 @@ public class InterstitialProcessor {
         int w;
         int h;
 
-        private static Stream<InterstitialSize> getNestedSizes(double minWidth, double minHeight,
-                                                                 InterstitialSize max) {
+        private static Stream<InterstitialSize> getNestedSizes(double minWidth,
+                                                               double minHeight,
+                                                               InterstitialSize max) {
             return INTERSTITIAL_SIZES.stream()
                     .filter(size -> isNested(size, minWidth, minHeight, max))
                     .limit(MAX_SIZES_COUNT);
         }
 
-        private static boolean isNested(InterstitialSize size, double minWidth, double minHeight,
-                                         InterstitialSize max) {
+        private static boolean isNested(InterstitialSize size,
+                                        double minWidth,
+                                        double minHeight,
+                                        InterstitialSize max) {
             return size.w >= minWidth && size.w <= max.w && size.h >= minHeight && size.h <= max.h;
         }
     }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidSdk.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidSdk.java
@@ -1,5 +1,6 @@
 package org.prebid.server.proto.openrtb.ext.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Value;
 
 import java.util.List;
@@ -7,11 +8,25 @@ import java.util.List;
 /**
  * Defines the contract for bidrequest.ext.prebid.sdk
  */
-@Value(staticConstructor = "of")
+@Value
 public class ExtRequestPrebidSdk {
 
     /**
      * Defines the contract for bidrequest.ext.prebid.sdk.renderers
      */
     List<ExtRequestPrebidSdkRenderer> renderers;
+
+    /**
+     * Defines the contract for bidrequest.ext.prebid.sdk.usepxratio
+     */
+    @JsonProperty("usepxratio")
+    Boolean usePxRatio;
+
+    public static ExtRequestPrebidSdk of(List<ExtRequestPrebidSdkRenderer> renderers) {
+        return new ExtRequestPrebidSdk(renderers, null);
+    }
+
+    public static ExtRequestPrebidSdk of(List<ExtRequestPrebidSdkRenderer> renderers, Boolean usePxRatio) {
+        return new ExtRequestPrebidSdk(renderers, usePxRatio);
+    }
 }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidSdk.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidSdk.java
@@ -22,10 +22,6 @@ public class ExtRequestPrebidSdk {
     @JsonProperty("usepxratio")
     Boolean usePxRatio;
 
-    public static ExtRequestPrebidSdk of(List<ExtRequestPrebidSdkRenderer> renderers) {
-        return new ExtRequestPrebidSdk(renderers, null);
-    }
-
     public static ExtRequestPrebidSdk of(List<ExtRequestPrebidSdkRenderer> renderers, Boolean usePxRatio) {
         return new ExtRequestPrebidSdk(renderers, usePxRatio);
     }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidSdk.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/request/ExtRequestPrebidSdk.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Defines the contract for bidrequest.ext.prebid.sdk
  */
-@Value
+@Value(staticConstructor = "of")
 public class ExtRequestPrebidSdk {
 
     /**
@@ -22,7 +22,4 @@ public class ExtRequestPrebidSdk {
     @JsonProperty("usepxratio")
     Boolean usePxRatio;
 
-    public static ExtRequestPrebidSdk of(List<ExtRequestPrebidSdkRenderer> renderers, Boolean usePxRatio) {
-        return new ExtRequestPrebidSdk(renderers, usePxRatio);
-    }
 }

--- a/src/test/java/org/prebid/server/auction/InterstitialProcessorTest.java
+++ b/src/test/java/org/prebid/server/auction/InterstitialProcessorTest.java
@@ -11,6 +11,11 @@ import org.prebid.server.exception.InvalidRequestException;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevice;
 import org.prebid.server.proto.openrtb.ext.request.ExtDeviceInt;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevicePrebid;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid;
+import org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebidSdk;
+
+import java.math.BigDecimal;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -72,6 +77,28 @@ public class InterstitialProcessorTest extends VertxTest {
     }
 
     @Test
+    public void processShouldReturnBidRequestUpdatedWithInterstitialFormatsUsingDeviceSizeInDipsWhenFormatIsEmpty() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder().banner(Banner.builder().build()).instl(1).build()))
+                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                        .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(60, 60))))
+                        .build())
+                .ext(usePxRatioExt())
+                .build();
+
+        // when
+        final BidRequest result = interstitialProcessor.process(bidRequest);
+
+        // then
+        assertThat(result.getImp())
+                .extracting(Imp::getBanner)
+                .flatExtracting(Banner::getFormat)
+                .contains(Format.builder().w(320).h(480).build())
+                .doesNotContain(Format.builder().w(768).h(1024).build());
+    }
+
+    @Test
     public void processShouldReturnBidRequestUpdatedWithInterstitialFormatsUsingSizesFromDeviceWhenFormatIsOneToOne() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
@@ -94,6 +121,97 @@ public class InterstitialProcessorTest extends VertxTest {
                         Format.builder().w(320).h(568).build(),
                         Format.builder().w(320).h(500).build(),
                         Format.builder().w(320).h(481).build());
+    }
+
+    @Test
+    public void processShouldReturnBidRequestUpdatedWithInterstitialFormatsUsingDeviceSizeInDipsWhenFormatIsOneToOne() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder().banner(Banner.builder().format(singletonList(
+                        Format.builder().w(1).h(1).build())).build()).instl(1).build()))
+                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                        .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(60, 60))))
+                        .build())
+                .ext(usePxRatioExt())
+                .build();
+
+        // when
+        final BidRequest result = interstitialProcessor.process(bidRequest);
+
+        // then
+        assertThat(result.getImp())
+                .extracting(Imp::getBanner)
+                .flatExtracting(Banner::getFormat)
+                .contains(Format.builder().w(320).h(480).build())
+                .doesNotContain(Format.builder().w(768).h(1024).build());
+    }
+
+    @Test
+    public void processShouldNotConvertExplicitFormatSizeUsingDevicePxratio() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder().banner(Banner.builder()
+                                .format(singletonList(Format.builder().w(400).h(600).build())).build()).instl(1)
+                        .build()))
+                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                        .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(80, 80))))
+                        .build())
+                .ext(usePxRatioExt())
+                .build();
+
+        // when
+        final BidRequest result = interstitialProcessor.process(bidRequest);
+
+        // then
+        assertThat(result.getImp())
+                .extracting(Imp::getBanner)
+                .flatExtracting(Banner::getFormat)
+                .containsOnly(Format.builder().w(320).h(480).build(),
+                        Format.builder().w(336).h(544).build(),
+                        Format.builder().w(320).h(568).build(),
+                        Format.builder().w(320).h(500).build(),
+                        Format.builder().w(320).h(481).build());
+    }
+
+    @Test
+    public void processShouldKeepCurrentDeviceSizeBehaviorWhenUsePxRatioIsTrueAndDevicePxRatioIsAbsent() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder().banner(Banner.builder().build()).instl(1).build()))
+                .device(Device.builder().w(1080).h(1920)
+                        .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(1, 1))))
+                        .build())
+                .ext(usePxRatioExt())
+                .build();
+
+        // when
+        final BidRequest result = interstitialProcessor.process(bidRequest);
+
+        // then
+        assertThat(result.getImp())
+                .extracting(Imp::getBanner)
+                .flatExtracting(Banner::getFormat)
+                .contains(Format.builder().w(768).h(1024).build());
+    }
+
+    @Test
+    public void processShouldKeepCurrentDeviceSizeBehaviorWhenUsePxRatioIsAbsent() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder().banner(Banner.builder().build()).instl(1).build()))
+                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                        .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(1, 1))))
+                        .build())
+                .build();
+
+        // when
+        final BidRequest result = interstitialProcessor.process(bidRequest);
+
+        // then
+        assertThat(result.getImp())
+                .extracting(Imp::getBanner)
+                .flatExtracting(Banner::getFormat)
+                .contains(Format.builder().w(768).h(1024).build());
     }
 
     @Test
@@ -264,6 +382,12 @@ public class InterstitialProcessorTest extends VertxTest {
                 .device(Device.builder()
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(80, 80))))
                         .build())
+                .build());
+    }
+
+    private static ExtRequest usePxRatioExt() {
+        return ExtRequest.of(ExtRequestPrebid.builder()
+                .sdk(ExtRequestPrebidSdk.of(null, true))
                 .build());
     }
 }

--- a/src/test/java/org/prebid/server/auction/InterstitialProcessorTest.java
+++ b/src/test/java/org/prebid/server/auction/InterstitialProcessorTest.java
@@ -45,7 +45,7 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(320).h(480).build(),
+                .containsExactly(Format.builder().w(320).h(480).build(),
                         Format.builder().w(336).h(544).build(),
                         Format.builder().w(320).h(568).build(),
                         Format.builder().w(320).h(500).build(),
@@ -69,7 +69,7 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(320).h(480).build(),
+                .containsExactly(Format.builder().w(320).h(480).build(),
                         Format.builder().w(336).h(544).build(),
                         Format.builder().w(320).h(568).build(),
                         Format.builder().w(320).h(500).build(),
@@ -81,7 +81,10 @@ public class InterstitialProcessorTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder().banner(Banner.builder().build()).instl(1).build()))
-                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                .device(Device.builder()
+                        .w(1080)
+                        .h(1920)
+                        .pxratio(BigDecimal.valueOf(3))
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(60, 60))))
                         .build())
                 .ext(usePxRatioExt())
@@ -94,8 +97,16 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .contains(Format.builder().w(320).h(480).build())
-                .doesNotContain(Format.builder().w(768).h(1024).build());
+                .containsExactly(Format.builder().w(300).h(600).build(),
+                        Format.builder().w(320).h(480).build(),
+                        Format.builder().w(250).h(600).build(),
+                        Format.builder().w(360).h(640).build(),
+                        Format.builder().w(320).h(640).build(),
+                        Format.builder().w(300).h(480).build(),
+                        Format.builder().w(336).h(544).build(),
+                        Format.builder().w(303).h(603).build(),
+                        Format.builder().w(320).h(568).build(),
+                        Format.builder().w(301).h(601).build());
     }
 
     @Test
@@ -116,7 +127,7 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(320).h(480).build(),
+                .containsExactly(Format.builder().w(320).h(480).build(),
                         Format.builder().w(336).h(544).build(),
                         Format.builder().w(320).h(568).build(),
                         Format.builder().w(320).h(500).build(),
@@ -129,7 +140,10 @@ public class InterstitialProcessorTest extends VertxTest {
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder().banner(Banner.builder().format(singletonList(
                         Format.builder().w(1).h(1).build())).build()).instl(1).build()))
-                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                .device(Device.builder()
+                        .w(1080)
+                        .h(1920)
+                        .pxratio(BigDecimal.valueOf(3))
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(60, 60))))
                         .build())
                 .ext(usePxRatioExt())
@@ -142,8 +156,16 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .contains(Format.builder().w(320).h(480).build())
-                .doesNotContain(Format.builder().w(768).h(1024).build());
+                .containsExactly(Format.builder().w(300).h(600).build(),
+                        Format.builder().w(320).h(480).build(),
+                        Format.builder().w(250).h(600).build(),
+                        Format.builder().w(360).h(640).build(),
+                        Format.builder().w(320).h(640).build(),
+                        Format.builder().w(300).h(480).build(),
+                        Format.builder().w(336).h(544).build(),
+                        Format.builder().w(303).h(603).build(),
+                        Format.builder().w(320).h(568).build(),
+                        Format.builder().w(301).h(601).build());
     }
 
     @Test
@@ -153,7 +175,10 @@ public class InterstitialProcessorTest extends VertxTest {
                 .imp(singletonList(Imp.builder().banner(Banner.builder()
                                 .format(singletonList(Format.builder().w(400).h(600).build())).build()).instl(1)
                         .build()))
-                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                .device(Device.builder()
+                        .w(1080)
+                        .h(1920)
+                        .pxratio(BigDecimal.valueOf(3))
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(80, 80))))
                         .build())
                 .ext(usePxRatioExt())
@@ -166,7 +191,7 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(320).h(480).build(),
+                .containsExactly(Format.builder().w(320).h(480).build(),
                         Format.builder().w(336).h(544).build(),
                         Format.builder().w(320).h(568).build(),
                         Format.builder().w(320).h(500).build(),
@@ -178,7 +203,9 @@ public class InterstitialProcessorTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder().banner(Banner.builder().build()).instl(1).build()))
-                .device(Device.builder().w(1080).h(1920)
+                .device(Device.builder()
+                        .w(1080)
+                        .h(1920)
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(1, 1))))
                         .build())
                 .ext(usePxRatioExt())
@@ -191,7 +218,16 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .contains(Format.builder().w(768).h(1024).build());
+                .containsExactly(Format.builder().w(300).h(250).build(),
+                        Format.builder().w(728).h(90).build(),
+                        Format.builder().w(160).h(600).build(),
+                        Format.builder().w(320).h(50).build(),
+                        Format.builder().w(300).h(600).build(),
+                        Format.builder().w(970).h(250).build(),
+                        Format.builder().w(970).h(1000).build(),
+                        Format.builder().w(320).h(320).build(),
+                        Format.builder().w(768).h(1024).build(),
+                        Format.builder().w(1024).h(768).build());
     }
 
     @Test
@@ -199,7 +235,10 @@ public class InterstitialProcessorTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder().banner(Banner.builder().build()).instl(1).build()))
-                .device(Device.builder().w(1080).h(1920).pxratio(BigDecimal.valueOf(3))
+                .device(Device.builder()
+                        .w(1080)
+                        .h(1920)
+                        .pxratio(BigDecimal.valueOf(3))
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(1, 1))))
                         .build())
                 .build();
@@ -211,7 +250,41 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .contains(Format.builder().w(768).h(1024).build());
+                .containsExactly(Format.builder().w(300).h(250).build(),
+                        Format.builder().w(728).h(90).build(),
+                        Format.builder().w(160).h(600).build(),
+                        Format.builder().w(320).h(50).build(),
+                        Format.builder().w(300).h(600).build(),
+                        Format.builder().w(970).h(250).build(),
+                        Format.builder().w(970).h(1000).build(),
+                        Format.builder().w(320).h(320).build(),
+                        Format.builder().w(768).h(1024).build(),
+                        Format.builder().w(1024).h(768).build());
+    }
+
+    @Test
+    public void processShouldNotTruncateMinimumInterstitialSizeThreshold() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .imp(singletonList(Imp.builder().banner(Banner.builder()
+                                .format(singletonList(Format.builder().w(301).h(500).build())).build()).instl(1)
+                        .build()))
+                .device(Device.builder()
+                        .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(80, 80))))
+                        .build())
+                .build();
+
+        // when
+        final BidRequest result = interstitialProcessor.process(bidRequest);
+
+        // then
+        assertThat(result.getImp())
+                .extracting(Imp::getBanner)
+                .flatExtracting(Banner::getFormat)
+                .containsExactly(Format.builder().w(300).h(480).build(),
+                        Format.builder().w(300).h(500).build(),
+                        Format.builder().w(300).h(431).build(),
+                        Format.builder().w(300).h(430).build());
     }
 
     @Test
@@ -233,7 +306,7 @@ public class InterstitialProcessorTest extends VertxTest {
         assertThat(result.getImp())
                 .extracting(Imp::getBanner)
                 .flatExtracting(Banner::getFormat)
-                .containsOnly(Format.builder().w(300).h(250).build(),
+                .containsExactly(Format.builder().w(300).h(250).build(),
                         Format.builder().w(160).h(600).build(),
                         Format.builder().w(320).h(50).build(),
                         Format.builder().w(300).h(600).build(),

--- a/src/test/java/org/prebid/server/auction/InterstitialProcessorTest.java
+++ b/src/test/java/org/prebid/server/auction/InterstitialProcessorTest.java
@@ -138,8 +138,10 @@ public class InterstitialProcessorTest extends VertxTest {
     public void processShouldReturnBidRequestUpdatedWithInterstitialFormatsUsingDeviceSizeInDipsWhenFormatIsOneToOne() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(Imp.builder().banner(Banner.builder().format(singletonList(
-                        Format.builder().w(1).h(1).build())).build()).instl(1).build()))
+                .imp(singletonList(Imp.builder()
+                        .banner(Banner.builder().format(singletonList(Format.builder().w(1).h(1).build())).build())
+                        .instl(1)
+                        .build()))
                 .device(Device.builder()
                         .w(1080)
                         .h(1920)
@@ -172,8 +174,9 @@ public class InterstitialProcessorTest extends VertxTest {
     public void processShouldNotConvertExplicitFormatSizeUsingDevicePxratio() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(Imp.builder().banner(Banner.builder()
-                                .format(singletonList(Format.builder().w(400).h(600).build())).build()).instl(1)
+                .imp(singletonList(Imp.builder()
+                        .banner(Banner.builder().format(singletonList(Format.builder().w(400).h(600).build())).build())
+                        .instl(1)
                         .build()))
                 .device(Device.builder()
                         .w(1080)
@@ -266,8 +269,9 @@ public class InterstitialProcessorTest extends VertxTest {
     public void processShouldNotTruncateMinimumInterstitialSizeThreshold() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
-                .imp(singletonList(Imp.builder().banner(Banner.builder()
-                                .format(singletonList(Format.builder().w(301).h(500).build())).build()).instl(1)
+                .imp(singletonList(Imp.builder()
+                        .banner(Banner.builder().format(singletonList(Format.builder().w(301).h(500).build())).build())
+                        .instl(1)
                         .build()))
                 .device(Device.builder()
                         .ext(ExtDevice.of(null, ExtDevicePrebid.of(ExtDeviceInt.of(80, 80))))

--- a/src/test/java/org/prebid/server/bidder/nativo/NativoBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/nativo/NativoBidderTest.java
@@ -276,7 +276,7 @@ public class NativoBidderTest extends VertxTest {
                 .imp(singletonList(impCustomizer.apply(Imp.builder().id("imp1")).build()))
                 .ext(ExtRequest.of(ExtRequestPrebid.builder()
                         .sdk(ExtRequestPrebidSdk.of(singletonList(
-                                ExtRequestPrebidSdkRenderer.of(rendererName, rendererVersion, null, null))))
+                                ExtRequestPrebidSdkRenderer.of(rendererName, rendererVersion, null, null)), null))
                         .build()))
                 .build();
     }


### PR DESCRIPTION
## Description

Fixes [#4501](https://github.com/prebid/prebid-server/issues/4501)

Prebid Server was not converting `device.w`/`device.h` from physical pixels to device-independent pixels (DIPs) when generating the list of candidate sizes for interstitial ads. According to the OpenRTB spec, `device.w`/`device.h` represent physical screen pixels, while `banner.format` sizes are expected in DIPs. On high-density screens this caused standard mobile interstitial sizes (e.g. 320x480) to be absent from the generated format list.

This change adds opt-in pxratio conversion controlled by a new field `ext.prebid.sdk.usepxratio`. When set to `true`, `device.w`/`device.h` are divided by `device.pxratio` before being used to calculate the interstitial size bounds. Conversion is only applied when falling back to device dimensions — explicit `banner.format` sizes are left untouched.

## Changes

- Added `usePxRatio` (`Boolean`, JSON: `usepxratio`) field to `ExtRequestPrebidSdk`; added explicit `of()` factory overloads to preserve backward compatibility with existing callers
- Added `usePxRatio(BidRequest)` helper to read the flag from `ext.prebid.sdk`
- Added `deviceSizeToDips(Integer, BigDecimal)` helper: divides by `pxratio` using `doubleValue()`, rounds to nearest integer, clamps to minimum 1; returns size unchanged when `size` or `pxratio` is null or non-positive
- Applied conversion in `processInterstitialImp()` only in the device-size fallback branch

## Testing

- `processShouldReturnBidRequestUpdatedWithInterstitialFormatsUsingDeviceSizeInDipsWhenFormatIsEmpty` — device 1080×1920 @ pxratio 3 → expects 320×480 in results
- `processShouldReturnBidRequestUpdatedWithInterstitialFormatsUsingDeviceSizeInDipsWhenFormatIsOneToOne` — same, with 1×1 sentinel format
- `processShouldNotConvertExplicitFormatSizeUsingDevicePxratio` — explicit banner format is not converted
- `processShouldKeepCurrentDeviceSizeBehaviorWhenUsePxRatioIsAbsent` — no flag, no conversion (backward compatibility)
- `processShouldKeepCurrentDeviceSizeBehaviorWhenUsePxRatioIsTrueAndDevicePxRatioIsAbsent` — flag set but `pxratio` missing, sizes unchanged
