### PR TITLE
RTBHouse: Fix unintended site object creation for app requests

### DIFF
--- a/src/main/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidder.java
+++ b/src/main/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Publisher;
@@ -88,6 +89,7 @@ public class RtbhouseBidder implements Bidder<BidRequest> {
         final BidRequest outgoingRequest = bidRequest.toBuilder()
                 .cur(Collections.singletonList(BIDDER_CURRENCY))
                 .site(modifySite(bidRequest.getSite(), publisherId))
+                .app(modifyApp(bidRequest.getApp(), publisherId))
                 .imp(modifiedImps)
                 .build();
 
@@ -178,23 +180,32 @@ public class RtbhouseBidder implements Bidder<BidRequest> {
     }
 
     private Site modifySite(Site site, String publisherId) {
+        return Optional.ofNullable(site)
+                .map(Site::toBuilder)
+                .map(builder -> builder.publisher(modifyPublisher(site.getPublisher(), publisherId)))
+                .map(Site.SiteBuilder::build)
+                .orElse(site);
+    }
+
+    private App modifyApp(App app, String publisherId) {
+        return Optional.ofNullable(app)
+                .map(App::toBuilder)
+                .map(builder -> builder.publisher(modifyPublisher(app.getPublisher(), publisherId)))
+                .map(App.AppBuilder::build)
+                .orElse(app);
+    }
+
+    private Publisher modifyPublisher(Publisher publisher, String publisherId) {
         final ObjectNode prebidNode = mapper.mapper().createObjectNode();
         prebidNode.put("publisherId", publisherId);
 
         final ExtPublisher extPublisher = ExtPublisher.empty();
         extPublisher.addProperty("prebid", prebidNode);
 
-        final Publisher publisher = Optional.ofNullable(site)
-                .map(Site::getPublisher)
+        return Optional.ofNullable(publisher)
                 .map(Publisher::toBuilder)
                 .orElseGet(Publisher::builder)
                 .ext(extPublisher)
-                .build();
-
-        return Optional.ofNullable(site)
-                .map(Site::toBuilder)
-                .orElseGet(Site::builder)
-                .publisher(publisher)
                 .build();
     }
 

--- a/src/test/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidderTest.java
@@ -3,6 +3,7 @@ package org.prebid.server.bidder.rtbhouse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.iab.openrtb.request.App;
 import com.iab.openrtb.request.Banner;
 import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Deal;
@@ -189,10 +190,10 @@ public class RtbhouseBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldCreateSiteAndPublisherWhenBidRequestHasNoSite() {
+    public void makeHttpRequestsShouldNotCreateSiteWhenBidRequestHasAppOnly() {
         // given
         final BidRequest bidRequest = givenBidRequest(
-                bidReq -> bidReq.site(null),
+                bidReq -> bidReq.site(null).app(App.builder().id("app_id").build()),
                 identity(),
                 identity());
 
@@ -204,12 +205,31 @@ public class RtbhouseBidderTest extends VertxTest {
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getPayload)
                 .extracting(BidRequest::getSite)
-                .allSatisfy(site -> {
-                    assertThat(site).isNotNull();
-                    assertThat(site.getPublisher()).isNotNull();
-                    assertThat(site.getPublisher().getExt()).isNotNull();
+                .containsOnlyNulls();
+    }
 
-                    final JsonNode prebidNode = site.getPublisher().getExt().getProperty("prebid");
+    @Test
+    public void makeHttpRequestsShouldAddPublisherToAppWhenBidRequestHasAppOnly() {
+        // given
+        final BidRequest bidRequest = givenBidRequest(
+                bidReq -> bidReq.site(null).app(App.builder().id("app_id").build()),
+                identity(),
+                identity());
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(HttpRequest::getPayload)
+                .extracting(BidRequest::getApp)
+                .allSatisfy(app -> {
+                    assertThat(app.getId()).isEqualTo("app_id");
+                    assertThat(app.getPublisher()).isNotNull();
+                    assertThat(app.getPublisher().getExt()).isNotNull();
+
+                    final JsonNode prebidNode = app.getPublisher().getExt().getProperty("prebid");
                     assertThat(prebidNode).isNotNull();
                     assertThat(prebidNode.get("publisherId").asText()).isEqualTo("publisherId");
                 });

--- a/src/test/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/rtbhouse/RtbhouseBidderTest.java
@@ -256,8 +256,10 @@ public class RtbhouseBidderTest extends VertxTest {
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getValue()).hasSize(1)
                 .extracting(HttpRequest::getPayload)
-                .extracting(BidRequest::getSite)
-                .allSatisfy(site -> {
+                .allSatisfy(payload -> {
+                    assertThat(payload.getApp()).isNull();
+
+                    final Site site = payload.getSite();
                     assertThat(site.getId()).isEqualTo("site_id");
                     assertThat(site.getName()).isEqualTo("site_name");
                     assertThat(site.getDomain()).isEqualTo("example.com");


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bid adapter update
- [x] bugfix

### ✨ What's the context?
The RTBHouse bidder was unconditionally constructing a `site` object on every outgoing request while attaching the publisher ID. For app-only requests (no `site` in the incoming Prebid Server request), this resulted in a synthetic `site` object being added to the outbound bid request, even though only an `app` object was present.

### 📋 Description
Fixes publisher ID propagation so it no longer fabricates a `site` object:

1. `modifySite` now only modifies an existing `site` and returns `null` untouched — no synthetic `site` is created when the request has none.
2. New `modifyApp` propagates the publisher ID to `app.publisher.ext.prebid.publisherId` for app traffic, mirroring the existing `site.publisher` behaviour.
3. Extracted a shared `modifyPublisher` helper used by both `site` and `app`.

### 🧪 Testing results
```Tests run: 26, Failures: 0, Errors: 0, Skipped: 0```
All RTBHouse bidder tests pass, including new coverage:
- `makeHttpRequestsShouldNotCreateSiteWhenBidRequestHasAppOnly` — verifies no `site` is added for app-only requests
- `makeHttpRequestsShouldAddPublisherToAppWhenBidRequestHasAppOnly` — verifies publisher ID is propagated to `app.publisher`
- Existing site-path and backward-compatibility tests retained

### Other information
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).

