### PR TITLE
Teal: bid type update

### DIFF
--- a/src/main/java/org/prebid/server/bidder/teal/TealBidder.java
+++ b/src/main/java/org/prebid/server/bidder/teal/TealBidder.java
@@ -183,7 +183,7 @@ public class TealBidder implements Bidder<BidRequest> {
     }
 
     private static BidType getBidType(Bid bid, List<Imp> imps) {
-        final BidType mediaType = Optional.ofNullable(bid.getExt())
+        final BidType bidType = Optional.ofNullable(bid.getExt())
                 .map(ext -> ext.get("prebid"))
                 .map(extPrebid -> extPrebid.get("type"))
                 .filter(JsonNode::isTextual)
@@ -191,8 +191,8 @@ public class TealBidder implements Bidder<BidRequest> {
                 .map(BidType::fromString)
                 .orElse(null);
 
-        if (mediaType != null) {
-            return mediaType;
+        if (bidType != null) {
+            return bidType;
         }
 
         for (Imp imp : imps) {

--- a/src/main/java/org/prebid/server/bidder/teal/TealBidder.java
+++ b/src/main/java/org/prebid/server/bidder/teal/TealBidder.java
@@ -8,6 +8,7 @@ import com.iab.openrtb.request.BidRequest;
 import com.iab.openrtb.request.Imp;
 import com.iab.openrtb.request.Publisher;
 import com.iab.openrtb.request.Site;
+import com.iab.openrtb.response.Bid;
 import com.iab.openrtb.response.BidResponse;
 import com.iab.openrtb.response.SeatBid;
 import org.apache.commons.collections4.CollectionUtils;
@@ -177,13 +178,25 @@ public class TealBidder implements Bidder<BidRequest> {
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
-                .map(bid -> BidderBid.of(bid, getBidType(bid.getImpid(), bidRequest.getImp()), bidResponse.getCur()))
+                .map(bid -> BidderBid.of(bid, getBidType(bid, bidRequest.getImp()), bidResponse.getCur()))
                 .toList();
     }
 
-    private static BidType getBidType(String impId, List<Imp> imps) {
+    private static BidType getBidType(Bid bid, List<Imp> imps) {
+        final BidType mediaType = Optional.ofNullable(bid.getExt())
+                .map(ext -> ext.get("prebid"))
+                .map(extPrebid -> extPrebid.get("type"))
+                .filter(JsonNode::isTextual)
+                .map(JsonNode::textValue)
+                .map(BidType::fromString)
+                .orElse(null);
+
+        if (mediaType != null) {
+            return mediaType;
+        }
+
         for (Imp imp : imps) {
-            if (imp.getId().equals(impId)) {
+            if (imp.getId().equals(bid.getImpid())) {
                 if (imp.getBanner() != null) {
                     return BidType.banner;
                 } else if (imp.getVideo() != null) {

--- a/src/test/java/org/prebid/server/bidder/teal/TealBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/teal/TealBidderTest.java
@@ -177,6 +177,26 @@ public class TealBidderTest extends VertxTest {
     }
 
     @Test
+    public void makeBidsShouldReturnBidTypeFromBidExtPrebidType() throws JsonProcessingException {
+        // given
+        final ObjectNode bidExt = mapper.createObjectNode();
+        bidExt.putObject("prebid").put("type", "video");
+
+        final Bid responseBid = givenBid("imp1", 2, 1).toBuilder().ext(bidExt).build();
+        final BidRequest bidRequest = givenBidRequest(imp -> imp.id("imp1").banner(Banner.builder().id("id").build()));
+        final BidderCall<BidRequest> httpCall = givenHttpCall(bidRequest, singletonList(responseBid));
+
+        // when
+        final Result<List<BidderBid>> result = target.makeBids(httpCall, bidRequest);
+
+        // then
+        final Bid expectedBid = givenBid("imp1", 2, 1).toBuilder().ext(bidExt).build();
+
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).containsExactly(BidderBid.of(expectedBid, BidType.video, "USD"));
+    }
+
+    @Test
     public void makeBidsShouldReturnBannerBid() throws JsonProcessingException {
         // given
         final Bid responseBid = givenBid("imp1", 1, 1);
@@ -231,6 +251,7 @@ public class TealBidderTest extends VertxTest {
         return givenBidRequest(null, impCustomizer);
     }
 
+    @SafeVarargs
     private static BidRequest givenBidRequest(Site site, UnaryOperator<Imp.ImpBuilder>... impCustomizers) {
         final List<Imp> imps = Stream.of(impCustomizers)
                 .map(customizer -> customizer.apply(Imp.builder().id("impId")).build())


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bid adapter update

### ✨ What's the context?
This change updates the Teal adapter to retrieve the bid type in the first instance directly from the bid response.

### 🧠 Rationale behind the change
This ensures that multi format bid requests accurately categorise the returned ad format, rather than just defaulting to the format from the impression.

### 🧪 Test plan
Change has been tested.

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [x] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
