### PR TITLE
OpenRTB: Allow model inheritance from external packages

### DIFF
--- a/docs/developers/openrtb-model-inheritance.md
+++ b/docs/developers/openrtb-model-inheritance.md
@@ -1,0 +1,36 @@
+# Extending OpenRTB models
+
+Applications that use Prebid Server Java as a JAR dependency can subclass the models in
+`com.iab.openrtb.request` and `com.iab.openrtb.response` from their own packages. This includes the nested OpenRTB and
+Native Ads objects, so an integration can extend individual parts of a request or response as well as the root object.
+
+This is useful when reusing bidder adapters in an application that has its own request and response representation.
+A subclass can carry local context or implement application-specific behavior while remaining assignable to the concrete
+OpenRTB types accepted by existing APIs. Without inheritance, an unrelated wrapper cannot be passed to those APIs;
+integrations must construct the Prebid model or maintain a modified copy of it.
+
+The value classes retain their private final fields and existing builders. Their all-arguments constructors are protected
+for use by subclasses, and the existing `of(...)` factories remain available. `BrandVersion` retains its existing public
+constructor. The already extensible `Native` class retains its constructors and builder.
+
+For example, a response subclass can initialize the inherited state from an existing response:
+
+```java
+public class ApplicationBidResponse extends BidResponse {
+
+    public ApplicationBidResponse(BidResponse response) {
+        super(response.getId(), response.getSeatbid(), response.getBidid(), response.getCur(),
+                response.getCustomdata(), response.getNbr(), response.getExt());
+    }
+}
+```
+
+Subclassing does not change the behavior of the generated builders: `build()` and `toBuilder().build()` produce the
+declared model type, not the application's subtype. In particular, generated `toBuilder()` methods copy backing fields,
+so overriding getters alone does not implement a lazy or copy-on-write proxy. Builder inheritance and change tracking
+are outside the scope of this extension point. Custom accessors used by equality, such as `Imp.bidFloor()`, may also read
+backing fields directly. Subclasses must account for this when overriding getters or equality.
+
+Applications are responsible for their subclasses' serialization, equality and state ownership. Additional getters can
+become JSON properties, and mutable collections or extension nodes are not made immutable by inheritance. Constructor
+signatures follow the model fields, so subclasses may need to be updated when upgrading the dependency.

--- a/src/main/java/com/iab/openrtb/request/App.java
+++ b/src/main/java/com/iab/openrtb/request/App.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtApp;
 
 import java.util.List;
@@ -14,6 +17,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class App {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Asset.java
+++ b/src/main/java/com/iab/openrtb/request/Asset.java
@@ -1,11 +1,16 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Asset {
 
     public static final Asset EMPTY = Asset.builder().build();

--- a/src/main/java/com/iab/openrtb/request/Audio.java
+++ b/src/main/java/com/iab/openrtb/request/Audio.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -23,6 +26,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Audio {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Banner.java
+++ b/src/main/java/com/iab/openrtb/request/Banner.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -23,6 +26,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Banner {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/BidRequest.java
+++ b/src/main/java/com/iab/openrtb/request/BidRequest.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtRequest;
 
 import java.util.List;
@@ -20,6 +23,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BidRequest {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/BrandVersion.java
+++ b/src/main/java/com/iab/openrtb/request/BrandVersion.java
@@ -2,6 +2,7 @@ package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -12,6 +13,7 @@ import java.util.List;
  * platform or operating system.
  */
 @Value
+@NonFinal
 public class BrandVersion {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Channel.java
+++ b/src/main/java/com/iab/openrtb/request/Channel.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * This object describes the channel an ad will be displayed on. A
@@ -16,6 +19,8 @@ import lombok.Value;
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Channel {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Content.java
+++ b/src/main/java/com/iab/openrtb/request/Content.java
@@ -2,8 +2,11 @@ package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -18,6 +21,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Content {
 
     private static final Content EMPTY = Content.builder().build();

--- a/src/main/java/com/iab/openrtb/request/Data.java
+++ b/src/main/java/com/iab/openrtb/request/Data.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -16,6 +19,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Data {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/DataObject.java
+++ b/src/main/java/com/iab/openrtb/request/DataObject.java
@@ -1,11 +1,16 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class DataObject {
 
     Integer type;

--- a/src/main/java/com/iab/openrtb/request/Deal.java
+++ b/src/main/java/com/iab/openrtb/request/Deal.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -15,6 +18,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Deal {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Device.java
+++ b/src/main/java/com/iab/openrtb/request/Device.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtDevice;
 
 import java.math.BigDecimal;
@@ -26,6 +29,8 @@ import java.math.BigDecimal;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Device {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Dooh.java
+++ b/src/main/java/com/iab/openrtb/request/Dooh.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtDooh;
 
 import java.util.List;
@@ -13,6 +16,8 @@ import java.util.List;
  */
 @Value
 @Builder(toBuilder = true)
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Dooh {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/DurFloor.java
+++ b/src/main/java/com/iab/openrtb/request/DurFloor.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 
@@ -11,6 +14,8 @@ import java.math.BigDecimal;
  */
 @Value
 @Builder
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class DurFloor {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Eid.java
+++ b/src/main/java/com/iab/openrtb/request/Eid.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
 @Value
 @Builder(toBuilder = true)
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Eid {
 
     String source;

--- a/src/main/java/com/iab/openrtb/request/EventTracker.java
+++ b/src/main/java/com/iab/openrtb/request/EventTracker.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventTracker {
 
     Integer event;

--- a/src/main/java/com/iab/openrtb/request/Format.java
+++ b/src/main/java/com/iab/openrtb/request/Format.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * This object represents an allowed size (i.e., height and width combination)
@@ -13,6 +16,8 @@ import lombok.Value;
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Format {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Geo.java
+++ b/src/main/java/com/iab/openrtb/request/Geo.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtGeo;
 
 /**
@@ -16,6 +19,8 @@ import org.prebid.server.proto.openrtb.ext.request.ExtGeo;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Geo {
 
     public static final Geo EMPTY = Geo.builder().build();

--- a/src/main/java/com/iab/openrtb/request/ImageObject.java
+++ b/src/main/java/com/iab/openrtb/request/ImageObject.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageObject {
 
     Integer type;

--- a/src/main/java/com/iab/openrtb/request/Imp.java
+++ b/src/main/java/com/iab/openrtb/request/Imp.java
@@ -2,10 +2,13 @@ package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -25,6 +28,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Imp {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Metric.java
+++ b/src/main/java/com/iab/openrtb/request/Metric.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * This object is associated with an impression as an array of metrics.
@@ -13,6 +16,8 @@ import lombok.Value;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Metric {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Network.java
+++ b/src/main/java/com/iab/openrtb/request/Network.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * This object describes the network an ad will be displayed on.A
@@ -16,6 +19,8 @@ import lombok.Value;
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Network {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Pmp.java
+++ b/src/main/java/com/iab/openrtb/request/Pmp.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -14,6 +17,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pmp {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Producer.java
+++ b/src/main/java/com/iab/openrtb/request/Producer.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -14,6 +17,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Producer {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Publisher.java
+++ b/src/main/java/com/iab/openrtb/request/Publisher.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtPublisher;
 
 import java.util.List;
@@ -12,6 +15,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Publisher {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Qty.java
+++ b/src/main/java/com/iab/openrtb/request/Qty.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 
@@ -14,6 +17,8 @@ import java.math.BigDecimal;
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Qty {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/RefSettings.java
+++ b/src/main/java/com/iab/openrtb/request/RefSettings.java
@@ -1,11 +1,16 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefSettings {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Refresh.java
+++ b/src/main/java/com/iab/openrtb/request/Refresh.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Refresh {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Regs.java
+++ b/src/main/java/com/iab/openrtb/request/Regs.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtRegs;
 
 import java.util.List;
@@ -13,6 +16,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Regs {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Request.java
+++ b/src/main/java/com/iab/openrtb/request/Request.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -18,6 +21,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Request {
 
     /** Version in use. **/

--- a/src/main/java/com/iab/openrtb/request/Segment.java
+++ b/src/main/java/com/iab/openrtb/request/Segment.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * Segment objects are essentially key-value pairs that convey specific units of
@@ -13,6 +16,8 @@ import lombok.Value;
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Segment {
 
     /** ID of the data segment specific to the data provider. */

--- a/src/main/java/com/iab/openrtb/request/Site.java
+++ b/src/main/java/com/iab/openrtb/request/Site.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtSite;
 
 import java.util.List;
@@ -14,6 +17,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Site {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Source.java
+++ b/src/main/java/com/iab/openrtb/request/Source.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtSource;
 
 /**
@@ -15,6 +18,8 @@ import org.prebid.server.proto.openrtb.ext.request.ExtSource;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Source {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/SupplyChain.java
+++ b/src/main/java/com/iab/openrtb/request/SupplyChain.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -13,7 +16,9 @@ import java.util.List;
  * in the direct flow of payment for inventory. Detailed
  * implementation examples can be found <a href="https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md">here</a>.
  */
-@Value(staticConstructor = "of")
+@Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class SupplyChain {
 
     /**
@@ -45,4 +50,8 @@ public class SupplyChain {
      * Placeholder for advertising-system specific extensions to this object.
      */
     ObjectNode ext;
+
+    public static SupplyChain of(Integer complete, List<SupplyChainNode> nodes, String ver, ObjectNode ext) {
+        return new SupplyChain(complete, nodes, ver, ext);
+    }
 }

--- a/src/main/java/com/iab/openrtb/request/SupplyChainNode.java
+++ b/src/main/java/com/iab/openrtb/request/SupplyChainNode.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * This object is associated with a SupplyChain object as an array of nodes.
@@ -9,7 +12,9 @@ import lombok.Value;
  * chain of a bid request. Detailed implementation examples can be found
  * <a href="https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md">here</a>.
  */
-@Value(staticConstructor = "of")
+@Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class SupplyChainNode {
 
     /**
@@ -72,4 +77,16 @@ public class SupplyChainNode {
      * Placeholder for advertising-system specific extensions to this object.
      */
     ObjectNode ext;
+
+    public static SupplyChainNode of(
+            String asi,
+            String sid,
+            String rid,
+            String name,
+            String domain,
+            Integer hp,
+            ObjectNode ext) {
+
+        return new SupplyChainNode(asi, sid, rid, name, domain, hp, ext);
+    }
 }

--- a/src/main/java/com/iab/openrtb/request/TitleObject.java
+++ b/src/main/java/com/iab/openrtb/request/TitleObject.java
@@ -1,11 +1,16 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class TitleObject {
 
     Integer len;

--- a/src/main/java/com/iab/openrtb/request/Uid.java
+++ b/src/main/java/com/iab/openrtb/request/Uid.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * This object contains a single user identifier provided as part of
@@ -11,6 +14,8 @@ import lombok.Value;
  */
 @Value
 @Builder(toBuilder = true)
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Uid {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/User.java
+++ b/src/main/java/com/iab/openrtb/request/User.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.request;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.request.ExtUser;
 
 import java.util.List;
@@ -15,6 +18,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     public static final User EMPTY = User.builder().build();

--- a/src/main/java/com/iab/openrtb/request/UserAgent.java
+++ b/src/main/java/com/iab/openrtb/request/UserAgent.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -16,6 +19,8 @@ import java.util.List;
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserAgent {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/Video.java
+++ b/src/main/java/com/iab/openrtb/request/Video.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -23,6 +26,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Video {
 
     /**

--- a/src/main/java/com/iab/openrtb/request/VideoObject.java
+++ b/src/main/java/com/iab/openrtb/request/VideoObject.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.request;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class VideoObject {
 
     List<String> mimes;

--- a/src/main/java/com/iab/openrtb/response/Asset.java
+++ b/src/main/java/com/iab/openrtb/response/Asset.java
@@ -2,11 +2,16 @@ package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Asset {
 
     Integer id;

--- a/src/main/java/com/iab/openrtb/response/Bid.java
+++ b/src/main/java/com/iab/openrtb/response/Bid.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -15,6 +18,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bid {
 
     /**

--- a/src/main/java/com/iab/openrtb/response/BidResponse.java
+++ b/src/main/java/com/iab/openrtb/response/BidResponse.java
@@ -1,7 +1,10 @@
 package com.iab.openrtb.response;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.prebid.server.proto.openrtb.ext.response.ExtBidResponse;
 
 import java.util.List;
@@ -21,6 +24,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BidResponse {
 
     /**

--- a/src/main/java/com/iab/openrtb/response/DataObject.java
+++ b/src/main/java/com/iab/openrtb/response/DataObject.java
@@ -1,11 +1,14 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Builder
 @Data
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class DataObject {
 
     Integer type;

--- a/src/main/java/com/iab/openrtb/response/EventTracker.java
+++ b/src/main/java/com/iab/openrtb/response/EventTracker.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.Map;
 
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventTracker {
 
     /**

--- a/src/main/java/com/iab/openrtb/response/ImageObject.java
+++ b/src/main/java/com/iab/openrtb/response/ImageObject.java
@@ -1,11 +1,14 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Builder
 @Data
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageObject {
 
     Integer type;

--- a/src/main/java/com/iab/openrtb/response/Link.java
+++ b/src/main/java/com/iab/openrtb/response/Link.java
@@ -1,14 +1,19 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
 /**
  * Used for ‘call to action’ assets, or other links from the Native ad.
  */
-@Value(staticConstructor = "of")
+@Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Link {
 
     /**
@@ -27,4 +32,8 @@ public class Link {
     String fallback;
 
     ObjectNode ext;
+
+    public static Link of(String url, List<String> clicktrackers, String fallback, ObjectNode ext) {
+        return new Link(url, clicktrackers, fallback, ext);
+    }
 }

--- a/src/main/java/com/iab/openrtb/response/Response.java
+++ b/src/main/java/com/iab/openrtb/response/Response.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -15,6 +18,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Response {
 
     /**

--- a/src/main/java/com/iab/openrtb/response/SeatBid.java
+++ b/src/main/java/com/iab/openrtb/response/SeatBid.java
@@ -1,8 +1,11 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 import java.util.List;
 
@@ -16,6 +19,8 @@ import java.util.List;
  */
 @Builder(toBuilder = true)
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class SeatBid {
 
     /**

--- a/src/main/java/com/iab/openrtb/response/TitleObject.java
+++ b/src/main/java/com/iab/openrtb/response/TitleObject.java
@@ -1,11 +1,16 @@
 package com.iab.openrtb.response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class TitleObject {
 
     String text;

--- a/src/main/java/com/iab/openrtb/response/VideoObject.java
+++ b/src/main/java/com/iab/openrtb/response/VideoObject.java
@@ -1,13 +1,18 @@
 package com.iab.openrtb.response;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 /**
  * Corresponds to the Video Object in the request, yet containing a value of a conforming VAST tag as a value.
  */
 @Builder
 @Value
+@NonFinal
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class VideoObject {
 
     /**

--- a/src/test/java/org/prebid/server/json/OpenRtbModelInheritanceTest.java
+++ b/src/test/java/org/prebid/server/json/OpenRtbModelInheritanceTest.java
@@ -1,0 +1,215 @@
+package org.prebid.server.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iab.openrtb.request.BidRequest;
+import com.iab.openrtb.request.BrandVersion;
+import com.iab.openrtb.request.Imp;
+import com.iab.openrtb.request.SupplyChain;
+import com.iab.openrtb.request.SupplyChainNode;
+import com.iab.openrtb.response.Bid;
+import com.iab.openrtb.response.BidResponse;
+import com.iab.openrtb.response.DataObject;
+import com.iab.openrtb.response.ImageObject;
+import com.iab.openrtb.response.Link;
+import com.iab.openrtb.response.SeatBid;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenRtbModelInheritanceTest {
+
+    private final ObjectMapper mapper = ObjectMapperProvider.mapper();
+
+    @Test
+    void requestSubclassShouldRetainFieldsAndJsonRepresentation() throws Exception {
+        // given
+        final BidRequest source = BidRequest.builder()
+                .id("request-id")
+                .tmax(100L)
+                .imp(Collections.singletonList(Imp.builder().id("imp-id").build()))
+                .build();
+
+        // when
+        final BidRequest result = new ApplicationBidRequest(source);
+
+        // then
+        assertThat(result).isEqualTo(source);
+        assertThat(source).isEqualTo(result);
+        assertThat(result.hashCode()).isEqualTo(source.hashCode());
+        assertThat(result.getImp()).isSameAs(source.getImp());
+        assertThat(mapper.readTree(mapper.writeValueAsString(result)))
+                .isEqualTo(mapper.readTree(mapper.writeValueAsString(source)));
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), BidRequest.class)).isEqualTo(source);
+        assertThat(result.toBuilder().tmax(50L).build()).isEqualTo(source.toBuilder().tmax(50L).build());
+        assertThat(result.getTmax()).isEqualTo(100L);
+    }
+
+    @Test
+    void responseSubclassShouldRetainFieldsAndJsonRepresentation() throws Exception {
+        // given
+        final BidResponse source = BidResponse.builder()
+                .id("request-id")
+                .cur("USD")
+                .seatbid(Collections.singletonList(SeatBid.builder()
+                        .bid(Collections.singletonList(Bid.builder().id("bid-id").impid("imp-id").build()))
+                        .build()))
+                .build();
+
+        // when
+        final BidResponse result = new ApplicationBidResponse(source);
+
+        // then
+        assertThat(result).isEqualTo(source);
+        assertThat(source).isEqualTo(result);
+        assertThat(result.hashCode()).isEqualTo(source.hashCode());
+        assertThat(result.getSeatbid()).isSameAs(source.getSeatbid());
+        assertThat(mapper.readTree(mapper.writeValueAsString(result)))
+                .isEqualTo(mapper.readTree(mapper.writeValueAsString(source)));
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), BidResponse.class)).isEqualTo(source);
+        assertThat(result.toBuilder().cur("EUR").build()).isEqualTo(source.toBuilder().cur("EUR").build());
+        assertThat(result.getCur()).isEqualTo("USD");
+    }
+
+    @Test
+    void supplyChainFactoryShouldPreserveFieldsAndJsonRoundTrip() throws Exception {
+        // given
+        final SupplyChainNode node = SupplyChainNode.of(
+                "ssp.test", "seller-id", "request-id", "seller", "seller.test", 1, mapper.createObjectNode());
+
+        // when
+        final SupplyChain result = SupplyChain.of(1, Collections.singletonList(node), "1.0", mapper.createObjectNode());
+
+        // then
+        assertThat(result.getComplete()).isEqualTo(1);
+        assertThat(result.getNodes()).containsExactly(node);
+        assertThat(result.getVer()).isEqualTo("1.0");
+        assertThat(result.getExt()).isEqualTo(mapper.createObjectNode());
+        assertThat(node.getAsi()).isEqualTo("ssp.test");
+        assertThat(node.getSid()).isEqualTo("seller-id");
+        assertThat(node.getRid()).isEqualTo("request-id");
+        assertThat(node.getName()).isEqualTo("seller");
+        assertThat(node.getDomain()).isEqualTo("seller.test");
+        assertThat(node.getHp()).isEqualTo(1);
+        assertThat(node.getExt()).isEqualTo(mapper.createObjectNode());
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), SupplyChain.class)).isEqualTo(result);
+    }
+
+    @Test
+    void linkSubclassShouldBeCompatibleWithFactoryAndJsonRoundTrip() throws Exception {
+        // given
+        final Link source = Link.of("https://landing.test", Collections.singletonList("https://tracker.test"),
+                "https://fallback.test", mapper.createObjectNode());
+
+        // when
+        final Link result = new Link(
+                source.getUrl(), source.getClicktrackers(), source.getFallback(), source.getExt()) {
+        };
+
+        // then
+        assertThat(result.getUrl()).isEqualTo("https://landing.test");
+        assertThat(result.getClicktrackers()).containsExactly("https://tracker.test");
+        assertThat(result.getFallback()).isEqualTo("https://fallback.test");
+        assertThat(result.getExt()).isEqualTo(mapper.createObjectNode());
+        assertThat(result).isEqualTo(source);
+        assertThat(source).isEqualTo(result);
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), Link.class)).isEqualTo(source);
+    }
+
+    @Test
+    void brandVersionShouldRetainPublicConstructor() throws Exception {
+        // when
+        final BrandVersion result = new BrandVersion("browser", Collections.singletonList("1"), null);
+
+        // then
+        assertThat(result.getBrand()).isEqualTo("browser");
+        assertThat(result.getVersion()).containsExactly("1");
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), BrandVersion.class)).isEqualTo(result);
+    }
+
+    @Test
+    void dataObjectSubclassShouldBeCompatibleWithBuilderAndJsonRoundTrip() throws Exception {
+        // given
+        final DataObject source = DataObject.builder()
+                .type(1).len(5).value("value").ext(mapper.createObjectNode()).build();
+
+        // when
+        final DataObject result = new DataObject(
+                source.getType(), source.getLen(), source.getValue(), source.getExt()) {
+        };
+
+        // then
+        assertThat(result).isEqualTo(source);
+        assertThat(source).isEqualTo(result);
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), DataObject.class)).isEqualTo(source);
+        result.setValue("updated");
+        assertThat(result.getValue()).isEqualTo("updated");
+        assertThat(source.getValue()).isEqualTo("value");
+    }
+
+    @Test
+    void imageObjectSubclassShouldBeCompatibleWithBuilderAndJsonRoundTrip() throws Exception {
+        // given
+        final ImageObject source = ImageObject.builder()
+                .type(1).url("https://image.test").w(100).h(50).ext(mapper.createObjectNode()).build();
+
+        // when
+        final ImageObject result = new ImageObject(
+                source.getType(), source.getUrl(), source.getW(), source.getH(), source.getExt()) {
+        };
+
+        // then
+        assertThat(result).isEqualTo(source);
+        assertThat(source).isEqualTo(result);
+        assertThat(mapper.readValue(mapper.writeValueAsString(result), ImageObject.class)).isEqualTo(source);
+        result.setW(200);
+        assertThat(result.getW()).isEqualTo(200);
+        assertThat(source.getW()).isEqualTo(100);
+    }
+
+    private static class ApplicationBidRequest extends BidRequest {
+
+        private ApplicationBidRequest(BidRequest source) {
+            super(
+                    source.getId(),
+                    source.getImp(),
+                    source.getSite(),
+                    source.getApp(),
+                    source.getDooh(),
+                    source.getDevice(),
+                    source.getUser(),
+                    source.getTest(),
+                    source.getAt(),
+                    source.getTmax(),
+                    source.getWseat(),
+                    source.getBseat(),
+                    source.getAllimps(),
+                    source.getCur(),
+                    source.getWlang(),
+                    source.getWlangb(),
+                    source.getAcat(),
+                    source.getBcat(),
+                    source.getCattax(),
+                    source.getBadv(),
+                    source.getBapp(),
+                    source.getSource(),
+                    source.getRegs(),
+                    source.getExt());
+        }
+    }
+
+    private static class ApplicationBidResponse extends BidResponse {
+
+        private ApplicationBidResponse(BidResponse source) {
+            super(
+                    source.getId(),
+                    source.getSeatbid(),
+                    source.getBidid(),
+                    source.getCur(),
+                    source.getCustomdata(),
+                    source.getNbr(),
+                    source.getExt());
+        }
+    }
+}


### PR DESCRIPTION
### 🔧 Type of changes

- [x] new feature
- [x] documentation

### ✨ What's the context?

When using Prebid Server Java as a JAR dependency, an application may reuse bidder adapters while keeping its own request and response representation. The adapter APIs accept concrete OpenRTB classes, so an unrelated wrapper cannot be passed to them. Most of these models are final and have package-private or private constructors, which prevents application-defined subclasses outside the model package.

This change allows those applications to extend the request and response models, including their nested OpenRTB and Native Ads objects, without maintaining a fork just to change class and constructor visibility. For example, an integration can attach local context to a response or define application-specific behavior in a subtype accepted by the existing APIs.

### 🧠 Rationale behind the change

Use `@NonFinal` on value classes and protected all-arguments constructors where constructors were inaccessible to external subclasses. Existing fields, builders and wire properties are retained. The `SupplyChain`, `SupplyChainNode` and `Link` factories remain available as explicit `of(...)` methods; `BrandVersion` keeps its existing public constructor. `Native` is already extensible and does not need a change.

This is a limited first step toward supporting external integrations. It does not implement lazy conversion, change tracking or builder inheritance, and does not claim an allocation reduction on its own. Inherited value fields remain private and final; applications are responsible for the behavior and state ownership of their subclasses. Subclass constructors may need updating as model fields evolve.

An alternative would be to migrate the other models to `@SuperBuilder`, following the existing `Native` implementation. That could provide a more complete foundation for inheritance with builders, but it is a broader change that needs additional implementation time and compatibility testing of the generated builder API. If maintainers prefer that direction, I am happy to follow up with a `@SuperBuilder` migration.

### Subclass example and limitations

For example, a response subclass can initialize the inherited state from an existing response:

```java
public class ApplicationBidResponse extends BidResponse {

    public ApplicationBidResponse(BidResponse response) {
        super(response.getId(), response.getSeatbid(), response.getBidid(), response.getCur(),
                response.getCustomdata(), response.getNbr(), response.getExt());
    }
}
```

Subclassing does not change the behavior of the generated builders: `build()` and `toBuilder().build()` produce the
declared model type, not the application's subtype. In particular, generated `toBuilder()` methods copy backing fields,
so overriding getters alone does not implement a lazy or copy-on-write proxy. Builder inheritance and change tracking
are outside the scope of this extension point. Custom accessors used by equality, such as `Imp.bidFloor()`, may also read
backing fields directly. Subclasses must account for this when overriding getters or equality.

Applications are responsible for their subclasses' serialization, equality and state ownership. Additional getters can
become JSON properties, and mutable collections or extension nodes are not made immutable by inheritance. Constructor
signatures follow the model fields, so subclasses may need to be updated when upgrading the dependency.

### 🧪 Test plan

- `mvn -B -Dtest=OpenRtbModelInheritanceTest test` passes on JDK 25, including Checkstyle and compilation of production and test sources. The seven tests cover external-package request/response subclasses, equality, JSON round trips, `toBuilder()`, mutable native response models, retained factories and the public `BrandVersion` constructor.
- Compiled an external-package subclass of every one of the 53 direct request/response models against the built classes. Compared their public method and constructor signatures with the baseline: all existing signatures are retained.
- Full `mvn -B test` run: 8,785 tests, three failures in `UidsCookieServiceTest` (the same three tests also fail on the unchanged baseline), two skipped, and one environment-related `SanityTest` error because `/var/tmp/vendor2` was not writable. `SanityTest` passes when rerun with vendor cache paths under `target` via system properties.

### 🏎 Quality check

- [x] Changes follow the code style guidelines.
- [ ] Breaking changes to existing public construction APIs.
- [ ] Test coverage exceeds 90%.
- [ ] Erroneous console logs, debuggers or leftover code.

The project's JaCoCo configuration excludes `com/iab/openrtb/**`, so no coverage percentage is claimed for these models. The retained explicit factory methods are exercised by the regression tests.
