### PR TITLE
Bugfix: Filter usersyncs with empty cookie family name

### DIFF
--- a/src/main/java/org/prebid/server/spring/config/bidder/util/BidderDepsAssembler.java
+++ b/src/main/java/org/prebid/server/spring/config/bidder/util/BidderDepsAssembler.java
@@ -149,6 +149,7 @@ public class BidderDepsAssembler<CFG extends BidderConfigurationProperties> {
     private Usersyncer usersyncer(CFG configProperties, CookieFamilySource cookieFamilySource) {
         final UsersyncConfigurationProperties usersync = configProperties.getUsersync();
         final boolean usersyncPresent = usersync != null
+                && StringUtils.isNotBlank(usersync.getCookieFamilyName())
                 && ObjectUtils.anyNotNull(usersync.getRedirect(), usersync.getIframe());
         return usersyncPresent ? usersyncerCreator.apply(usersync, cookieFamilySource) : null;
     }


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [ ] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Usersync without a cookie family name has no meaning. We should filter those.