### PR TITLE
Seedtag Bidder - add app-media-types

### DIFF
--- a/src/main/resources/bidder-config/seedtag.yaml
+++ b/src/main/resources/bidder-config/seedtag.yaml
@@ -4,6 +4,9 @@ adapters:
     endpoint-compression: gzip
     meta-info:
       maintainer-email: prebid@seedtag.com
+      app-media-types:
+        - banner
+        - video
       site-media-types:
         - banner
         - video


### PR DESCRIPTION
Go PR :  https://github.com/prebid/prebid-server/pull/4931
Doc update : https://github.com/prebid/prebid.github.io/pull/6720

### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
enable app traffic for mediatype video and banner

### 🧠 Rationale behind the change
mandatory change

### 🔎 New Bid Adapter Checklist
- [ ] verify email contact works
- [ ] NO fully dynamic hostnames
- [ ] geographic host parameters are NOT required
- [ ] direct use of HTTP is prohibited - *implement an existing Bidder interface that will do all the job*
- [ ] if the ORTB is just forwarded to the endpoint, use the generic adapter - *define the new adapter as the alias of the generic adapter*
- [ ] cover an adapter configuration with an integration test

### 🧪 Test plan
How do you know the changes are safe to ship to production?

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [ ] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
