### PR TITLE
medianet: add regional endpoint support

### DIFF
--- a/src/main/resources/bidder-config/medianet.yaml
+++ b/src/main/resources/bidder-config/medianet.yaml
@@ -7,8 +7,8 @@ adapters:
     #   Asia     → https://prebid-adapter-asia.media.net/rtb/pb/prebids2s
     #   Europe   → https://prebid-adapter-eu.media.net/rtb/pb/prebids2s
     #
-    # Replace REGION in the endpoint URL with: useast | uswest | asia | eu
-    endpoint: https://prebid-adapter-REGION.media.net/rtb/pb/prebids2s?src={{PREBID_SERVER_ENDPOINT}}
+    # Replace [REGION] in the endpoint URL with: useast | uswest | asia | eu
+    endpoint: https://prebid-adapter-[REGION].media.net/rtb/pb/prebids2s?src={{PREBID_SERVER_ENDPOINT}}
     ortb-version: "2.6"
     endpoint-compression: gzip
     meta-info:

--- a/src/main/resources/bidder-config/medianet.yaml
+++ b/src/main/resources/bidder-config/medianet.yaml
@@ -1,7 +1,7 @@
 adapters:
   medianet:
-    # Media.net's Prebid Server adapter supports regional endpoints.
-    # Set the endpoint below to match the datacenter region where this config is deployed:
+    # Media.net supports the following regional endpoint domains.
+    # Kindly set the endpoint below to match the datacenter region where this config is deployed:
     #   US East  → https://prebid-adapter-useast.media.net/rtb/pb/prebids2s
     #   US West  → https://prebid-adapter-uswest.media.net/rtb/pb/prebids2s
     #   Asia     → https://prebid-adapter-asia.media.net/rtb/pb/prebids2s

--- a/src/main/resources/bidder-config/medianet.yaml
+++ b/src/main/resources/bidder-config/medianet.yaml
@@ -1,6 +1,14 @@
 adapters:
   medianet:
-    endpoint: https://prebid-adapter.media.net/rtb/pb/prebids2s?src={{PREBID_SERVER_ENDPOINT}}
+    # Media.net's Prebid Server adapter supports regional endpoints.
+    # Set the endpoint below to match the datacenter region where this config is deployed:
+    #   US East  → https://prebid-adapter-useast.media.net/rtb/pb/prebids2s
+    #   US West  → https://prebid-adapter-uswest.media.net/rtb/pb/prebids2s
+    #   Asia     → https://prebid-adapter-asia.media.net/rtb/pb/prebids2s
+    #   Europe   → https://prebid-adapter-eu.media.net/rtb/pb/prebids2s
+    #
+    # Replace REGION in the endpoint URL with: useast | uswest | asia | eu
+    endpoint: https://prebid-adapter-REGION.media.net/rtb/pb/prebids2s?src={{PREBID_SERVER_ENDPOINT}}
     ortb-version: "2.6"
     endpoint-compression: gzip
     meta-info:


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Update the Media.net adapter endpoint to support datacenter-specific regional URLs (useast, uswest, asia, eu) with documentation comments.