### PR TITLE
Refactor Initializable interface to use Future

### DIFF
--- a/extra/modules/greenbids-real-time-data/src/main/java/org/prebid/server/hooks/modules/greenbids/real/time/data/config/DatabaseReaderFactory.java
+++ b/extra/modules/greenbids-real-time-data/src/main/java/org/prebid/server/hooks/modules/greenbids/real/time/data/config/DatabaseReaderFactory.java
@@ -4,7 +4,6 @@ import com.maxmind.db.Reader;
 import com.maxmind.geoip2.DatabaseReader;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
@@ -45,11 +44,10 @@ public class DatabaseReaderFactory implements Initializable {
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
-        downloadAndExtract()
+    public Future<Void> initialize() {
+        return downloadAndExtract()
                 .onSuccess(databaseReaderRef::set)
-                .<Void>mapEmpty()
-                .onComplete(initializePromise);
+                .mapEmpty();
     }
 
     private Future<DatabaseReader> downloadAndExtract() {

--- a/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/agma/AgmaAnalyticsReporter.java
@@ -12,7 +12,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -97,9 +96,9 @@ public class AgmaAnalyticsReporter implements AnalyticsReporter, Initializable {
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
+    public Future<Void> initialize() {
         vertx.setPeriodic(bufferTimeoutMs, ignored -> sendEvents(buffer.pollAll()));
-        initializePromise.complete();
+        return Future.succeededFuture();
     }
 
     @Override

--- a/src/main/java/org/prebid/server/analytics/reporter/pubstack/PubstackAnalyticsReporter.java
+++ b/src/main/java/org/prebid/server/analytics/reporter/pubstack/PubstackAnalyticsReporter.java
@@ -1,7 +1,6 @@
 package org.prebid.server.analytics.reporter.pubstack;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -116,9 +115,9 @@ public class PubstackAnalyticsReporter implements AnalyticsReporter, Initializab
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
+    public Future<Void> initialize() {
         vertx.setPeriodic(configurationRefreshDelay, id -> fetchRemoteConfig());
-        fetchRemoteConfig().onComplete(initializePromise);
+        return fetchRemoteConfig();
     }
 
     void shutdown() {

--- a/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
+++ b/src/main/java/org/prebid/server/currency/CurrencyConversionService.java
@@ -2,7 +2,6 @@ package org.prebid.server.currency;
 
 import com.iab.openrtb.request.BidRequest;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -68,7 +67,7 @@ public class CurrencyConversionService implements Initializable {
      * Must be called on Vertx event loop thread.
      */
     @Override
-    public void initialize(Promise<Void> initializePromise) {
+    public Future<Void> initialize() {
         if (externalConversionProperties != null) {
             final Long refreshPeriod = externalConversionProperties.getRefreshPeriodMs();
             final Long defaultTimeout = externalConversionProperties.getDefaultTimeoutMs();
@@ -84,7 +83,7 @@ public class CurrencyConversionService implements Initializable {
             externalConversionProperties.getMetrics().createCurrencyRatesGauge(this::isRatesStale);
         }
 
-        initializePromise.tryComplete();
+        return Future.succeededFuture();
     }
 
     /**

--- a/src/main/java/org/prebid/server/settings/service/DatabasePeriodicRefreshService.java
+++ b/src/main/java/org/prebid/server/settings/service/DatabasePeriodicRefreshService.java
@@ -1,7 +1,6 @@
 package org.prebid.server.settings.service;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.commons.lang3.StringUtils;
 import org.prebid.server.execution.timeout.Timeout;
@@ -104,12 +103,12 @@ public class DatabasePeriodicRefreshService implements Initializable {
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
+    public Future<Void> initialize() {
         getAll();
         if (refreshPeriod > 0) {
             vertx.setPeriodic(refreshPeriod, aLong -> refresh());
         }
-        initializePromise.tryComplete();
+        return Future.succeededFuture();
     }
 
     private void getAll() {

--- a/src/main/java/org/prebid/server/settings/service/HttpPeriodicRefreshService.java
+++ b/src/main/java/org/prebid/server/settings/service/HttpPeriodicRefreshService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.prebid.server.exception.PreBidException;
 import org.prebid.server.json.DecodeException;
@@ -91,13 +90,13 @@ public class HttpPeriodicRefreshService implements Initializable {
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
+    public Future<Void> initialize() {
         getAll();
         if (refreshPeriod > 0) {
             vertx.setPeriodic(refreshPeriod, aLong -> refresh());
         }
 
-        initializePromise.tryComplete();
+        return Future.succeededFuture();
     }
 
     private void getAll() {

--- a/src/main/java/org/prebid/server/settings/service/S3PeriodicRefreshService.java
+++ b/src/main/java/org/prebid/server/settings/service/S3PeriodicRefreshService.java
@@ -2,7 +2,6 @@ package org.prebid.server.settings.service;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.prebid.server.auction.model.Tuple2;
 import org.prebid.server.log.Logger;
@@ -73,15 +72,13 @@ public class S3PeriodicRefreshService implements Initializable {
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
-        fetchStoredDataResult(clock.millis(), MetricName.initialize)
-                .<Void>mapEmpty()
-                .onComplete(initializePromise);
-
+    public Future<Void> initialize() {
         if (refreshPeriod > 0) {
             logger.info("Starting s3 periodic refresh for " + cacheType + " every " + refreshPeriod + " s");
             vertx.setPeriodic(refreshPeriod, ignored -> fetchStoredDataResult(clock.millis(), MetricName.update));
         }
+
+        return fetchStoredDataResult(clock.millis(), MetricName.initialize).mapEmpty();
     }
 
     private Future<StoredDataResult<String>> fetchStoredDataResult(long startTime, MetricName metricName) {

--- a/src/main/java/org/prebid/server/util/system/CpuLoadAverageStats.java
+++ b/src/main/java/org/prebid/server/util/system/CpuLoadAverageStats.java
@@ -1,6 +1,6 @@
 package org.prebid.server.util.system;
 
-import io.vertx.core.Promise;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.prebid.server.vertx.Initializable;
 import oshi.SystemInfo;
@@ -31,10 +31,10 @@ public class CpuLoadAverageStats implements Initializable {
     }
 
     @Override
-    public void initialize(Promise<Void> initializePromise) {
+    public Future<Void> initialize() {
         measureCpuLoad();
         vertx.setPeriodic(measurementIntervalMillis, timerId -> measureCpuLoad());
-        initializePromise.tryComplete();
+        return Future.succeededFuture();
     }
 
     private void measureCpuLoad() {

--- a/src/main/java/org/prebid/server/vertx/Initializable.java
+++ b/src/main/java/org/prebid/server/vertx/Initializable.java
@@ -1,7 +1,7 @@
 package org.prebid.server.vertx;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 
 /**
  * Denotes components requiring initialization after they have been created.
@@ -12,5 +12,5 @@ import io.vertx.core.Promise;
 @FunctionalInterface
 public interface Initializable {
 
-    void initialize(Promise<Void> initializePromise);
+    Future<Void> initialize();
 }

--- a/src/main/java/org/prebid/server/vertx/verticles/server/DaemonVerticle.java
+++ b/src/main/java/org/prebid/server/vertx/verticles/server/DaemonVerticle.java
@@ -11,10 +11,8 @@ import org.prebid.server.log.LoggerFactory;
 import org.prebid.server.vertx.CloseableAdapter;
 import org.prebid.server.vertx.Initializable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class DaemonVerticle extends AbstractVerticle {
@@ -33,31 +31,26 @@ public class DaemonVerticle extends AbstractVerticle {
 
     @Override
     public void start(Promise<Void> startPromise) {
-        all(initializables, initializable -> initializable::initialize).onComplete(startPromise);
+        all(initializables, Initializable::initialize, true).onComplete(startPromise);
     }
 
     @Override
     public void stop(Promise<Void> stopPromise) {
-        all(closeables, closeable -> closeable::close).onComplete(stopPromise);
+        all(closeables, closeable -> Future.future(closeable::close), false).onComplete(stopPromise);
     }
 
-    private static <E> Future<Void> all(Collection<E> entries,
-                                        Function<E, Consumer<Promise<Void>>> entryToPromiseConsumerMapper) {
-
-        final List<Future<Void>> entriesFutures = new ArrayList<>();
-
-        for (E entry : entries) {
-            final Promise<Void> entryPromise = Promise.promise();
-            entriesFutures.add(entryPromise.future());
-
-            entryToPromiseConsumerMapper.apply(entry).accept(entryPromise);
-        }
-
-        return Future.all(entriesFutures)
+    private static <E> Future<Void> all(
+            Collection<E> entries,
+            Function<E, Future<Void>> entryToFutureMapper,
+            boolean start
+    ) {
+        return Future.all(entries.stream().map(entryToFutureMapper).toList())
                 .onSuccess(r -> logger.info(
-                        "Successfully started {} instance on thread: {}",
+                        "Successfully {} {} instance on thread: {}",
+                        start ? "started" : "stopped",
                         DaemonVerticle.class.getSimpleName(),
                         Thread.currentThread().getName()))
                 .mapEmpty();
     }
+
 }

--- a/src/main/java/org/prebid/server/vertx/verticles/server/DaemonVerticle.java
+++ b/src/main/java/org/prebid/server/vertx/verticles/server/DaemonVerticle.java
@@ -42,8 +42,8 @@ public class DaemonVerticle extends AbstractVerticle {
     private static <E> Future<Void> all(
             Collection<E> entries,
             Function<E, Future<Void>> entryToFutureMapper,
-            boolean start
-    ) {
+            boolean start) {
+
         return Future.all(entries.stream().map(entryToFutureMapper).toList())
                 .onSuccess(r -> logger.info(
                         "Successfully {} {} instance on thread: {}",

--- a/src/test/java/org/prebid/server/analytics/reporter/pubstack/PubstackAnalyticsReporterTest.java
+++ b/src/test/java/org/prebid/server/analytics/reporter/pubstack/PubstackAnalyticsReporterTest.java
@@ -2,7 +2,6 @@ package org.prebid.server.analytics.reporter.pubstack;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,7 +92,7 @@ public class PubstackAnalyticsReporterTest extends VertxTest {
                 Future.succeededFuture(HttpClientResponse.of(200, null, mapper.writeValueAsString(pubstackConfig))));
 
         // when
-        pubstackAnalyticsReporter.initialize(Promise.promise());
+        pubstackAnalyticsReporter.initialize();
 
         // then
         verify(vertx).setPeriodic(anyLong(), any());
@@ -109,17 +108,16 @@ public class PubstackAnalyticsReporterTest extends VertxTest {
             throws JsonProcessingException {
 
         // given
-        final Promise<Void> promise = Promise.promise();
         final PubstackConfig pubstackConfig = PubstackConfig.of("newScopeId", "invalid",
                 Collections.singletonMap(EventType.auction, true));
         given(httpClient.get(anyString(), anyLong())).willReturn(
                 Future.succeededFuture(HttpClientResponse.of(200, null, mapper.writeValueAsString(pubstackConfig))));
 
         // when
-        pubstackAnalyticsReporter.initialize(promise);
+        final Future<Void> result = pubstackAnalyticsReporter.initialize();
 
         // then
-        assertThatThrownBy(() -> promise.future().await(5, TimeUnit.SECONDS))
+        assertThatThrownBy(() -> result.await(5, TimeUnit.SECONDS))
                 .hasMessage("[pubstack] Failed to create event report url for endpoint: invalid")
                 .isInstanceOf(PreBidException.class);
         verify(auctionHandler).reportEvents();
@@ -138,8 +136,8 @@ public class PubstackAnalyticsReporterTest extends VertxTest {
                 Future.succeededFuture(HttpClientResponse.of(200, null, mapper.writeValueAsString(pubstackConfig))));
 
         // when
-        pubstackAnalyticsReporter.initialize(Promise.promise());
-        pubstackAnalyticsReporter.initialize(Promise.promise());
+        pubstackAnalyticsReporter.initialize();
+        pubstackAnalyticsReporter.initialize();
 
         // then
         verify(httpClient, times(2)).get(anyString(), anyLong());
@@ -157,7 +155,7 @@ public class PubstackAnalyticsReporterTest extends VertxTest {
                 Future.succeededFuture(HttpClientResponse.of(400, null, null)));
 
         // when
-        pubstackAnalyticsReporter.initialize(Promise.promise());
+        pubstackAnalyticsReporter.initialize();
 
         // then
         verify(vertx).setPeriodic(anyLong(), any());
@@ -173,7 +171,7 @@ public class PubstackAnalyticsReporterTest extends VertxTest {
                 Future.succeededFuture(HttpClientResponse.of(200, null, "{\"endpoint\" : {}}")));
 
         // when
-        pubstackAnalyticsReporter.initialize(Promise.promise());
+        pubstackAnalyticsReporter.initialize();
 
         // then
         verify(vertx).setPeriodic(anyLong(), any());

--- a/src/test/java/org/prebid/server/auction/CurrencyConversionServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/CurrencyConversionServiceTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.iab.openrtb.request.BidRequest;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -397,7 +396,7 @@ public class CurrencyConversionServiceTest extends VertxTest {
                         clock,
                         jacksonMapper));
 
-        currencyService.initialize(Promise.promise());
+        currencyService.initialize();
 
         return currencyService;
     }

--- a/src/test/java/org/prebid/server/settings/service/DatabasePeriodicRefreshServiceTest.java
+++ b/src/test/java/org/prebid/server/settings/service/DatabasePeriodicRefreshServiceTest.java
@@ -2,7 +2,6 @@ package org.prebid.server.settings.service;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,7 +155,7 @@ public class DatabasePeriodicRefreshServiceTest {
                 metrics,
                 clock);
 
-        databasePeriodicRefreshService.initialize(Promise.promise());
+        databasePeriodicRefreshService.initialize();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/prebid/server/settings/service/HttpPeriodicRefreshServiceTest.java
+++ b/src/test/java/org/prebid/server/settings/service/HttpPeriodicRefreshServiceTest.java
@@ -3,7 +3,6 @@ package org.prebid.server.settings.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -174,7 +173,7 @@ public class HttpPeriodicRefreshServiceTest extends VertxTest {
 
         final HttpPeriodicRefreshService httpPeriodicRefreshService = new HttpPeriodicRefreshService(
                 url, refreshPeriod, timeout, notificationListener, vertx, httpClient, jacksonMapper);
-        httpPeriodicRefreshService.initialize(Promise.promise());
+        httpPeriodicRefreshService.initialize();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/prebid/server/settings/service/S3PeriodicRefreshServiceTest.java
+++ b/src/test/java/org/prebid/server/settings/service/S3PeriodicRefreshServiceTest.java
@@ -1,7 +1,6 @@
 package org.prebid.server.settings.service;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -169,8 +168,6 @@ public class S3PeriodicRefreshServiceTest extends VertxTest {
                 metrics,
                 vertx);
 
-        final Promise<Void> init = Promise.promise();
-        s3PeriodicRefreshService.initialize(init);
-        return init.future();
+        return s3PeriodicRefreshService.initialize();
     }
 }


### PR DESCRIPTION
### 🔧 Type of changes
- [x] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
To align with changes in Vert.x 5, refactor Initializable interface to use futures instead of promises.
