### PR TITLE
Fix Mobkoi adapter to support aliased requests

### DIFF
--- a/src/main/java/org/prebid/server/bidder/mobkoi/MobkoiBidder.java
+++ b/src/main/java/org/prebid/server/bidder/mobkoi/MobkoiBidder.java
@@ -131,7 +131,7 @@ public class MobkoiBidder implements Bidder<BidRequest> {
                 .map(SeatBid::getBid)
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
-                .map(bid -> BidderBid.of(bid, BidType.banner, "mobkoi", bidResponse.getCur()))
+                .map(bid -> BidderBid.of(bid, BidType.banner, bidResponse.getCur()))
                 .toList();
     }
 }

--- a/src/test/java/org/prebid/server/bidder/mobkoi/MobkoiBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/mobkoi/MobkoiBidderTest.java
@@ -198,7 +198,7 @@ public class MobkoiBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeBidsShouldReturnBannerBidWithMobkoiSeat() throws JsonProcessingException {
+    public void makeBidsShouldReturnBannerBidWithoutAnyDefaultSeat() throws JsonProcessingException {
         // given
         final BidResponse bannerBidResponse = givenBidResponse(bidBuilder -> bidBuilder.mtype(1).impid("123"));
         final BidderCall<BidRequest> httpCall = givenHttpCall(mapper.writeValueAsString(bannerBidResponse));
@@ -211,7 +211,7 @@ public class MobkoiBidderTest extends VertxTest {
         assertThat(result.getValue())
                 .containsExactly(
                         BidderBid.of(
-                                Bid.builder().mtype(1).impid("123").build(), banner, "mobkoi", "USD"));
+                                Bid.builder().mtype(1).impid("123").build(), banner, "USD"));
     }
 
     private static BidRequest givenBidRequest(UnaryOperator<Imp.ImpBuilder> impModifier) {


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Port of https://github.com/prebid/prebid-server/pull/4840

### 🧠 Rationale behind the change
Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
