### PR TITLE
Allowed duplicate cookie family names for priority sync

### DIFF
--- a/src/main/java/org/prebid/server/cookie/PrioritizedCoopSyncProvider.java
+++ b/src/main/java/org/prebid/server/cookie/PrioritizedCoopSyncProvider.java
@@ -11,11 +11,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class PrioritizedCoopSyncProvider {
@@ -23,14 +21,13 @@ public class PrioritizedCoopSyncProvider {
     private static final Logger logger = LoggerFactory.getLogger(PrioritizedCoopSyncProvider.class);
 
     private final Set<String> prioritizedBidders;
-    private final Map<String, String> prioritizedCookieFamilyNameToBidderName;
+    private final Set<String> prioritizedCookieFamilies;
 
     public PrioritizedCoopSyncProvider(Set<String> bidders, BidderCatalog bidderCatalog) {
         this.prioritizedBidders = validCoopSyncBidders(Objects.requireNonNull(bidders), bidderCatalog);
-        this.prioritizedCookieFamilyNameToBidderName = prioritizedBidders.stream()
-                .collect(Collectors.toMap(
-                        bidder -> bidderCatalog.cookieFamilyName(bidder).orElseThrow(),
-                        Function.identity()));
+        this.prioritizedCookieFamilies = prioritizedBidders.stream()
+                .map(bidder -> bidderCatalog.cookieFamilyName(bidder).orElseThrow())
+                .collect(Collectors.toSet());
     }
 
     private static Set<String> validCoopSyncBidders(Set<String> bidders, BidderCatalog bidderCatalog) {
@@ -71,7 +68,6 @@ public class PrioritizedCoopSyncProvider {
     }
 
     public boolean isPrioritizedFamily(String cookieFamilyName) {
-        final String bidder = prioritizedCookieFamilyNameToBidderName.get(cookieFamilyName);
-        return prioritizedBidders.contains(bidder);
+        return prioritizedCookieFamilies.contains(cookieFamilyName);
     }
 }

--- a/src/test/java/org/prebid/server/cookie/PrioritizedCoopSyncProviderTest.java
+++ b/src/test/java/org/prebid/server/cookie/PrioritizedCoopSyncProviderTest.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
 
@@ -45,6 +46,18 @@ public class PrioritizedCoopSyncProviderTest {
 
         // then
         assertThat(result).containsExactly("valid");
+    }
+
+    @Test
+    public void creationShouldAllowMultipleBiddersWithTheSameCookieFamilyName() {
+        // given
+        givenValidBidderWithCookieSync("bidder1", "cookie-family-name");
+        givenValidBidderWithCookieSync("bidder2", "cookie-family-name");
+        given(bidderCatalog.usersyncReadyBidders()).willReturn(Set.of("bidder1", "bidder2"));
+
+        // when and then
+        assertThatNoException().isThrownBy(() ->
+                new PrioritizedCoopSyncProvider(Set.of("bidder1", "bidder2"), bidderCatalog));
     }
 
     @Test
@@ -99,9 +112,14 @@ public class PrioritizedCoopSyncProviderTest {
     }
 
     private void givenValidBidderWithCookieSync(String bidder) {
+        givenValidBidderWithCookieSync(bidder, null);
+    }
+
+    private void givenValidBidderWithCookieSync(String bidder, String cookieFamilyName) {
         given(bidderCatalog.isValidName(bidder)).willReturn(true);
         given(bidderCatalog.isActive(bidder)).willReturn(true);
-        given(bidderCatalog.cookieFamilyName(bidder)).willReturn(Optional.of(bidder + "-cookie-family"));
+        given(bidderCatalog.cookieFamilyName(bidder))
+                .willReturn(Optional.ofNullable(cookieFamilyName).or(() -> Optional.of(bidder + "-cookie-family")));
         given(bidderCatalog.usersyncerByName(bidder)).willReturn(
                 Optional.of(Usersyncer.of(
                         "cookie-family-name",


### PR DESCRIPTION
### 🔧 Type of changes
- [x] bugfix

### ✨ What's the context?
Allow bidders with the same cookie family name in priority sync list
