### PR TITLE
Validate url domain and path

### DIFF
--- a/src/main/java/org/prebid/server/bidder/acuityads/AcuityadsBidder.java
+++ b/src/main/java/org/prebid/server/bidder/acuityads/AcuityadsBidder.java
@@ -95,7 +95,7 @@ public class AcuityadsBidder implements Bidder<BidRequest> {
 
     private String resolveEndpoint(String host, String accountId) {
         return endpointUrl
-                .replace(URL_HOST_MACRO, StringUtils.stripToEmpty(host))
+                .replace(URL_HOST_MACRO, HttpUtil.validateDomainName(StringUtils.stripToEmpty(host)))
                 .replace(URL_ACCOUNT_ID_MACRO, StringUtils.stripToEmpty(accountId));
     }
 

--- a/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adhese/AdheseBidder.java
@@ -78,7 +78,7 @@ public class AdheseBidder implements Bidder<BidRequest> {
     }
 
     private String getUrl(ExtImpAdhese extImpAdhese) {
-        return endpointUrl.replace("{{AccountId}}", extImpAdhese.getAccount());
+        return endpointUrl.replace("{{AccountId}}", HttpUtil.validateDomainName(extImpAdhese.getAccount()));
     }
 
     private BidRequest modifyBidRequest(BidRequest bidRequest, ExtImpAdhese extImpAdhese) {

--- a/src/main/java/org/prebid/server/bidder/adtonos/AdtonosBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adtonos/AdtonosBidder.java
@@ -63,7 +63,7 @@ public class AdtonosBidder implements Bidder<BidRequest> {
     }
 
     private String makeUrl(ExtImpAdtonos extImp) {
-        return endpointUrl.replace(PUBLISHER_ID_MACRO, extImp.getSupplierId());
+        return endpointUrl.replace(PUBLISHER_ID_MACRO, HttpUtil.validatePathSegment(extImp.getSupplierId()));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/adview/AdviewBidder.java
+++ b/src/main/java/org/prebid/server/bidder/adview/AdviewBidder.java
@@ -131,7 +131,7 @@ public class AdviewBidder implements Bidder<BidRequest> {
     }
 
     private String resolveEndpoint(String accountId) {
-        return endpointUrl.replace(ACCOUNT_ID_MACRO, HttpUtil.encodeUrl(accountId));
+        return endpointUrl.replace(ACCOUNT_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(accountId)));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/axonix/AxonixBidder.java
+++ b/src/main/java/org/prebid/server/bidder/axonix/AxonixBidder.java
@@ -67,7 +67,7 @@ public class AxonixBidder implements Bidder<BidRequest> {
     }
 
     private String resolveEndpoint(String supplyId) {
-        return endpointUrl.replace(URL_SUPPLY_ID_MACRO, HttpUtil.encodeUrl(supplyId));
+        return endpointUrl.replace(URL_SUPPLY_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(supplyId)));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/bidmachine/BidmachineBidder.java
+++ b/src/main/java/org/prebid/server/bidder/bidmachine/BidmachineBidder.java
@@ -142,9 +142,9 @@ public class BidmachineBidder implements Bidder<BidRequest> {
     }
 
     private String buildEndpointUrl(ExtImpBidmachine extImpBidmachine) {
-        return endpointUrl.replace("{{HOST}}", extImpBidmachine.getHost())
-                .replace("{{PATH}}", extImpBidmachine.getPath())
-                .replace("{{SELLER_ID}}", extImpBidmachine.getSellerId());
+        return endpointUrl.replace("{{HOST}}", HttpUtil.validateDomainName(extImpBidmachine.getHost()))
+                .replace("{{PATH}}", HttpUtil.validatePathSegment(extImpBidmachine.getPath()))
+                .replace("{{SELLER_ID}}", HttpUtil.validatePathSegment(extImpBidmachine.getSellerId()));
     }
 
     private ExtPrebid<ExtImpPrebid, ExtImpBidmachine> parseImpExt(Imp imp) {

--- a/src/main/java/org/prebid/server/bidder/blis/BlisBidder.java
+++ b/src/main/java/org/prebid/server/bidder/blis/BlisBidder.java
@@ -72,7 +72,7 @@ public class BlisBidder implements Bidder<BidRequest> {
     }
 
     private String makeUrl(String supplyId) {
-        return endpointUrl.replace(SUPPLY_ID_MACRO, HttpUtil.encodeUrl(supplyId));
+        return endpointUrl.replace(SUPPLY_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(supplyId)));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/clydo/ClydoBidder.java
+++ b/src/main/java/org/prebid/server/bidder/clydo/ClydoBidder.java
@@ -111,7 +111,7 @@ public class ClydoBidder implements Bidder<BidRequest> {
     private static String resolveUrl(String endpoint, ExtImpClydo extImp) {
         return endpoint
                 .replace(REGION_MACRO, getRegionInfo(extImp))
-                .replace(PARTNER_ID_MACRO, HttpUtil.encodeUrl(extImp.getPartnerId()));
+                .replace(PARTNER_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(extImp.getPartnerId())));
     }
 
     private static String getRegionInfo(ExtImpClydo extImp) {

--- a/src/main/java/org/prebid/server/bidder/contxtful/ContxtfulBidder.java
+++ b/src/main/java/org/prebid/server/bidder/contxtful/ContxtfulBidder.java
@@ -129,7 +129,7 @@ public class ContxtfulBidder implements Bidder<ContxtfulCompositeRequest> {
     }
 
     private String makeUrl(String customerId) {
-        return endpointUrl.replace(ACCOUNT_ID_MACRO, HttpUtil.encodeUrl(customerId));
+        return endpointUrl.replace(ACCOUNT_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(customerId)));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/elementaltv/ElementalTVBidder.java
+++ b/src/main/java/org/prebid/server/bidder/elementaltv/ElementalTVBidder.java
@@ -86,7 +86,7 @@ public class ElementalTVBidder implements Bidder<BidRequest> {
     private String resolveUrl(ExtImpElementalTV extImp) {
         try {
             return endpointTemplate
-                    .replace("{{AdUnit}}", HttpUtil.encodeUrl(extImp.getAdunit()));
+                    .replace("{{AdUnit}}", HttpUtil.encodeUrl(HttpUtil.validatePathSegment(extImp.getAdunit())));
         } catch (Exception e) {
             throw new PreBidException(e.getMessage());
         }

--- a/src/main/java/org/prebid/server/bidder/eplanning/EplanningBidder.java
+++ b/src/main/java/org/prebid/server/bidder/eplanning/EplanningBidder.java
@@ -232,7 +232,12 @@ public class EplanningBidder implements Bidder<Void> {
                 ? app.getBundle()
                 : pageDomain;
 
-        final String uri = "%s/%s/%s/%s/%s".formatted(endpointUrl, clientId, DFP_CLIENT_ID, requestTarget, SEC);
+        final String uri = "%s/%s/%s/%s/%s".formatted(
+                endpointUrl,
+                HttpUtil.validatePathSegment(clientId),
+                DFP_CLIENT_ID,
+                HttpUtil.validatePathSegment(requestTarget),
+                SEC);
 
         final URIBuilder uriBuilder;
         try {

--- a/src/main/java/org/prebid/server/bidder/gamoshi/GamoshiBidder.java
+++ b/src/main/java/org/prebid/server/bidder/gamoshi/GamoshiBidder.java
@@ -57,7 +57,7 @@ public class GamoshiBidder implements Bidder<BidRequest> {
 
         if (validImps.isEmpty()) {
             errors.add(BidderError.badInput("No valid impressions in the bid request"));
-            return Result.of(Collections.emptyList(), errors);
+            return Result.of(Collections.<HttpRequest<BidRequest>>emptyList(), errors);
         }
 
         final ExtImpGamoshi firstImpExt;
@@ -69,7 +69,9 @@ public class GamoshiBidder implements Bidder<BidRequest> {
 
         final BidRequest outgoingRequest = request.toBuilder().imp(validImps).build();
 
-        final String requestUrl = endpointUrl + "/r/" + firstImpExt.getSupplyPartnerId() + "/bidr?bidder=prebid-server";
+        final String requestUrl = endpointUrl + "/r/"
+                + HttpUtil.validatePathSegment(firstImpExt.getSupplyPartnerId())
+                + "/bidr?bidder=prebid-server";
         final MultiMap headers = resolveHeaders(request.getDevice());
 
         return Result.of(Collections.singletonList(

--- a/src/main/java/org/prebid/server/bidder/imds/ImdsBidder.java
+++ b/src/main/java/org/prebid/server/bidder/imds/ImdsBidder.java
@@ -95,7 +95,8 @@ public class ImdsBidder implements Bidder<BidRequest> {
     }
 
     private String generateEndpointUrl(ExtImpImds firstExtImp) {
-        final String accountId = URLEncoder.encode(firstExtImp.getSeatId(), StandardCharsets.UTF_8);
+        final String accountId = URLEncoder.encode(
+                HttpUtil.validatePathSegment(firstExtImp.getSeatId()), StandardCharsets.UTF_8);
         final String sourceId = URLEncoder.encode(prebidVersion, StandardCharsets.UTF_8);
         return endpointUrl
                 .replaceAll("\\{\\{AccountID}}", accountId)

--- a/src/main/java/org/prebid/server/bidder/kayzen/KayzenBidder.java
+++ b/src/main/java/org/prebid/server/bidder/kayzen/KayzenBidder.java
@@ -71,7 +71,8 @@ public class KayzenBidder implements Bidder<BidRequest> {
     }
 
     private HttpRequest<BidRequest> createRequest(ExtImpKayzen extImpKayzen, BidRequest request, List<Imp> imps) {
-        final String url = endpointUrl.replace(URL_ZONE_ID_MACRO, extImpKayzen.getZone())
+        final String url = endpointUrl
+                .replace(URL_ZONE_ID_MACRO, HttpUtil.validateDomainName(extImpKayzen.getZone()))
                 .replace(URL_ACCOUNT_ID_MACRO, extImpKayzen.getExchange());
         final BidRequest outgoingRequest = request.toBuilder().imp(imps).build();
 

--- a/src/main/java/org/prebid/server/bidder/kueezrtb/KueezRtbBidder.java
+++ b/src/main/java/org/prebid/server/bidder/kueezrtb/KueezRtbBidder.java
@@ -67,7 +67,8 @@ public class KueezRtbBidder implements Bidder<BidRequest> {
 
     private HttpRequest<BidRequest> makeHttpRequest(BidRequest bidRequest, Imp imp, KueezRtbImpExt impExt) {
         final BidRequest modifiedBidRequest = bidRequest.toBuilder().imp(Collections.singletonList(imp)).build();
-        final String uri = endpointUrl + HttpUtil.encodeUrl(StringUtils.defaultString(impExt.getConnectionId()).trim());
+        final String uri = endpointUrl + HttpUtil.encodeUrl(
+                HttpUtil.validatePathSegment(StringUtils.defaultString(impExt.getConnectionId()).trim()));
 
         return BidderUtil.defaultRequest(modifiedBidRequest, uri, mapper);
     }

--- a/src/main/java/org/prebid/server/bidder/madvertise/MadvertiseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/madvertise/MadvertiseBidder.java
@@ -89,7 +89,7 @@ public class MadvertiseBidder implements Bidder<BidRequest> {
     }
 
     private HttpRequest<BidRequest> createRequest(BidRequest request, String zoneID) {
-        final String url = endpointUrl.replace(ZONE_ID_MACRO, HttpUtil.encodeUrl(zoneID));
+        final String url = endpointUrl.replace(ZONE_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(zoneID)));
 
         return HttpRequest.<BidRequest>builder()
                 .method(HttpMethod.POST)

--- a/src/main/java/org/prebid/server/bidder/mgid/MgidBidder.java
+++ b/src/main/java/org/prebid/server/bidder/mgid/MgidBidder.java
@@ -69,7 +69,10 @@ public class MgidBidder implements Bidder<BidRequest> {
                 .imp(imps)
                 .build();
 
-        return Result.withValue(BidderUtil.defaultRequest(outgoingRequest, endpointUrl + accountId, mapper));
+        return Result.withValue(BidderUtil.defaultRequest(
+                outgoingRequest,
+                endpointUrl + HttpUtil.validatePathSegment(accountId),
+                mapper));
     }
 
     private ExtImpMgid parseImpExt(Imp imp) {

--- a/src/main/java/org/prebid/server/bidder/onetag/OnetagBidder.java
+++ b/src/main/java/org/prebid/server/bidder/onetag/OnetagBidder.java
@@ -54,7 +54,8 @@ public class OnetagBidder implements Bidder<BidRequest> {
             }
         }
 
-        final String url = endpointUrl.replace(URL_PUBLISHER_ID_MACRO, StringUtils.defaultString(requestPubId));
+        final String url = endpointUrl.replace(
+                URL_PUBLISHER_ID_MACRO, HttpUtil.validatePathSegment(StringUtils.defaultString(requestPubId)));
         return Result.withValue(BidderUtil.defaultRequest(request, url, mapper));
     }
 

--- a/src/main/java/org/prebid/server/bidder/operaads/OperaadsBidder.java
+++ b/src/main/java/org/prebid/server/bidder/operaads/OperaadsBidder.java
@@ -179,7 +179,8 @@ public class OperaadsBidder implements Bidder<BidRequest> {
 
     private String resolveUrl(ExtImpOperaads extImpOperaads) {
         return endpointUrl
-                .replace(PUBLISHER_ID_MACRO, HttpUtil.encodeUrl(extImpOperaads.getPublisherId()))
+                .replace(PUBLISHER_ID_MACRO,
+                        HttpUtil.encodeUrl(HttpUtil.validatePathSegment(extImpOperaads.getPublisherId())))
                 .replace(ACCOUNT_ID_MACRO, HttpUtil.encodeUrl(extImpOperaads.getEndpointId()));
     }
 

--- a/src/main/java/org/prebid/server/bidder/ownadx/OwnAdxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/ownadx/OwnAdxBidder.java
@@ -88,8 +88,10 @@ public class OwnAdxBidder implements Bidder<BidRequest> {
     private String makeUrl(ExtImpOwnAdx extImpOwnAdx) {
         final Optional<ExtImpOwnAdx> ownAdx = Optional.ofNullable(extImpOwnAdx);
         return endpointUrl
-                .replace(SEAT_ID_MACROS_ENDPOINT, ownAdx.map(ExtImpOwnAdx::getSeatId).orElse(StringUtils.EMPTY))
-                .replace(SSP_ID_MACROS_ENDPOINT, ownAdx.map(ExtImpOwnAdx::getSspId).orElse(StringUtils.EMPTY))
+                .replace(SEAT_ID_MACROS_ENDPOINT,
+                        HttpUtil.validatePathSegment(ownAdx.map(ExtImpOwnAdx::getSeatId).orElse(StringUtils.EMPTY)))
+                .replace(SSP_ID_MACROS_ENDPOINT,
+                        HttpUtil.validatePathSegment(ownAdx.map(ExtImpOwnAdx::getSspId).orElse(StringUtils.EMPTY)))
                 .replace(TOKEN_ID_MACROS_ENDPOINT, ownAdx.map(ExtImpOwnAdx::getTokenId).orElse(StringUtils.EMPTY));
     }
 

--- a/src/main/java/org/prebid/server/bidder/rediads/RediadsBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rediads/RediadsBidder.java
@@ -125,7 +125,8 @@ public class RediadsBidder implements Bidder<BidRequest> {
     }
 
     private String resolveEndpointUrl(String subdomain) {
-        return endpointUrl.replace(SUBDOMAIN_MACRO, StringUtils.defaultIfBlank(subdomain, defaultSubdomain));
+        return endpointUrl.replace(
+                SUBDOMAIN_MACRO, HttpUtil.validateDomainName(StringUtils.defaultIfBlank(subdomain, defaultSubdomain)));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/relevantdigital/RelevantDigitalBidder.java
+++ b/src/main/java/org/prebid/server/bidder/relevantdigital/RelevantDigitalBidder.java
@@ -174,7 +174,7 @@ public class RelevantDigitalBidder implements Bidder<BidRequest> {
                 .replace("http://", "")
                 .replace("https://", "")
                 .replace(".relevant-digital.com", "");
-        return endpointUrl.replace(HOST_MACRO, modifiedHost);
+        return endpointUrl.replace(HOST_MACRO, HttpUtil.validateDomainName(modifiedHost));
     }
 
     private static MultiMap makeHeaders(BidRequest bidRequest) {

--- a/src/main/java/org/prebid/server/bidder/roulax/RoulaxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/roulax/RoulaxBidder.java
@@ -66,7 +66,8 @@ public class RoulaxBidder implements Bidder<BidRequest> {
 
     private String resolveEndpoint(ExtImpRoulax extImpRoulax) {
         return endpointUrl
-                .replace(PUBLISHER_PATH_MACRO, StringUtils.defaultString(extImpRoulax.getPublisherPath()).trim())
+                .replace(PUBLISHER_PATH_MACRO,
+                        HttpUtil.validatePathSegment(StringUtils.defaultString(extImpRoulax.getPublisherPath()).trim()))
                 .replace(ACCOUNT_ID_MACRO, StringUtils.defaultString(extImpRoulax.getPid()).trim());
     }
 

--- a/src/main/java/org/prebid/server/bidder/silvermob/SilvermobBidder.java
+++ b/src/main/java/org/prebid/server/bidder/silvermob/SilvermobBidder.java
@@ -104,8 +104,8 @@ public class SilvermobBidder implements Bidder<BidRequest> {
 
     private String resolveEndpoint(ExtImpSilvermob extImp) {
         return endpointUrl
-                .replace(URL_HOST_MACRO, extImp.getHost())
-                .replace(URL_ZONE_ID_MACRO, HttpUtil.encodeUrl(extImp.getZoneId()));
+                .replace(URL_HOST_MACRO, HttpUtil.validateDomainName(extImp.getHost()))
+                .replace(URL_ZONE_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(extImp.getZoneId())));
     }
 
     private static MultiMap resolveHeaders(Device device) {

--- a/src/main/java/org/prebid/server/bidder/smartyads/SmartyAdsBidder.java
+++ b/src/main/java/org/prebid/server/bidder/smartyads/SmartyAdsBidder.java
@@ -97,7 +97,7 @@ public class SmartyAdsBidder implements Bidder<BidRequest> {
 
     private String resolveUrl(ExtImpSmartyAds extImp) {
         return endpointUrl
-                .replace(URL_HOST_MACRO, extImp.getHost())
+                .replace(URL_HOST_MACRO, HttpUtil.validateDomainName(extImp.getHost()))
                 .replace(URL_SOURCE_ID_MACRO, HttpUtil.encodeUrl(extImp.getSourceId()))
                 .replace(URL_ACCOUNT_ID_MACRO, HttpUtil.encodeUrl(extImp.getAccountId()));
     }

--- a/src/main/java/org/prebid/server/bidder/smilewanted/SmileWantedBidder.java
+++ b/src/main/java/org/prebid/server/bidder/smilewanted/SmileWantedBidder.java
@@ -56,7 +56,8 @@ public class SmileWantedBidder implements Bidder<BidRequest> {
         }
 
         final BidRequest outgoingRequest = request.toBuilder().at(DEFAULT_AT).build();
-        final String url = endpointUrl.replace(ZONE_ID_MACRO, HttpUtil.encodeUrl(extImpSmilewanted.getZoneId()));
+        final String url = endpointUrl.replace(
+                ZONE_ID_MACRO, HttpUtil.encodeUrl(HttpUtil.validatePathSegment(extImpSmilewanted.getZoneId())));
 
         return Result.withValue(BidderUtil.defaultRequest(
                 outgoingRequest,

--- a/src/main/java/org/prebid/server/bidder/tappx/TappxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/tappx/TappxBidder.java
@@ -23,6 +23,7 @@ import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
 import org.prebid.server.proto.openrtb.ext.request.tappx.ExtImpTappx;
 import org.prebid.server.proto.openrtb.ext.response.BidType;
 import org.prebid.server.util.BidderUtil;
+import org.prebid.server.util.HttpUtil;
 
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
@@ -101,7 +102,8 @@ public class TappxBidder implements Bidder<BidRequest> {
 
         if (!isNewEndpoint) {
             final List<String> pathSegments = uriBuilder.getPathSegments();
-            uriBuilder.setPathSegments(ListUtils.union(pathSegments, Collections.singletonList(subdomain)));
+            uriBuilder.setPathSegments(ListUtils.union(pathSegments,
+                    Collections.singletonList(HttpUtil.validatePathSegment(subdomain))));
         }
 
         uriBuilder.addParameter("tappxkey", extImpTappx.getTappxkey());

--- a/src/main/java/org/prebid/server/bidder/thetradedesk/TheTradeDeskBidder.java
+++ b/src/main/java/org/prebid/server/bidder/thetradedesk/TheTradeDeskBidder.java
@@ -175,7 +175,8 @@ public class TheTradeDeskBidder implements Bidder<BidRequest> {
     private String resolveEndpoint(String sourceSupplyId) {
         return endpointUrl.replace(
                 SUPPLY_ID_MACRO,
-                HttpUtil.encodeUrl(StringUtils.defaultString(ObjectUtils.defaultIfNull(sourceSupplyId, supplyId))));
+                HttpUtil.encodeUrl(HttpUtil.validatePathSegment(
+                        StringUtils.defaultString(ObjectUtils.defaultIfNull(sourceSupplyId, supplyId)))));
     }
 
     @Override

--- a/src/main/java/org/prebid/server/bidder/tradplus/TradPlusBidder.java
+++ b/src/main/java/org/prebid/server/bidder/tradplus/TradPlusBidder.java
@@ -79,8 +79,9 @@ public class TradPlusBidder implements Bidder<BidRequest> {
     private HttpRequest<BidRequest> makeHttpRequest(ExtImpTradPlus extImpTradPlus, List<Imp> imps,
                                                     BidRequest bidRequest) {
         final String uri;
-        uri = endpointUrl.replace(ZONE_ID, extImpTradPlus.getZoneId()).replace(ACCOUNT_ID,
-                extImpTradPlus.getAccountId());
+        uri = endpointUrl
+                .replace(ZONE_ID, HttpUtil.validateDomainName(extImpTradPlus.getZoneId()))
+                .replace(ACCOUNT_ID, HttpUtil.validatePathSegment(extImpTradPlus.getAccountId()));
 
         final BidRequest outgoingRequest = bidRequest.toBuilder().imp(removeImpsExt(imps)).build();
 

--- a/src/main/java/org/prebid/server/bidder/trafficgate/TrafficGateBidder.java
+++ b/src/main/java/org/prebid/server/bidder/trafficgate/TrafficGateBidder.java
@@ -65,7 +65,7 @@ public class TrafficGateBidder implements Bidder<BidRequest> {
     }
 
     private String resolveHost(ExtImpTrafficGate extImpTrafficGate) {
-        return endpointUrl.replace(SUBDOMAIN_MACRO, extImpTrafficGate.getHost());
+        return endpointUrl.replace(SUBDOMAIN_MACRO, HttpUtil.validateDomainName(extImpTrafficGate.getHost()));
     }
 
     private ExtImpTrafficGate parseImpExt(Imp imp) {

--- a/src/main/java/org/prebid/server/bidder/ucfunnel/UcfunnelBidder.java
+++ b/src/main/java/org/prebid/server/bidder/ucfunnel/UcfunnelBidder.java
@@ -63,7 +63,8 @@ public class UcfunnelBidder implements Bidder<BidRequest> {
             errors.add(BidderError.badInput(e.getMessage()));
         }
 
-        final String requestUrl = "%s/%s/request".formatted(endpointUrl, HttpUtil.encodeUrl(partnerId));
+        final String requestUrl = "%s/%s/request".formatted(endpointUrl,
+                HttpUtil.encodeUrl(HttpUtil.validatePathSegment(partnerId)));
 
         return Result.of(Collections.singletonList(BidderUtil.defaultRequest(request, requestUrl, mapper)),
                 errors);

--- a/src/main/java/org/prebid/server/bidder/vidazoo/VidazooBidder.java
+++ b/src/main/java/org/prebid/server/bidder/vidazoo/VidazooBidder.java
@@ -68,7 +68,8 @@ public class VidazooBidder implements Bidder<BidRequest> {
 
     private HttpRequest<BidRequest> makeHttpRequest(BidRequest bidRequest, Imp imp, VidazooImpExt impExt) {
         final BidRequest modifiedBidRequest = bidRequest.toBuilder().imp(Collections.singletonList(imp)).build();
-        final String uri = endpointUrl + HttpUtil.encodeUrl(StringUtils.defaultString(impExt.getConnectionId()).trim());
+        final String uri = endpointUrl + HttpUtil.encodeUrl(
+                HttpUtil.validatePathSegment(StringUtils.defaultString(impExt.getConnectionId()).trim()));
 
         return BidderUtil.defaultRequest(modifiedBidRequest, uri, mapper);
     }

--- a/src/main/java/org/prebid/server/bidder/yeahmobi/YeahmobiBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yeahmobi/YeahmobiBidder.java
@@ -120,7 +120,7 @@ public class YeahmobiBidder implements Bidder<BidRequest> {
     private HttpRequest<BidRequest> makeHttpRequest(BidRequest request, String zoneId) {
         return BidderUtil.defaultRequest(
                 request,
-                endpointUrl.replace(HOST_MACRO, HOST_PATTERN.formatted(zoneId)),
+                endpointUrl.replace(HOST_MACRO, HttpUtil.validateDomainName(HOST_PATTERN.formatted(zoneId))),
                 mapper);
     }
 

--- a/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
+++ b/src/main/java/org/prebid/server/bidder/yieldlab/YieldlabBidder.java
@@ -153,7 +153,8 @@ public class YieldlabBidder implements Bidder<Void> {
     }
 
     private String makeUrl(ExtImpYieldlab extImpYieldlab, BidRequest request, Map<String, ExtImpYieldlab> extImps) {
-        final String updatedPath = "%s/%s".formatted(endpointUrl, extImpYieldlab.getAdslotId());
+        final String updatedPath = "%s/%s".formatted(
+                endpointUrl, HttpUtil.validatePathSegment(extImpYieldlab.getAdslotId()));
 
         final URIBuilder uriBuilder;
         try {
@@ -546,9 +547,9 @@ public class YieldlabBidder implements Bidder<Void> {
         }
 
         return AD_SOURCE_URL.formatted(
-                extImp.getAdslotId(),
-                extImp.getSupplyId(),
-                yieldlabBid.getAdSize(),
+                HttpUtil.validatePathSegment(extImp.getAdslotId()),
+                HttpUtil.validatePathSegment(extImp.getSupplyId()),
+                HttpUtil.validatePathSegment(yieldlabBid.getAdSize()),
                 uriBuilder.toString().replace("?", ""));
     }
 

--- a/src/main/java/org/prebid/server/bidder/zeroclickfraud/ZeroclickfraudBidder.java
+++ b/src/main/java/org/prebid/server/bidder/zeroclickfraud/ZeroclickfraudBidder.java
@@ -90,7 +90,7 @@ public class ZeroclickfraudBidder implements Bidder<BidRequest> {
     private HttpRequest<BidRequest> makeHttpRequest(ExtImpZeroclickfraud extImpZeroclickfraud, List<Imp> imps,
                                                     BidRequest bidRequest) {
         final String uri = endpointTemplate
-                .replace(HOST, extImpZeroclickfraud.getHost())
+                .replace(HOST, HttpUtil.validateDomainName(extImpZeroclickfraud.getHost()))
                 .replace(SOURCE_ID, extImpZeroclickfraud.getSourceId().toString());
 
         final BidRequest outgoingRequest = bidRequest.toBuilder().imp(imps).build();

--- a/src/main/java/org/prebid/server/util/HttpUtil.java
+++ b/src/main/java/org/prebid/server/util/HttpUtil.java
@@ -9,6 +9,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
+import org.prebid.server.exception.PreBidException;
 import org.prebid.server.log.ConditionalLogger;
 import org.prebid.server.log.Logger;
 import org.prebid.server.log.LoggerFactory;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -85,6 +87,9 @@ public final class HttpUtil {
     public static final String MACROS_OPEN = "{{";
     public static final String MACROS_CLOSE = "}}";
 
+    private static final Pattern VALID_DOMAIN = Pattern.compile("^[a-zA-Z0-9.-]+(:[0-9]+)?$");
+    private static final String INVALID_PATH_CHARACTERS = "?#\\";
+
     private static final UrlValidator URL_VALIDAROR = UrlValidator.getInstance();
 
     private HttpUtil() {
@@ -117,6 +122,30 @@ public final class HttpUtil {
     // TODO: We need our own way to work with url macrosses
     private static boolean containsMacrosses(String url) {
         return StringUtils.contains(url, MACROS_OPEN) && StringUtils.contains(url, MACROS_CLOSE);
+    }
+
+    public static String validateDomainName(String domainName) {
+        if (!VALID_DOMAIN.matcher(domainName).matches()) {
+            throw new PreBidException("Domain name %s contains invalid characters".formatted(domainName));
+        }
+        return domainName;
+    }
+
+    public static String validatePathSegment(String pathSegment) {
+        for (char c : INVALID_PATH_CHARACTERS.toCharArray()) {
+            if (pathSegment.indexOf(c) != -1) {
+                throw new PreBidException("Path segment %s contains forbidden character %s".formatted(pathSegment, c));
+            }
+        }
+
+        if (pathSegment.contains("//")) {
+            throw new PreBidException("Path segment %s contains forbidden sequence %s".formatted(pathSegment, "//"));
+        }
+        if (Arrays.asList(pathSegment.split("/")).contains("..")) {
+            throw new PreBidException("Path segment %s contains forbidden segment %s".formatted(pathSegment, ".."));
+        }
+
+        return pathSegment;
     }
 
     /**
@@ -230,10 +259,10 @@ public final class HttpUtil {
                 .filter(entry -> !isSensitiveHeader(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey,
                         entry -> StringUtils.isNotBlank(entry.getValue())
-                                ? Arrays.stream(entry.getValue().split(","))
+                                 ? Arrays.stream(entry.getValue().split(","))
                                 .map(String::trim)
                                 .toList()
-                                : Collections.singletonList(entry.getValue())))
+                                 : Collections.singletonList(entry.getValue())))
                 : null;
     }
 

--- a/src/main/java/org/prebid/server/util/HttpUtil.java
+++ b/src/main/java/org/prebid/server/util/HttpUtil.java
@@ -125,6 +125,12 @@ public final class HttpUtil {
     }
 
     public static String validateDomainName(String domainName) {
+        if (domainName == null) {
+            throw new PreBidException("Domain name is null");
+        }
+        if (domainName.isEmpty()) {
+            return domainName;
+        }
         if (!VALID_DOMAIN.matcher(domainName).matches()) {
             throw new PreBidException("Domain name %s contains invalid characters".formatted(domainName));
         }

--- a/src/main/resources/bidder-config/clydo.yaml
+++ b/src/main/resources/bidder-config/clydo.yaml
@@ -1,6 +1,6 @@
 adapters:
   clydo:
-    endpoint: http://region={{Region}}.clydo.io/partnerId={{PartnerId}}
+    endpoint: http://{{Region}}.clydo.io/{{PartnerId}}
     modifying-vast-xml-allowed: true
     endpoint-compression: gzip
     geoscope:

--- a/src/test/java/org/prebid/server/util/HttpUtilTest.java
+++ b/src/test/java/org/prebid/server/util/HttpUtilTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.prebid.server.exception.PreBidException;
 import org.prebid.server.model.CaseInsensitiveMultiMap;
 import org.prebid.server.model.HttpRequestContext;
 
@@ -18,6 +19,7 @@ import java.util.function.Consumer;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
@@ -60,6 +62,75 @@ public class HttpUtilTest {
         // then
         assertThat(url).isNotNull();
         assertThat(url).isEqualTo("http://domain.org/query-string?a=1");
+    }
+
+    @Test
+    public void validateDomainNameShouldReturnExpectedDomainName() {
+        // when and then
+        assertThat(HttpUtil.validateDomainName("example.com")).isEqualTo("example.com");
+        assertThat(HttpUtil.validateDomainName("sub.domain-example.com")).isEqualTo("sub.domain-example.com");
+        assertThat(HttpUtil.validateDomainName("127.0.0.1")).isEqualTo("127.0.0.1");
+        assertThat(HttpUtil.validateDomainName("example.com:8080")).isEqualTo("example.com:8080");
+    }
+
+    @Test
+    public void validateDomainNameShouldFailOnInvalidCharacters() {
+        // when and then
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validateDomainName("example.com/path"))
+                .withMessage("Domain name example.com/path contains invalid characters");
+
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validateDomainName("example@com"))
+                .withMessage("Domain name example@com contains invalid characters");
+
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validateDomainName("example.com:port"))
+                .withMessage("Domain name example.com:port contains invalid characters");
+    }
+
+    @Test
+    public void validatePathSegmentShouldReturnExpectedPathSegment() {
+        // when and then
+        assertThat(HttpUtil.validatePathSegment("path")).isEqualTo("path");
+        assertThat(HttpUtil.validatePathSegment("path/to/resource")).isEqualTo("path/to/resource");
+        assertThat(HttpUtil.validatePathSegment(".")).isEqualTo(".");
+    }
+
+    @Test
+    public void validatePathSegmentShouldFailOnForbiddenCharacter() {
+        // when and then
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validatePathSegment("path?query"))
+                .withMessage("Path segment path?query contains forbidden character ?");
+
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validatePathSegment("path#fragment"))
+                .withMessage("Path segment path#fragment contains forbidden character #");
+
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validatePathSegment("path\\segment"))
+                .withMessage("Path segment path\\segment contains forbidden character \\");
+    }
+
+    @Test
+    public void validatePathSegmentShouldFailOnDoubleSlash() {
+        // when and then
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validatePathSegment("path//segment"))
+                .withMessage("Path segment path//segment contains forbidden sequence //");
+    }
+
+    @Test
+    public void validatePathSegmentShouldFailOnSegmentContainingTwoDots() {
+        // when and then
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validatePathSegment("path/../segment"))
+                .withMessage("Path segment path/../segment contains forbidden segment ..");
+
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validatePathSegment(".."))
+                .withMessage("Path segment .. contains forbidden segment ..");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/util/HttpUtilTest.java
+++ b/src/test/java/org/prebid/server/util/HttpUtilTest.java
@@ -71,6 +71,15 @@ public class HttpUtilTest {
         assertThat(HttpUtil.validateDomainName("sub.domain-example.com")).isEqualTo("sub.domain-example.com");
         assertThat(HttpUtil.validateDomainName("127.0.0.1")).isEqualTo("127.0.0.1");
         assertThat(HttpUtil.validateDomainName("example.com:8080")).isEqualTo("example.com:8080");
+        assertThat(HttpUtil.validateDomainName("")).isEqualTo("");
+    }
+
+    @Test
+    public void validateDomainNameShouldFailOnNull() {
+        // when and then
+        assertThatExceptionOfType(PreBidException.class)
+                .isThrownBy(() -> HttpUtil.validateDomainName(null))
+                .withMessage("Domain name is null");
     }
 
     @Test


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bugfix

### ✨ What's the context?
https://github.com/prebid/prebid-server/pull/4802

Bidders with host validation added:
- acuityads
- adhese
- bidmachine
- kayzen
- rediads
- relevantdigital
- silvermob
- smartyads
- tradplus
- trafficgate
- yeahmobi
- zeroclickfraud

Bidders with path segment validation added:
- adtonos
- adview
- axonix
- bidmachine
- blis
- clydo (uses enum for host part)
- contxtful
- elementaltv
- eplanning
- gamoshi
- imds
- kueezrtb
- madvertise
- onetag
- operaads
- ownadx
- roulax
- silvermob
- smilewanted
- tappx
- thetradedesk
- tradplus
- ucfunnel
- vidazoo
- yieldlab

Bidders without changes, because they use enum in json schema or validate in the bidder code that value can only take enum values:
- adot
- algorix
- between
- taboola

Bidders without changes, because they replace macro with a number:
- improvedigital
- intertech
- invibes (static string + number)
- limelightDigital
- yandex

