### PR TITLE
OpenX - Add support for multi imp requests

### DIFF
--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -1,5 +1,8 @@
 package org.prebid.server.bidder.openx;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.BidRequest;
@@ -99,13 +102,12 @@ public class OpenxBidder implements Bidder<BidRequest> {
             BidRequest bidRequest,
             List<Imp> imps,
             List<BidderError> errors) {
-        final List<BidRequest> bidRequests = new ArrayList<>();
 
         final BidRequest request = createSingleRequest(imps, bidRequest, errors);
         if (request != null) {
-            bidRequests.add(request);
+            return singletonList(request);
         }
-        return bidRequests;
+        return emptyList();
     }
 
     private static BidType resolveBidType(Imp imp) {
@@ -162,7 +164,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
                     requestExt = makeReqExt(impExt.getBidder());
                 }
             } catch (PreBidException e) {
-                errors.add(BidderError.badInput("imp id=" + imp.getId() + ": " + e.getMessage()));
+                errors.add(BidderError.badInput("imp id=%s: %s".formatted(imp.getId(), e.getMessage())));
             }
         }
 
@@ -235,7 +237,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
     private List<BidderBid> extractBids(BidRequest bidRequest, BidResponse bidResponse) {
         return bidResponse == null || CollectionUtils.isEmpty(bidResponse.getSeatbid())
-                ? Collections.emptyList()
+                ? emptyList()
                 : bidsFromResponse(bidRequest, bidResponse);
     }
 

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -1,8 +1,5 @@
 package org.prebid.server.bidder.openx;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.iab.openrtb.request.BidRequest;
@@ -105,9 +102,9 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
         final BidRequest request = createSingleRequest(imps, bidRequest, errors);
         if (request != null) {
-            return singletonList(request);
+            return Collections.singletonList(request);
         }
-        return emptyList();
+        return Collections.emptyList();
     }
 
     private static BidType resolveBidType(Imp imp) {
@@ -237,7 +234,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
     private List<BidderBid> extractBids(BidRequest bidRequest, BidResponse bidResponse) {
         return bidResponse == null || CollectionUtils.isEmpty(bidResponse.getSeatbid())
-                ? emptyList()
+                ? Collections.emptyList()
                 : bidsFromResponse(bidRequest, bidResponse);
     }
 

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -68,18 +68,17 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
     @Override
     public Result<List<HttpRequest<BidRequest>>> makeHttpRequests(BidRequest bidRequest) {
-        final Map<OpenxImpType, List<Imp>> differentiatedImps = bidRequest.getImp().stream()
-                .collect(Collectors.groupingBy(OpenxBidder::resolveImpType));
+        final Map<Boolean, List<Imp>> partitionedImps = bidRequest.getImp().stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.partitioningBy(OpenxBidder::isSupportedImpType));
 
         final List<BidderError> processingErrors = new ArrayList<>();
         final List<BidRequest> outgoingRequests = makeRequests(
                 bidRequest,
-                differentiatedImps.get(OpenxImpType.banner),
-                differentiatedImps.get(OpenxImpType.video),
-                differentiatedImps.get(OpenxImpType.xNative),
+                partitionedImps.get(Boolean.TRUE),
                 processingErrors);
 
-        final List<BidderError> errors = errors(differentiatedImps.get(OpenxImpType.other), processingErrors);
+        final List<BidderError> errors = errors(partitionedImps.get(Boolean.FALSE), processingErrors);
 
         return Result.of(createHttpRequests(outgoingRequests), errors);
     }
@@ -96,30 +95,19 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
     private List<BidRequest> makeRequests(
             BidRequest bidRequest,
-            List<Imp> bannerImps,
-            List<Imp> videoImps,
-            List<Imp> nativeImps,
+            List<Imp> supportedImps,
             List<BidderError> errors) {
         final List<BidRequest> bidRequests = new ArrayList<>();
-        // single request for all banner and native imps
-        final List<Imp> bannerAndNativeImps = Stream.of(bannerImps, nativeImps)
-                .filter(Objects::nonNull)
-                .flatMap(Collection::stream)
-                .toList();
-        final BidRequest bannerAndNativeImpsRequest = createSingleRequest(bannerAndNativeImps, bidRequest, errors);
-        if (bannerAndNativeImpsRequest != null) {
-            bidRequests.add(bannerAndNativeImpsRequest);
-        }
 
-        if (CollectionUtils.isNotEmpty(videoImps)) {
-            // single request for each video imp
-            bidRequests.addAll(videoImps.stream()
-                    .map(Collections::singletonList)
-                    .map(imps -> createSingleRequest(imps, bidRequest, errors))
-                    .filter(Objects::nonNull)
-                    .toList());
+        final BidRequest request = createSingleRequest(supportedImps, bidRequest, errors);
+        if (request != null) {
+            bidRequests.add(request);
         }
         return bidRequests;
+    }
+
+    private static boolean isSupportedImpType(Imp imp) {
+        return imp.getBanner() != null ||  imp.getVideo() != null || imp.getXNative() != null;
     }
 
     private static OpenxImpType resolveImpType(Imp imp) {

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -155,13 +155,14 @@ public class OpenxBidder implements Bidder<BidRequest> {
         ExtRequest requestExt = null;
         for (Imp imp : imps) {
             try {
-                processedImps.add(makeImp(imp));
+                final ExtPrebid<ExtImpPrebid, ExtImpOpenx> impExt = parseOpenxExt(imp);
+                processedImps.add(makeImp(imp, impExt));
                 // the first successfully parsed imp's delDomain/platform win; other imps' values are ignored
                 if (requestExt == null) {
-                    requestExt = makeReqExt(imp);
+                    requestExt = makeReqExt(impExt.getBidder());
                 }
             } catch (PreBidException e) {
-                errors.add(BidderError.badInput(e.getMessage()));
+                errors.add(BidderError.badInput("imp id=" + imp.getId() + ": " + e.getMessage()));
             }
         }
 
@@ -173,8 +174,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
                 : null;
     }
 
-    private Imp makeImp(Imp imp) {
-        final ExtPrebid<ExtImpPrebid, ExtImpOpenx> impExt = parseOpenxExt(imp);
+    private Imp makeImp(Imp imp, ExtPrebid<ExtImpPrebid, ExtImpOpenx> impExt) {
         final ExtImpOpenx openxImpExt = impExt.getBidder();
         final ExtImpPrebid prebidImpExt = impExt.getPrebid();
         final Imp.ImpBuilder impBuilder = imp.toBuilder()
@@ -198,8 +198,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
                 : impBidFloor;
     }
 
-    private ExtRequest makeReqExt(Imp imp) {
-        final ExtImpOpenx openxImpExt = parseOpenxExt(imp).getBidder();
+    private ExtRequest makeReqExt(ExtImpOpenx openxImpExt) {
         return mapper.fillExtension(
                 ExtRequest.empty(),
                 OpenxRequestExt.of(openxImpExt.getDelDomain(), openxImpExt.getPlatform(), OPENX_CONFIG));

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -91,6 +91,10 @@ public class OpenxBidder implements Bidder<BidRequest> {
         }
     }
 
+    private static boolean isSupportedImpType(Imp imp) {
+        return imp.getBanner() != null || imp.getVideo() != null || imp.getXNative() != null;
+    }
+
     private List<BidRequest> makeRequests(
             BidRequest bidRequest,
             List<Imp> supportedImps,
@@ -102,10 +106,6 @@ public class OpenxBidder implements Bidder<BidRequest> {
             bidRequests.add(request);
         }
         return bidRequests;
-    }
-
-    private static boolean isSupportedImpType(Imp imp) {
-        return imp.getBanner() != null || imp.getVideo() != null || imp.getXNative() != null;
     }
 
     private static BidType resolveBidType(Imp imp) {

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -157,7 +157,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
             try {
                 final ExtPrebid<ExtImpPrebid, ExtImpOpenx> impExt = parseOpenxExt(imp);
                 processedImps.add(makeImp(imp, impExt));
-                // the first successfully parsed imp's delDomain/platform win; other imps' values are ignored
+
                 if (requestExt == null) {
                     requestExt = makeReqExt(impExt.getBidder());
                 }

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -16,7 +16,6 @@ import org.prebid.server.bidder.model.BidderCall;
 import org.prebid.server.bidder.model.BidderError;
 import org.prebid.server.bidder.model.HttpRequest;
 import org.prebid.server.bidder.model.Result;
-import org.prebid.server.bidder.openx.model.OpenxImpType;
 import org.prebid.server.bidder.openx.proto.OpenxBidExt;
 import org.prebid.server.bidder.openx.proto.OpenxRequestExt;
 import org.prebid.server.bidder.openx.proto.OpenxVideoExt;
@@ -43,7 +42,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class OpenxBidder implements Bidder<BidRequest> {
 
@@ -107,20 +105,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
     }
 
     private static boolean isSupportedImpType(Imp imp) {
-        return imp.getBanner() != null ||  imp.getVideo() != null || imp.getXNative() != null;
-    }
-
-    private static OpenxImpType resolveImpType(Imp imp) {
-        if (imp.getBanner() != null) {
-            return OpenxImpType.banner;
-        }
-        if (imp.getVideo() != null) {
-            return OpenxImpType.video;
-        }
-        if (imp.getXNative() != null) {
-            return OpenxImpType.xNative;
-        }
-        return OpenxImpType.other;
+        return imp.getBanner() != null || imp.getVideo() != null || imp.getXNative() != null;
     }
 
     private static BidType resolveBidType(Imp imp) {
@@ -166,17 +151,24 @@ public class OpenxBidder implements Bidder<BidRequest> {
             return null;
         }
 
-        List<Imp> processedImps = null;
-        try {
-            processedImps = imps.stream().map(this::makeImp).toList();
-        } catch (PreBidException e) {
-            errors.add(BidderError.badInput(e.getMessage()));
+        final List<Imp> processedImps = new ArrayList<>();
+        ExtRequest requestExt = null;
+        for (Imp imp : imps) {
+            try {
+                processedImps.add(makeImp(imp));
+                // the first successfully parsed imp's delDomain/platform win; other imps' values are ignored
+                if (requestExt == null) {
+                    requestExt = makeReqExt(imp);
+                }
+            } catch (PreBidException e) {
+                errors.add(BidderError.badInput(e.getMessage()));
+            }
         }
 
         return CollectionUtils.isNotEmpty(processedImps)
                 ? bidRequest.toBuilder()
                   .imp(processedImps)
-                  .ext(makeReqExt(imps.getFirst()))
+                  .ext(requestExt)
                   .build()
                 : null;
     }
@@ -190,7 +182,7 @@ public class OpenxBidder implements Bidder<BidRequest> {
                 .bidfloor(resolveBidFloor(imp.getBidfloor(), openxImpExt.getCustomFloor()))
                 .ext(makeImpExt(imp.getExt(), MapUtils.isNotEmpty(openxImpExt.getCustomParams())));
 
-        if (resolveImpType(imp) == OpenxImpType.video
+        if (imp.getVideo() != null
                 && prebidImpExt != null
                 && Objects.equals(prebidImpExt.getIsRewardedInventory(), 1)) {
             impBuilder.video(imp.getVideo().toBuilder()

--- a/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
+++ b/src/main/java/org/prebid/server/bidder/openx/OpenxBidder.java
@@ -97,11 +97,11 @@ public class OpenxBidder implements Bidder<BidRequest> {
 
     private List<BidRequest> makeRequests(
             BidRequest bidRequest,
-            List<Imp> supportedImps,
+            List<Imp> imps,
             List<BidderError> errors) {
         final List<BidRequest> bidRequests = new ArrayList<>();
 
-        final BidRequest request = createSingleRequest(supportedImps, bidRequest, errors);
+        final BidRequest request = createSingleRequest(imps, bidRequest, errors);
         if (request != null) {
             bidRequests.add(request);
         }

--- a/src/main/java/org/prebid/server/bidder/openx/model/OpenxImpType.java
+++ b/src/main/java/org/prebid/server/bidder/openx/model/OpenxImpType.java
@@ -1,9 +1,0 @@
-package org.prebid.server.bidder.openx.model;
-
-public enum OpenxImpType {
-
-    // supported
-    banner, video, xNative,
-    // not supported
-    other
-}

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -296,7 +296,7 @@ public class OpenxBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldReturnResultWithSingleBidRequestForMultiFormatImps() {
+    public void makeHttpRequestsShouldReturnResultWithSingleBidRequestForMultipleImpsWithDifferentFormat() {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .id("bidRequestId")
@@ -304,16 +304,20 @@ public class OpenxBidderTest extends VertxTest {
                         Imp.builder()
                                 .id("impId1")
                                 .banner(Banner.builder().w(320).h(200).build())
-                                .video(Video.builder().maxduration(10).build())
                                 .ext(mapper.valueToTree(
                                         ExtPrebid.of(null, ExtImpOpenx.builder().unit("1").build())))
                                 .build(),
                         Imp.builder()
                                 .id("impId2")
-                                .banner(Banner.builder().w(300).h(150).build())
                                 .xNative(Native.builder().request("{\"version\":1}").build())
                                 .ext(mapper.valueToTree(
                                         ExtPrebid.of(null, ExtImpOpenx.builder().unit("2").build())))
+                                .build(),
+                        Imp.builder()
+                                .id("impId3")
+                                .video(Video.builder().maxduration(10).build())
+                                .ext(mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("3").build())))
                                 .build()))
                 .user(User.builder().ext(ExtUser.builder().consent("consent").build()).build())
                 .regs(Regs.builder().coppa(0).ext(ExtRegs.of(1, null, null, null)).build())
@@ -328,23 +332,24 @@ public class OpenxBidderTest extends VertxTest {
         assertThat(result.getValue()).hasSize(1)
                 .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
                 .containsExactly(
-                        // check if all native and banner imps are part of single bidRequest
                         BidRequest.builder()
                                 .id("bidRequestId")
                                 .imp(asList(
-                                        // verify banner and video media types are preserved in a single imp
                                         Imp.builder()
                                                 .id("impId1")
                                                 .tagid("1")
                                                 .banner(Banner.builder().w(320).h(200).build())
-                                                .video(Video.builder().maxduration(10).build())
                                                 .ext(mapper.valueToTree(ExtImpOpenx.builder().build())).build(),
-                                        // verify banner and native media types are preserved in a single imp
                                         Imp.builder()
                                                 .id("impId2")
                                                 .tagid("2")
-                                                .banner(Banner.builder().w(300).h(150).build())
                                                 .xNative(Native.builder().request("{\"version\":1}").build())
+                                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                                                .build(),
+                                        Imp.builder()
+                                                .id("impId3")
+                                                .tagid("3")
+                                                .video(Video.builder().maxduration(10).build())
                                                 .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
                                                 .build()))
                                 .ext(jacksonMapper.fillExtension(

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -233,10 +233,9 @@ public class OpenxBidderTest extends VertxTest {
                 .containsExactly(BidderError.badInput(
                         "OpenX only supports banner, video and native imps. Ignoring imp id=impId1"));
 
-        assertThat(result.getValue()).hasSize(3)
+        assertThat(result.getValue()).hasSize(1)
                 .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
                 .containsExactly(
-                        // check if all banner imps are part of single bidRequest
                         BidRequest.builder()
                                 .id("bidRequestId")
                                 .imp(asList(
@@ -262,19 +261,7 @@ public class OpenxBidderTest extends VertxTest {
                                                                 .customParams(
                                                                         givenCustomParams("foo2", "bar2"))
                                                                 .build()))
-                                                .build()))
-                                .ext(jacksonMapper.fillExtension(
-                                        ExtRequest.empty(),
-                                        OpenxRequestExt.of("se-demo-d.openx.net", null, "hb_pbs_1.0.0")))
-                                .user(User.builder()
-                                        .ext(ExtUser.builder().consent("consent").build())
-                                        .build())
-                                .regs(Regs.builder().coppa(0).ext(ExtRegs.of(1, null, null, null)).build())
-                                .build(),
-                        // check if each of video imps is a part of separate bidRequest and impId3 is rewarded video
-                        BidRequest.builder()
-                                .id("bidRequestId")
-                                .imp(singletonList(
+                                                .build(),
                                         Imp.builder()
                                                 .id("impId3")
                                                 .video(Video.builder()
@@ -288,20 +275,7 @@ public class OpenxBidderTest extends VertxTest {
                                                                 .customParams(
                                                                         givenCustomParams("foo3", "bar3"))
                                                                 .build()))
-                                                .build()))
-
-                                .ext(jacksonMapper.fillExtension(
-                                        ExtRequest.empty(),
-                                        OpenxRequestExt.of("se-demo-d.openx.net", null, "hb_pbs_1.0.0")))
-                                .user(User.builder()
-                                        .ext(ExtUser.builder().consent("consent").build())
-                                        .build())
-                                .regs(Regs.builder().coppa(0).ext(ExtRegs.of(1, null, null, null)).build())
-                                .build(),
-                        // check if each of video imps is a part of separate bidRequest
-                        BidRequest.builder()
-                                .id("bidRequestId")
-                                .imp(singletonList(
+                                                .build(),
                                         Imp.builder()
                                                 .id("impId4")
                                                 .video(Video.builder().build())
@@ -310,95 +284,6 @@ public class OpenxBidderTest extends VertxTest {
                                                         ExtImpOpenx.builder()
                                                                 .customParams(
                                                                         givenCustomParams("foo4", "bar4"))
-                                                                .build()))
-                                                .build()))
-                                .ext(jacksonMapper.fillExtension(
-                                        ExtRequest.empty(), OpenxRequestExt.of(null, "PLATFORM", "hb_pbs_1.0.0")))
-                                .user(User.builder()
-                                        .ext(ExtUser.builder().consent("consent").build())
-                                        .build())
-                                .regs(Regs.builder().coppa(0).ext(ExtRegs.of(1, null, null, null)).build())
-                                .build());
-    }
-
-    @Test
-    public void makeHttpRequestsShouldReturnResultWithSingleBidRequestForMultipleBannerAndNativeImps() {
-        // given
-        final BidRequest bidRequest = BidRequest.builder()
-                .id("bidRequestId")
-                .imp(asList(
-                        Imp.builder()
-                                .id("impId4")
-                                .banner(Banner.builder().build())
-                                .ext(mapper.valueToTree(
-                                        ExtPrebid.of(null,
-                                                ExtImpOpenx.builder()
-                                                        .customParams(givenCustomParams("foo4", "bar4"))
-                                                        .delDomain("se-demo-d.openx.net")
-                                                        .unit("4").build()))).build(),
-                        Imp.builder()
-                                .id("impId5")
-                                .xNative(Native.builder().request("{\"testreq\":1}").build())
-                                .ext(mapper.valueToTree(
-                                        ExtPrebid.of(null,
-                                                ExtImpOpenx.builder()
-                                                        .customParams(givenCustomParams("foo5", "bar5"))
-                                                        .delDomain("se-demo-d.openx.net")
-                                                        .unit("5").build()))).build(),
-                        Imp.builder()
-                                .id("impId6")
-                                .xNative(Native.builder().build())
-                                .ext(mapper.valueToTree(
-                                        ExtPrebid.of(null,
-                                                ExtImpOpenx.builder()
-                                                        .customParams(givenCustomParams("foo6", "bar6"))
-                                                        .delDomain("se-demo-d.openx.net")
-                                                        .unit("6").build()))).build()))
-                .user(User.builder().ext(ExtUser.builder().consent("consent").build()).build())
-                .regs(Regs.builder().coppa(0).ext(ExtRegs.of(1, null, null, null)).build())
-                .build();
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).isEmpty();
-
-        assertThat(result.getValue()).hasSize(1)
-                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
-                .containsExactly(
-                        // check if all native and banner imps are part of single bidRequest
-                        BidRequest.builder()
-                                .id("bidRequestId")
-                                .imp(asList(
-                                        Imp.builder()
-                                                .id("impId4")
-                                                .tagid("4")
-                                                .banner(Banner.builder().build())
-                                                .ext(mapper.valueToTree(
-                                                        ExtImpOpenx.builder()
-                                                                .customParams(
-                                                                        givenCustomParams("foo4", "bar4"))
-                                                                .build()))
-                                                .build(),
-                                        Imp.builder()
-                                                .id("impId5")
-                                                .tagid("5")
-                                                .xNative(Native.builder().request("{\"testreq\":1}").build())
-                                                .ext(mapper.valueToTree(
-                                                        ExtImpOpenx.builder()
-                                                                .customParams(
-                                                                        givenCustomParams("foo5", "bar5"))
-                                                                .build()))
-                                                .build(),
-                                        Imp.builder()
-                                                .id("impId6")
-                                                .tagid("6")
-                                                .xNative(Native.builder().build())
-                                                .ext(mapper.valueToTree(
-                                                        ExtImpOpenx.builder()
-                                                                .customParams(
-                                                                        givenCustomParams("foo6", "bar6"))
                                                                 .build()))
                                                 .build()))
                                 .ext(jacksonMapper.fillExtension(

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -99,6 +99,7 @@ public class OpenxBidderTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder()
+                        .id("impId1")
                         .banner(Banner.builder().build())
                         .build()))
                 .build();
@@ -109,7 +110,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsExactly(BidderError.badInput("imp id=null: openx parameters section is missing"));
+                .containsExactly(BidderError.badInput("imp id=impId1: openx parameters section is missing"));
     }
 
     @Test
@@ -117,6 +118,7 @@ public class OpenxBidderTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder()
+                        .id("impId1")
                         .banner(Banner.builder().build())
                         .ext(mapper.createObjectNode())
                         .build()))
@@ -128,7 +130,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsExactly(BidderError.badInput("imp id=null: openx parameters section is missing"));
+                .containsExactly(BidderError.badInput("imp id=impId1: openx parameters section is missing"));
     }
 
     @Test
@@ -136,6 +138,7 @@ public class OpenxBidderTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder()
+                        .id("impId1")
                         .video(Video.builder().build())
                         .ext(mapper.valueToTree(
                                 ExtPrebid.of(null, null)))
@@ -148,7 +151,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsExactly(BidderError.badInput("imp id=null: openx parameters section is missing"));
+                .containsExactly(BidderError.badInput("imp id=impId1: openx parameters section is missing"));
     }
 
     @Test
@@ -156,6 +159,7 @@ public class OpenxBidderTest extends VertxTest {
         // given
         final BidRequest bidRequest = BidRequest.builder()
                 .imp(singletonList(Imp.builder()
+                        .id("impId1")
                         .banner(Banner.builder().build())
                         .ext(mapper.valueToTree(ExtPrebid.of(null, mapper.createArrayNode())))
                         .build()))
@@ -167,7 +171,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors().getFirst().getMessage())
-                .startsWith("imp id=null: Cannot deserialize value of");
+                .startsWith("imp id=impId1: Cannot deserialize value of");
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -109,7 +109,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsExactly(BidderError.badInput("openx parameters section is missing"));
+                .containsExactly(BidderError.badInput("imp id=null: openx parameters section is missing"));
     }
 
     @Test
@@ -128,7 +128,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsExactly(BidderError.badInput("openx parameters section is missing"));
+                .containsExactly(BidderError.badInput("imp id=null: openx parameters section is missing"));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors()).hasSize(1)
-                .containsExactly(BidderError.badInput("openx parameters section is missing"));
+                .containsExactly(BidderError.badInput("imp id=null: openx parameters section is missing"));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getValue()).isEmpty();
         assertThat(result.getErrors().getFirst().getMessage())
-                .startsWith("Cannot deserialize value of");
+                .startsWith("imp id=null: Cannot deserialize value of");
     }
 
     @Test
@@ -389,8 +389,8 @@ public class OpenxBidderTest extends VertxTest {
         // then
         assertThat(result.getErrors()).hasSize(2)
                 .containsExactly(
-                        BidderError.badInput("openx parameters section is missing"),
-                        BidderError.badInput("openx parameters section is missing"));
+                        BidderError.badInput("imp id=badImp: openx parameters section is missing"),
+                        BidderError.badInput("imp id=anotherBadImp: openx parameters section is missing"));
 
         assertThat(result.getValue()).hasSize(1)
                 .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -268,7 +268,6 @@ public class OpenxBidderTest extends VertxTest {
                                                         .ext(mapper.valueToTree(OpenxVideoExt.of(1)))
                                                         .build())
                                                 .tagid("555555")
-                                                // check if each of video imps is a part of separate bidRequest
                                                 .bidfloor(BigDecimal.valueOf(0.1))
                                                 .ext(mapper.valueToTree(
                                                         ExtImpOpenx.builder()
@@ -356,6 +355,178 @@ public class OpenxBidderTest extends VertxTest {
                                         .build())
                                 .regs(Regs.builder().coppa(0).ext(ExtRegs.of(1, null, null, null)).build())
                                 .build());
+    }
+
+    @Test
+    public void makeHttpRequestsShouldSkipMalformedFirstImpAndDeriveRequestExtFromLaterValidImp() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .id("bidRequestId")
+                .imp(asList(
+                        Imp.builder()
+                                .id("badImp")
+                                .banner(Banner.builder().build())
+                                .build(),
+                        Imp.builder()
+                                .id("anotherBadImp")
+                                .banner(Banner.builder().build())
+                                .build(),
+                        Imp.builder()
+                                .id("goodImp")
+                                .banner(Banner.builder().build())
+                                .ext(mapper.valueToTree(
+                                        ExtPrebid.of(null,
+                                                ExtImpOpenx.builder()
+                                                        .delDomain("se-demo-d.openx.net")
+                                                        .platform("PLATFORM")
+                                                        .unit("555555").build())))
+                                .build()))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).hasSize(2)
+                .containsExactly(
+                        BidderError.badInput("openx parameters section is missing"),
+                        BidderError.badInput("openx parameters section is missing"));
+
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .containsExactly(
+                        BidRequest.builder()
+                                .id("bidRequestId")
+                                .imp(singletonList(
+                                        Imp.builder()
+                                                .id("goodImp")
+                                                .banner(Banner.builder().build())
+                                                .tagid("555555")
+                                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                                                .build()))
+                                .ext(jacksonMapper.fillExtension(
+                                        ExtRequest.empty(),
+                                        OpenxRequestExt.of("se-demo-d.openx.net", "PLATFORM", "hb_pbs_1.0.0")))
+                                .build());
+    }
+
+    @Test
+    public void makeHttpRequestsShouldReturnResultWithSingleBidRequestForMultipleNativeImpsAndVideoImp() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .id("bidRequestId")
+                .imp(asList(
+                        Imp.builder()
+                                .id("impId1")
+                                .xNative(Native.builder().request("{\"version\":1}").build())
+                                .ext(mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("1").build())))
+                                .build(),
+                        Imp.builder()
+                                .id("impId2")
+                                .xNative(Native.builder().request("{\"version\":2}").build())
+                                .ext(mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("2").build())))
+                                .build(),
+                        Imp.builder()
+                                .id("impId3")
+                                .video(Video.builder().maxduration(10).build())
+                                .ext(mapper.valueToTree(
+                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("3").build())))
+                                .build()))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .extracting(BidRequest::getImp)
+                .containsExactly(asList(
+                        Imp.builder()
+                                .id("impId1")
+                                .tagid("1")
+                                .xNative(Native.builder().request("{\"version\":1}").build())
+                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                                .build(),
+                        Imp.builder()
+                                .id("impId2")
+                                .tagid("2")
+                                .xNative(Native.builder().request("{\"version\":2}").build())
+                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                                .build(),
+                        Imp.builder()
+                                .id("impId3")
+                                .tagid("3")
+                                .video(Video.builder().maxduration(10).build())
+                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                                .build()));
+    }
+
+    @Test
+    public void makeHttpRequestsShouldAttachRewardedVideoExtWhenImpHasBothBannerAndVideo() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .id("bidRequestId")
+                .imp(singletonList(Imp.builder()
+                        .id("impId1")
+                        .banner(Banner.builder().build())
+                        .video(Video.builder().build())
+                        .ext(mapper.valueToTree(
+                                ExtPrebid.of(
+                                        ExtImpPrebid.builder().isRewardedInventory(1).build(),
+                                        ExtImpOpenx.builder().unit("1").build())))
+                        .build()))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp)
+                .containsExactly(Imp.builder()
+                        .id("impId1")
+                        .tagid("1")
+                        .banner(Banner.builder().build())
+                        .video(Video.builder().ext(mapper.valueToTree(OpenxVideoExt.of(1))).build())
+                        .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                        .build());
+    }
+
+    @Test
+    public void makeHttpRequestsShouldNotAttachRewardedVideoExtWhenImpHasNoVideo() {
+        // given
+        final BidRequest bidRequest = BidRequest.builder()
+                .id("bidRequestId")
+                .imp(singletonList(Imp.builder()
+                        .id("impId1")
+                        .banner(Banner.builder().build())
+                        .ext(mapper.valueToTree(
+                                ExtPrebid.of(
+                                        ExtImpPrebid.builder().isRewardedInventory(1).build(),
+                                        ExtImpOpenx.builder().unit("1").build())))
+                        .build()))
+                .build();
+
+        // when
+        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
+
+        // then
+        assertThat(result.getErrors()).isEmpty();
+        assertThat(result.getValue()).hasSize(1)
+                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
+                .flatExtracting(BidRequest::getImp)
+                .containsExactly(Imp.builder()
+                        .id("impId1")
+                        .tagid("1")
+                        .banner(Banner.builder().build())
+                        .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
+                        .build());
     }
 
     @Test

--- a/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
+++ b/src/test/java/org/prebid/server/bidder/openx/OpenxBidderTest.java
@@ -416,61 +416,6 @@ public class OpenxBidderTest extends VertxTest {
     }
 
     @Test
-    public void makeHttpRequestsShouldReturnResultWithSingleBidRequestForMultipleNativeImpsAndVideoImp() {
-        // given
-        final BidRequest bidRequest = BidRequest.builder()
-                .id("bidRequestId")
-                .imp(asList(
-                        Imp.builder()
-                                .id("impId1")
-                                .xNative(Native.builder().request("{\"version\":1}").build())
-                                .ext(mapper.valueToTree(
-                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("1").build())))
-                                .build(),
-                        Imp.builder()
-                                .id("impId2")
-                                .xNative(Native.builder().request("{\"version\":2}").build())
-                                .ext(mapper.valueToTree(
-                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("2").build())))
-                                .build(),
-                        Imp.builder()
-                                .id("impId3")
-                                .video(Video.builder().maxduration(10).build())
-                                .ext(mapper.valueToTree(
-                                        ExtPrebid.of(null, ExtImpOpenx.builder().unit("3").build())))
-                                .build()))
-                .build();
-
-        // when
-        final Result<List<HttpRequest<BidRequest>>> result = target.makeHttpRequests(bidRequest);
-
-        // then
-        assertThat(result.getErrors()).isEmpty();
-        assertThat(result.getValue()).hasSize(1)
-                .extracting(httpRequest -> mapper.readValue(httpRequest.getBody(), BidRequest.class))
-                .extracting(BidRequest::getImp)
-                .containsExactly(asList(
-                        Imp.builder()
-                                .id("impId1")
-                                .tagid("1")
-                                .xNative(Native.builder().request("{\"version\":1}").build())
-                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
-                                .build(),
-                        Imp.builder()
-                                .id("impId2")
-                                .tagid("2")
-                                .xNative(Native.builder().request("{\"version\":2}").build())
-                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
-                                .build(),
-                        Imp.builder()
-                                .id("impId3")
-                                .tagid("3")
-                                .video(Video.builder().maxduration(10).build())
-                                .ext(mapper.valueToTree(ExtImpOpenx.builder().build()))
-                                .build()));
-    }
-
-    @Test
     public void makeHttpRequestsShouldAttachRewardedVideoExtWhenImpHasBothBannerAndVideo() {
         // given
         final BidRequest bidRequest = BidRequest.builder()


### PR DESCRIPTION
### 🔧 Type of changes
- [ ] new bid adapter
- [x] bid adapter update
- [ ] new feature
- [ ] new analytics adapter
- [ ] new module
- [ ] module update
- [ ] bugfix
- [ ] documentation
- [ ] configuration
- [ ] dependency update
- [ ] tech debt (test coverage, refactorings, etc.)

### ✨ What's the context?
Before this change, the OpenX bidder adapter has separated imps that contained only video format into it's separate bidRequest. This is no longer needed and we want to have multi imp requests even when there are imps with video format.

### 🧠 Rationale behind the change
Separating of video imps into their own separate bidRequests is no longer needed.

### 🧪 Test plan
Unit tests should be enough for this case.

### 🏎 Quality check
- [ ] Are your changes following [our code style guidelines](https://github.com/prebid/prebid-server-java/blob/master/docs/developers/code-style.md)?
- [ ] Are there any breaking changes in your code?
- [x] Does your test coverage exceed 90%?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
