### PR TITLE
Mobkoi: do not hardcode bid seat, to support aliases

### DIFF
--- a/src/main/java/org/prebid/server/bidder/mobkoi/MobkoiBidder.java
+++ b/src/main/java/org/prebid/server/bidder/mobkoi/MobkoiBidder.java
@@ -131,7 +131,7 @@ public class MobkoiBidder implements Bidder<BidRequest> {
                 .map(SeatBid::getBid)
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
-                .map(bid -> BidderBid.of(bid, BidType.banner, "mobkoi", bidResponse.getCur()))
+                .map(bid -> BidderBid.of(bid, BidType.banner, bidResponse.getCur()))
                 .toList();
     }
 }

--- a/src/test/java/org/prebid/server/bidder/mobkoi/MobkoiBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/mobkoi/MobkoiBidderTest.java
@@ -198,7 +198,7 @@ public class MobkoiBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeBidsShouldReturnBannerBidWithMobkoiSeat() throws JsonProcessingException {
+    public void makeBidsShouldReturnBannerBidWithoutSeatSoAliasesWork() throws JsonProcessingException {
         // given
         final BidResponse bannerBidResponse = givenBidResponse(bidBuilder -> bidBuilder.mtype(1).impid("123"));
         final BidderCall<BidRequest> httpCall = givenHttpCall(mapper.writeValueAsString(bannerBidResponse));
@@ -211,7 +211,9 @@ public class MobkoiBidderTest extends VertxTest {
         assertThat(result.getValue())
                 .containsExactly(
                         BidderBid.of(
-                                Bid.builder().mtype(1).impid("123").build(), banner, "mobkoi", "USD"));
+                                Bid.builder().mtype(1).impid("123").build(), banner, "USD"));
+        assertThat(result.getValue()).allSatisfy(bidderBid ->
+                assertThat(bidderBid.getSeat()).isNull());
     }
 
     private static BidRequest givenBidRequest(UnaryOperator<Imp.ImpBuilder> impModifier) {


### PR DESCRIPTION
(cherry picked from commit bd0701fa15fc13ea478c429d705b967cadb74867)

### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

###  What's the context?

We're not supporting aliasing in the publisher page because we were hardcoding the seat name

###  Rationale behind the change

Leave Seat empty so PBS labels the bid with the requested bidder code, which
makes aliases work for every publisher without any publisher-side change.

### 🏎 Quality check
- [x] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
