### PR TITLE
Update setuid metrics to use bidder name instead of cookie family name

### DIFF
--- a/src/main/java/org/prebid/server/handler/SetuidHandler.java
+++ b/src/main/java/org/prebid/server/handler/SetuidHandler.java
@@ -230,7 +230,7 @@ public class SetuidHandler implements ApplicationResource {
 
         final TcfContext tcfContext = setuidContext.getPrivacyContext().getTcfContext();
         if (tcfContext.isInGdprScope() && !tcfContext.isConsentValid()) {
-            metrics.updateUserSyncTcfInvalidMetric(usersyncer.getCookieFamilyName());
+            metrics.updateUserSyncTcfInvalidMetric(setuidContext.getBidder());
             throw new InvalidRequestException("Consent string is invalid");
         }
 
@@ -254,7 +254,6 @@ public class SetuidHandler implements ApplicationResource {
 
         final TcfContext tcfContext = setuidContext.getPrivacyContext().getTcfContext();
         final RoutingContext routingContext = setuidContext.getRoutingContext();
-        final String cookieFamilyName = setuidContext.getUsersyncer().getCookieFamilyName();
 
         if (hostTcfResponseResult.succeeded()) {
             final CompositeFuture compositeFuture = hostTcfResponseResult.result();
@@ -272,7 +271,7 @@ public class SetuidHandler implements ApplicationResource {
             if (hostVendorTcfResponse.isVendorAllowed() && isBidderVendorAllowed) {
                 respondWithCookie(setuidContext);
             } else {
-                metrics.updateUserSyncTcfBlockedMetric(cookieFamilyName);
+                metrics.updateUserSyncTcfBlockedMetric(setuidContext.getBidder());
 
                 final HttpResponseStatus status = new HttpResponseStatus(UNAVAILABLE_FOR_LEGAL_REASONS,
                         "Unavailable for legal reasons");
@@ -287,7 +286,7 @@ public class SetuidHandler implements ApplicationResource {
             }
         } else {
             final Throwable error = hostTcfResponseResult.cause();
-            metrics.updateUserSyncTcfBlockedMetric(cookieFamilyName);
+            metrics.updateUserSyncTcfBlockedMetric(setuidContext.getBidder());
             handleErrors(error, routingContext, tcfContext);
         }
     }
@@ -304,7 +303,7 @@ public class SetuidHandler implements ApplicationResource {
                 .forEach(routingContext.response()::addCookie);
 
         if (uidsCookieUpdateResult.isUpdated()) {
-            metrics.updateUserSyncSetsMetric(cookieFamilyName);
+            metrics.updateUserSyncSetsMetric(setuidContext.getBidder());
         }
         final int statusCode = HttpResponseStatus.OK.code();
         HttpUtil.executeSafely(routingContext, Endpoint.setuid, buildCookieResponseConsumer(setuidContext, statusCode));

--- a/src/main/java/org/prebid/server/metric/Metrics.java
+++ b/src/main/java/org/prebid/server/metric/Metrics.java
@@ -400,12 +400,20 @@ public class Metrics extends UpdatableMetrics {
         userSync().incCounter(MetricName.bad_requests);
     }
 
-    public void updateUserSyncSetsMetric(String cookieFamilyName) {
-        userSync().forBidder(cookieFamilyName).incCounter(MetricName.sets);
+    public void updateUserSyncSetsMetric(String bidder) {
+        userSync().forBidder(bidder).incCounter(MetricName.sets);
     }
 
-    public void updateUserSyncTcfBlockedMetric(String cookieFamilyName) {
-        userSync().forBidder(cookieFamilyName).tcf().incCounter(MetricName.blocked);
+    public void updateUserSyncTcfBlockedMetric(String bidder) {
+        userSync().forBidder(bidder).tcf().incCounter(MetricName.blocked);
+    }
+
+    public void updateUserSyncTcfInvalidMetric() {
+        updateUserSyncTcfInvalidMetric(ALL_REQUEST_BIDDERS);
+    }
+
+    public void updateUserSyncTcfInvalidMetric(String bidder) {
+        userSync().forBidder(bidder).tcf().incCounter(MetricName.invalid);
     }
 
     public void updateUserSyncSizeBlockedMetric(String cookieFamilyName) {
@@ -414,14 +422,6 @@ public class Metrics extends UpdatableMetrics {
 
     public void updateUserSyncSizedOutMetric(String cookieFamilyName) {
         userSync().forBidder(cookieFamilyName).incCounter(MetricName.sizedout);
-    }
-
-    public void updateUserSyncTcfInvalidMetric(String cookieFamilyName) {
-        userSync().forBidder(cookieFamilyName).tcf().incCounter(MetricName.invalid);
-    }
-
-    public void updateUserSyncTcfInvalidMetric() {
-        updateUserSyncTcfInvalidMetric(ALL_REQUEST_BIDDERS);
     }
 
     public void updateCookieSyncFilteredMetric(String bidder) {

--- a/src/test/groovy/org/prebid/server/functional/tests/CookieSyncSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/CookieSyncSpec.groovy
@@ -383,7 +383,7 @@ class CookieSyncSpec extends BaseSpec {
         def bidderStatus = response.getBidderUserSync(GENERIC)
         assert bidderStatus.error == "Rejected by TCF"
 
-        and: "Metric should contain cookie_sync.FAMILY.tcf.blocked"
+        and: "Metric should contain cookie_sync.BIDDER.tcf.blocked"
         def metric = this.prebidServerService.sendCollectedMetricsRequest()
         assert metric["cookie_sync.generic.tcf.blocked"] == 1
     }
@@ -1396,7 +1396,7 @@ class CookieSyncSpec extends BaseSpec {
         def bidderStatus = response.getBidderUserSync(GENERIC)
         assert bidderStatus.error == "Rejected by TCF"
 
-        and: "Metric should contain cookie_sync.FAMILY.tcf.blocked"
+        and: "Metric should contain cookie_sync.BIDDER.tcf.blocked"
         def metric = prebidServerService.sendCollectedMetricsRequest()
         assert metric["cookie_sync.generic.tcf.blocked"] == 1
     }

--- a/src/test/groovy/org/prebid/server/functional/tests/SetUidSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/SetUidSpec.groovy
@@ -128,7 +128,7 @@ class SetUidSpec extends BaseSpec {
         assert response.responseBody ==
                 ResourceUtil.readByteArrayFromClassPath("org/prebid/server/functional/tracking-pixel.png")
 
-        and: "usersync.FAMILY.sets metric should be updated"
+        and: "usersync.BIDDER.sets metric should be updated"
         def metrics = singleCookiesPbsService.sendCollectedMetricsRequest()
         assert metrics["usersync.${GENERIC.value}.sets"] == 1
     }
@@ -285,7 +285,7 @@ class SetUidSpec extends BaseSpec {
         assert exception.statusCode == UNAVAILABLE_FOR_LEGAL_REASONS_CODE
         assert exception.responseBody == TCF_ERROR_MESSAGE
 
-        and: "usersync.FAMILY.tcf.blocked metric should be updated"
+        and: "usersync.BIDDER.tcf.blocked metric should be updated"
         def metric = prebidServerService.sendCollectedMetricsRequest()
         assert metric["usersync.${RUBICON.value}.tcf.blocked"] == 1
 
@@ -362,7 +362,7 @@ class SetUidSpec extends BaseSpec {
         def metricsRequest = prebidServerService.sendCollectedMetricsRequest()
         assert metricsRequest["usersync.${APPNEXUS.value}.sizeblocked"] == 1
 
-        and: "usersync.FAMILY.sets metric should be updated"
+        and: "usersync.BIDDER.sets metric should be updated"
         assert metricsRequest["usersync.${OPENX.value}.sets"] == 1
 
         cleanup: "Stop and remove pbs container"

--- a/src/test/groovy/org/prebid/server/functional/tests/privacy/gdpr/GdprSetUidSpec.groovy
+++ b/src/test/groovy/org/prebid/server/functional/tests/privacy/gdpr/GdprSetUidSpec.groovy
@@ -163,7 +163,7 @@ class GdprSetUidSpec extends PrivacyBaseSpec {
         assert exception.statusCode == UNAVAILABLE_FOR_LEGAL_REASONS_CODE
         assert exception.responseBody == TCF_ERROR_MESSAGE
 
-        and: "Metric should be increased usersync.FAMILY.tcf.blocked"
+        and: "Metric should be increased usersync.BIDDER.tcf.blocked"
         def metric = prebidServerService.sendCollectedMetricsRequest()
         assert metric["usersync.${GENERIC.value}.tcf.blocked"] == 1
     }
@@ -205,7 +205,7 @@ class GdprSetUidSpec extends PrivacyBaseSpec {
         assert exception.statusCode == UNAVAILABLE_FOR_LEGAL_REASONS_CODE
         assert exception.responseBody == TCF_ERROR_MESSAGE
 
-        and: "Metric should be increased usersync.FAMILY.tcf.blocked"
+        and: "Metric should be increased usersync.BIDDER.tcf.blocked"
         def metric = prebidServerService.sendCollectedMetricsRequest()
         assert metric["usersync.${GENERIC.value}.tcf.blocked"] == 1
     }
@@ -251,7 +251,7 @@ class GdprSetUidSpec extends PrivacyBaseSpec {
         assert exception.statusCode == UNAVAILABLE_FOR_LEGAL_REASONS_CODE
         assert exception.responseBody == TCF_ERROR_MESSAGE
 
-        and: "Metric should be increased usersync.FAMILY.tcf.blocked"
+        and: "Metric should be increased usersync.BIDDER.tcf.blocked"
         def metric = prebidServerService.sendCollectedMetricsRequest()
         assert metric["usersync.${GENERIC.value}.tcf.blocked"] == 1
 


### PR DESCRIPTION
### 🔧 Type of changes
- [x] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Follow up of https://github.com/prebid/prebid-server-java/pull/4464
